### PR TITLE
Add a separate Procfile for development

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,5 @@
-# for local development - run `foreman start`
+# This is intended for heroku deployment
+# for local development use `Procfile.dev` instead
 # for local heroku - run `heroku local`
 #
 web: RUBYOPT=-W:no-deprecated bundle exec puma -C config/puma.rb

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,5 @@
+# for local development run `foreman start -f Procfile.dev`
+# for local heroku - run `heroku local`
+#
+web: RUBYOPT=-W:no-deprecated rails s -p 3000
+assets: bin/webpack-dev-server

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ bin/webpack-dev-server
 
 or using a single terminal and foreman
 ```
-foreman start
+foreman start -f Procfile.dev
 ```
 
 ## Testing


### PR DESCRIPTION
#### What
add a separate file for foreman
to handle more reliable local development.

#### Why
heroku uses `Procfile` automatically so
should not, ideally, be used for local development.

local development can use
```
foreman start -f Procfile.dev
```

A note on `heroku local`. This command
runs the app locally similarly to how it would
on heroku. However, heroku remote will
serve weback assets, while local will not. This
is web the Procfile specifies `assets` proc as well.