### PR TITLE
Use govuk_password_field

### DIFF
--- a/app/views/devise/passwords/edit.html.haml
+++ b/app/views/devise/passwords/edit.html.haml
@@ -6,15 +6,13 @@
 
     = f.hidden_field :reset_password_token
 
-    = f.govuk_text_field(:password,
-      type: 'password',
+    = f.govuk_password_field(:password,
       label: { text: 'New password' },
       autofocus: true,
       autocomplete: 'new-password',
       hint_text: "#{@minimum_password_length} characters minimum")
 
-    = f.govuk_text_field(:password_confirmation,
-      type: 'password',
+    = f.govuk_password_field(:password_confirmation,
       label: { text: 'Confirm new password' },
       autocomplete: 'new-password')
 

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -6,7 +6,7 @@
 
     = f.govuk_email_field(:email, label: { text: 'Email' }, autofocus: true, autocomplete: 'email')
 
-    = f.govuk_text_field(:password, type: 'password', label: { text: 'Password' }, autocomplete: 'current-password')
+    = f.govuk_password_field(:password, label: { text: 'Password' }, autocomplete: 'current-password')
 
     - if devise_mapping.rememberable?
       = f.govuk_collection_radio_buttons :remember_me,


### PR DESCRIPTION
#### What
use updated govuk_design_system_formbuilder gem's
new helper instead of specifying type.

#### Why
version 1.1.2 of govuk_design_system_formbuilder
has included this new helper.