### PR TITLE
Refactor search to use strategy pattern

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,5 +1,5 @@
 CASEWORKER_PASSWORD: caseworker-password
 MANAGER_PASSWORD: manager-password
-# COURT_DATA_ADAPTOR_API_URL: https://laa-court-data-adaptor.apps.live-1.cloud-platform.service.justice.gov.uk/api/v1
-COURT_DATA_ADAPTOR_API_URL: http://localhost:9292
+COURT_DATA_ADAPTOR_API_URL: https://laa-court-data-adaptor-dev.apps.live-1.cloud-platform.service.justice.gov.uk/api
+# COURT_DATA_ADAPTOR_API_URL: http://localhost:9292
 COURT_DATA_ADAPTOR_BEARER_TOKEN: not-a-real-bearer-token

--- a/.env.test
+++ b/.env.test
@@ -1,3 +1,3 @@
-COURT_DATA_ADAPTOR_API_URL: https://laa-court-data-adaptor.apps.live-1.cloud-platform.service.justice.gov.uk/api
+COURT_DATA_ADAPTOR_API_URL: https://laa-court-data-adaptor-dev.apps.live-1.cloud-platform.service.justice.gov.uk/api
 # COURT_DATA_ADAPTOR_API_URL: http://localhost:9292
 COURT_DATA_ADAPTOR_BEARER_TOKEN: 'not-a-real-bearer-token'

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -11,7 +11,7 @@ class SearchesController < ApplicationController
   end
 
   def create
-    @search = Search.new(adaptor: @adaptor)
+    @search = Search.new(adaptor: adaptor)
     authorize! :create, @search
 
     @results = @search.execute
@@ -19,6 +19,8 @@ class SearchesController < ApplicationController
   end
 
   private
+
+  attr_reader :adaptor
 
   def set_search_args
     @term = search_params[:term]

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -5,12 +5,8 @@ require 'court_data_adaptor'
 class Search
   include ActiveModel::Model
 
-  attr_writer :filter
-  attr_accessor :query
-
-  def filter
-    @filter || :case_reference
-  end
+  attr_accessor :adaptor
+  attr_accessor :term
 
   def filters
     self.class.filters
@@ -31,28 +27,7 @@ class Search
     ]
   end
 
-  # TODO: abstract (strategy pattern/dependency inversion)
   def execute
-    case filter
-    when 'case_reference'
-      case_reference_search
-    when 'defendant'
-      defendant_search
-    else
-      raise CourtDataAdaptor::Resource::NotFound, ''
-    end
-  end
-
-  private
-
-  def case_reference_search
-    CourtDataAdaptor::ProsecutionCase.where(prosecution_case_reference: query).all
-  end
-
-  def defendant_search
-    results = query.split(' ').each_with_object([]) do |term, arr|
-      arr.append(CourtDataAdaptor::ProsecutionCase.where(first_name: term, last_name: term).all)
-    end
-    results.flatten.uniq(&:id)
+    adaptor.call
   end
 end

--- a/app/views/searches/_form.html.haml
+++ b/app/views/searches/_form.html.haml
@@ -1,5 +1,5 @@
 = form_with model: @search, local: true do |f|
   = f.govuk_error_summary
   = f.hidden_field(:filter, value: @filter)
-  = f.govuk_text_field(:query, value: @query, label: { text: @label }, hint_text: @hint )
+  = f.govuk_text_field(:term, value: @term, label: { text: @label }, hint_text: @hint )
   = f.govuk_submit( t('generic.search') )

--- a/app/views/searches/_results.html.haml
+++ b/app/views/searches/_results.html.haml
@@ -1,5 +1,5 @@
 .govuk-heading-l
-  = t('search.result_count', query: @query, count: @results.size)
+  = t('search.result_count', term: @term, count: @results.size)
 
 - if @results.empty?
   = render 'no_results'

--- a/config/locales/en/searches.yml
+++ b/config/locales/en/searches.yml
@@ -4,7 +4,7 @@ en:
     case_reference_label: Find a case
     case_reference_label_hint: Search by prosecution case reference
     defendant_label: Find a defendant
-    defendant_label_hint: Search by MAAT number or defendant name
+    defendant_label_hint: Search by defendant name
     no_result:
       body: There are no matching results.
       body_guide: 'Improve your search results by:'
@@ -16,9 +16,9 @@ en:
     result:
       caption: Search results
     result_count:
-      one: Search for "%{query}" returned 1 result
-      other: Search for "%{query}" returned %{count} results
-      zero: Search for "%{query}" returned 0 result
+      one: Search for "%{term}" returned 1 result
+      other: Search for "%{term}" returned %{count} results
+      zero: Search for "%{term}" returned 0 result
   search_filter:
     label_hint: choose an option
     legend_text: How do you want to search?

--- a/lib/court_data_adaptor.rb
+++ b/lib/court_data_adaptor.rb
@@ -2,7 +2,11 @@
 
 require_relative 'court_data_adaptor/resource/base'
 require_relative 'court_data_adaptor/resource/error'
-require_relative 'court_data_adaptor/prosecution_case'
+require_relative 'court_data_adaptor/resource/queryable'
+require_relative 'court_data_adaptor/resource/prosecution_case'
+require_relative 'court_data_adaptor/query/base'
+require_relative 'court_data_adaptor/query/defendant'
+require_relative 'court_data_adaptor/query/prosecution_case'
 
 module CourtDataAdaptor
   module Resource

--- a/lib/court_data_adaptor/prosecution_case.rb
+++ b/lib/court_data_adaptor/prosecution_case.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-module CourtDataAdaptor
-  # 'https://laa-court-data-adaptor.apps.live-1.cloud-platform.service.justice.gov.uk/api/v1/prosecution_case'
-  #
-  class ProsecutionCase < Resource::Base
-  end
-end

--- a/lib/court_data_adaptor/query/base.rb
+++ b/lib/court_data_adaptor/query/base.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module CourtDataAdaptor
+  module Query
+    class Base
+      include CourtDataAdaptor::Resource::Queryable
+
+      attr_accessor :term
+
+      def initialize(term)
+        @term = term
+      end
+
+      def self.call(term)
+        new(term).call
+      end
+
+      def call
+        raise 'Implement in subclass, e.g. resource.where(attribute: term).all'
+      end
+    end
+  end
+end

--- a/lib/court_data_adaptor/query/defendant.rb
+++ b/lib/court_data_adaptor/query/defendant.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module CourtDataAdaptor
+  module Query
+    class Defendant < Base
+      acts_as_resource CourtDataAdaptor::Resource::ProsecutionCase
+
+      def call
+        results = term.split(' ').each_with_object([]) do |aterm, arr|
+          arr.append(resource.where(first_name: aterm, last_name: aterm).all)
+        end
+        results.flatten.uniq(&:id)
+      end
+    end
+  end
+end

--- a/lib/court_data_adaptor/query/prosecution_case.rb
+++ b/lib/court_data_adaptor/query/prosecution_case.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module CourtDataAdaptor
+  module Query
+    class ProsecutionCase < Base
+      acts_as_resource CourtDataAdaptor::Resource::ProsecutionCase
+
+      def call
+        resource.where(prosecution_case_reference: term).all
+      end
+    end
+  end
+end

--- a/lib/court_data_adaptor/resource/prosecution_case.rb
+++ b/lib/court_data_adaptor/resource/prosecution_case.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module CourtDataAdaptor
+  module Resource
+    class ProsecutionCase < Base
+    end
+  end
+end

--- a/lib/court_data_adaptor/resource/queryable.rb
+++ b/lib/court_data_adaptor/resource/queryable.rb
@@ -9,9 +9,8 @@ module CourtDataAdaptor
       end
 
       module ClassMethods
-        cattr_accessor :resource
-
         def acts_as_resource(resource)
+          cattr_accessor :resource
           self.resource = resource
         end
       end

--- a/lib/court_data_adaptor/resource/queryable.rb
+++ b/lib/court_data_adaptor/resource/queryable.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module CourtDataAdaptor
+  module Resource
+    module Queryable
+      def self.included(base)
+        base.include InstanceMethods
+        base.extend ClassMethods
+      end
+
+      module ClassMethods
+        cattr_accessor :resource
+
+        def acts_as_resource(resource)
+          self.resource = resource
+        end
+      end
+
+      module InstanceMethods
+        def resource
+          self.class.resource
+        end
+      end
+    end
+  end
+end

--- a/spec/features/search/case_reference_spec.rb
+++ b/spec/features/search/case_reference_spec.rb
@@ -7,12 +7,12 @@ RSpec.feature 'Case reference search', type: :feature do
     sign_in user
   end
 
-  scenario 'case reference search with results', stub_case_reference_results: true do
+  scenario 'with results', stub_case_reference_results: true do
     visit '/'
 
     choose 'By case reference'
     click_button 'Continue'
-    fill_in 'search-query-field', with: '05PP1000915'
+    fill_in 'search-term-field', with: '05PP1000915'
     click_button 'Search'
     expect(page).to have_text 'Search for "05PP1000915" returned'
 
@@ -21,12 +21,12 @@ RSpec.feature 'Case reference search', type: :feature do
     end
   end
 
-  scenario 'case reference search with no results', stub_no_results: true do
+  scenario 'with no results', stub_no_results: true do
     visit '/'
 
     choose 'By case reference'
     click_button 'Continue'
-    fill_in 'search-query-field', with: '05PP1000915'
+    fill_in 'search-term-field', with: '05PP1000915'
     click_button 'Search'
     expect(page).to have_css('.govuk-body', text: 'There are no matching results')
   end

--- a/spec/features/search/defendant_spec.rb
+++ b/spec/features/search/defendant_spec.rb
@@ -7,12 +7,12 @@ RSpec.feature 'Defendant search', type: :feature do
     sign_in user
   end
 
-  scenario 'defendant name search with results', stub_defendant_results: true do
+  scenario 'with results', stub_defendant_results: true do
     visit '/'
 
     choose 'By defendant'
     click_button 'Continue'
-    fill_in 'search-query-field', with: 'Mickey Mouse'
+    fill_in 'search-term-field', with: 'Mickey Mouse'
     click_button 'Search'
     expect(page).to have_text 'Search for "Mickey Mouse" returned'
 
@@ -21,12 +21,12 @@ RSpec.feature 'Defendant search', type: :feature do
     end
   end
 
-  scenario 'defendant name search with no results', stub_no_results: true do
+  scenario 'with no results', stub_no_results: true do
     visit '/'
 
     choose 'By defendant'
     click_button 'Continue'
-    fill_in 'search-query-field', with: 'Fred Bloggs'
+    fill_in 'search-term-field', with: 'Fred Bloggs'
     click_button 'Search'
     expect(page).to have_css('.govuk-body', text: 'There are no matching results')
   end

--- a/spec/lib/court_data_adaptor/query/base_spec.rb
+++ b/spec/lib/court_data_adaptor/query/base_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'court_data_adaptor'
+
+RSpec.describe CourtDataAdaptor::Query::Base do
+  subject(:test_class) do
+    Class.new(described_class) do
+      acts_as_resource :nil_resource
+    end
+  end
+
+  it_behaves_like 'court_data_adaptor queryable object'
+  it_behaves_like 'court_data_adaptor query object'
+end

--- a/spec/lib/court_data_adaptor/query/defendant_spec.rb
+++ b/spec/lib/court_data_adaptor/query/defendant_spec.rb
@@ -1,4 +1,6 @@
-RSpec.fdescribe CourtDataAdaptor::Query::Defendant do
+# frozen_string_literal: true
+
+RSpec.describe CourtDataAdaptor::Query::Defendant do
   subject { described_class }
 
   it_behaves_like 'court_data_adaptor queryable object'

--- a/spec/lib/court_data_adaptor/query/defendant_spec.rb
+++ b/spec/lib/court_data_adaptor/query/defendant_spec.rb
@@ -1,0 +1,6 @@
+RSpec.fdescribe CourtDataAdaptor::Query::Defendant do
+  subject { described_class }
+
+  it_behaves_like 'court_data_adaptor queryable object'
+  it_behaves_like 'court_data_adaptor query object'
+end

--- a/spec/lib/court_data_adaptor/query/prosecution_case_spec.rb
+++ b/spec/lib/court_data_adaptor/query/prosecution_case_spec.rb
@@ -2,9 +2,32 @@
 
 require 'court_data_adaptor'
 
-RSpec.fdescribe CourtDataAdaptor::Query::ProsecutionCase do
+RSpec.describe CourtDataAdaptor::Query::ProsecutionCase do
   subject { described_class }
 
   it_behaves_like 'court_data_adaptor queryable object'
   it_behaves_like 'court_data_adaptor query object'
+
+  describe '#call', stub_no_results: true do
+    subject(:call) { described_class.new(term).call }
+
+    let(:term) { 'a-case-urn' }
+    let(:resource) { CourtDataAdaptor::Resource::ProsecutionCase }
+    let(:resultset) { instance_double('ResultSet') }
+
+    before do
+      allow(resource).to receive(:where).and_return(resultset)
+      allow(resultset).to receive(:all)
+    end
+
+    it 'sends where query to resource' do
+      call
+      expect(resource).to have_received(:where).with(prosecution_case_reference: term)
+    end
+
+    it 'sends all message to resultset' do
+      call
+      expect(resultset).to have_received(:all)
+    end
+  end
 end

--- a/spec/lib/court_data_adaptor/query/prosecution_case_spec.rb
+++ b/spec/lib/court_data_adaptor/query/prosecution_case_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'court_data_adaptor'
+
+RSpec.fdescribe CourtDataAdaptor::Query::ProsecutionCase do
+  subject { described_class }
+
+  it_behaves_like 'court_data_adaptor queryable object'
+  it_behaves_like 'court_data_adaptor query object'
+end

--- a/spec/lib/court_data_adaptor/resource/prosecution_case_spec.rb
+++ b/spec/lib/court_data_adaptor/resource/prosecution_case_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe CourtDataAdaptor::Resource::ProsecutionCase do
     subject { described_class.site }
 
     it 'returns court data adaptor external site' do
-      is_expected.to match %r{https:\/\/.*laa-court-data-adaptor\..*}
+      is_expected.to match %r{https:\/\/.*laa-court-data-adaptor-.*\..*}
     end
   end
 

--- a/spec/lib/court_data_adaptor/resource/prosecution_case_spec.rb
+++ b/spec/lib/court_data_adaptor/resource/prosecution_case_spec.rb
@@ -2,7 +2,7 @@
 
 require 'court_data_adaptor'
 
-RSpec.describe CourtDataAdaptor::ProsecutionCase do
+RSpec.describe CourtDataAdaptor::Resource::ProsecutionCase do
   let(:prosecution_case_endpoint) do
     [ENV.fetch('COURT_DATA_ADAPTOR_API_URL', nil), 'prosecution_cases'].join('/')
   end

--- a/spec/lib/court_data_adaptor/resource/queryable_spec.rb
+++ b/spec/lib/court_data_adaptor/resource/queryable_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'court_data_adaptor'
+
+RSpec.describe CourtDataAdaptor::Resource::Queryable, :concern do
+  let(:test_class) do
+    Class.new do
+      include CourtDataAdaptor::Resource::Queryable
+      acts_as_resource :my_resource_class
+    end
+  end
+
+  describe '.acts_as_resource' do
+    before { test_class.acts_as_resource :funky_resource_class }
+
+    it 'defines resource class constant on the class' do
+      expect(test_class.resource).to be :funky_resource_class
+    end
+  end
+
+  describe '.resource' do
+    subject { test_class.resource }
+
+    it { is_expected.to be :my_resource_class }
+  end
+
+  describe '#resource' do
+    subject { test_class.new.resource }
+
+    it { is_expected.to be :my_resource_class }
+  end
+end

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -5,7 +5,7 @@ require 'court_data_adaptor'
 RSpec.describe Search, type: :model do
   subject { described_class.new }
 
-  it { is_expected.to respond_to(:query, :filter, :execute, :errors, :valid?) }
+  it { is_expected.to respond_to(:adaptor, :term, :execute, :errors, :valid?) }
 
   describe '.filters' do
     subject { described_class.filters }
@@ -14,27 +14,29 @@ RSpec.describe Search, type: :model do
   end
 
   describe '#execute' do
-    let(:instance) { described_class.new(filter: filter) }
+    let(:term) { 'whatever' }
 
-    before { allow(instance).to receive(:case_reference_search) }
+    context 'when searching by case reference', stub_no_results: true do
+      let(:adaptor) { CourtDataAdaptor::Query::ProsecutionCase.new(term) }
+      let(:instance) { described_class.new(adaptor: adaptor) }
 
-    context 'when searching by case reference' do
-      let(:filter) { 'case_reference' }
+      before { allow(adaptor).to receive(:call) }
 
-      it 'calls case_reference_search' do
+      it 'calls case reference query object' do
         instance.execute
-        expect(instance).to have_received(:case_reference_search)
+        expect(adaptor).to have_received(:call)
       end
     end
 
-    context 'when searching by defendant name' do
-      let(:filter) { 'defendant' }
+    context 'when searching by defendant name', stub_no_results: true do
+      let(:adaptor) { CourtDataAdaptor::Query::Defendant.new(term) }
+      let(:instance) { described_class.new(adaptor: adaptor) }
 
-      before { allow(instance).to receive(:defendant_search) }
+      before { allow(adaptor).to receive(:call) }
 
-      it 'calls defendant_search' do
+      it 'calls defendant query object' do
         instance.execute
-        expect(instance).to have_received(:defendant_search)
+        expect(adaptor).to have_received(:call)
       end
     end
   end

--- a/spec/requests/search/case_reference_spec.rb
+++ b/spec/requests/search/case_reference_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe 'csae reference search', type: :request, stub_no_results: true do
+RSpec.describe 'case reference search', type: :request, stub_no_results: true do
   let(:user) { create(:user) }
 
   before do
@@ -14,7 +14,7 @@ RSpec.describe 'csae reference search', type: :request, stub_no_results: true do
 
   context 'when posting a query' do
     let(:search_params) do
-      { search: { query: '05PP1000915', filter: :case_reference } }
+      { search: { term: '05PP1000915', filter: :case_reference } }
     end
 
     it 'accepts query paramater' do
@@ -30,7 +30,8 @@ RSpec.describe 'csae reference search', type: :request, stub_no_results: true do
     context 'when results returned', stub_case_reference_results: true do
       it 'assigns array of results' do
         post '/searches', params: search_params
-        expect(assigns(:results)).to include(an_instance_of(CourtDataAdaptor::ProsecutionCase))
+        expect(assigns(:results))
+          .to include(an_instance_of(CourtDataAdaptor::Resource::ProsecutionCase))
       end
 
       it 'renders searches/_results' do
@@ -50,7 +51,7 @@ RSpec.describe 'csae reference search', type: :request, stub_no_results: true do
       end
 
       it 'renders searches/_no_results template' do
-        post '/searches', params: { search: { query: 'T20200001', filter: :case_reference } }
+        post '/searches', params: { search: { term: 'T20200001', filter: :case_reference } }
         expect(response).to render_template('searches/_no_results')
       end
     end

--- a/spec/requests/search/defendant_spec.rb
+++ b/spec/requests/search/defendant_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'defendant search', type: :request, stub_no_results: true do
 
   context 'when posting a query' do
     let(:search_params) do
-      { search: { query: 'mouse', filter: :defendant } }
+      { search: { term: 'mouse', filter: :defendant } }
     end
 
     it 'accepts query paramater' do
@@ -30,7 +30,8 @@ RSpec.describe 'defendant search', type: :request, stub_no_results: true do
     context 'when results returned', stub_defendant_results: true do
       it 'assigns array of results' do
         post '/searches', params: search_params
-        expect(assigns(:results)).to include(an_instance_of(CourtDataAdaptor::ProsecutionCase))
+        expect(assigns(:results))
+          .to include(an_instance_of(CourtDataAdaptor::Resource::ProsecutionCase))
       end
 
       it 'renders searches/_results' do
@@ -50,7 +51,7 @@ RSpec.describe 'defendant search', type: :request, stub_no_results: true do
       end
 
       it 'renders searches/_no_results template' do
-        post '/searches', params: { search: { query: 'mini mouse', filter: :defendant } }
+        post '/searches', params: { search: { term: 'mini mouse', filter: :defendant } }
         expect(response).to render_template('searches/_no_results')
       end
     end

--- a/spec/support/shared_examples_for_court_adaptor.rb
+++ b/spec/support/shared_examples_for_court_adaptor.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'court_data_adaptor queryable object' do
+  it { is_expected.to respond_to :acts_as_resource, :resource }
+  it { expect(test_class.new(nil)).to respond_to :resource }
+end
+
+RSpec.shared_examples 'court_data_adaptor query object' do
+  it { is_expected.to respond_to :call }
+  it { expect(test_class.new(nil)).to respond_to :call }
+
+  describe '#call' do
+    it { expect { test_class.new(nil).call }.to raise_error StandardError, /Implement in subclass/ }
+  end
+end

--- a/spec/support/shared_examples_for_court_adaptor.rb
+++ b/spec/support/shared_examples_for_court_adaptor.rb
@@ -2,14 +2,10 @@
 
 RSpec.shared_examples 'court_data_adaptor queryable object' do
   it { is_expected.to respond_to :acts_as_resource, :resource }
-  it { expect(test_class.new(nil)).to respond_to :resource }
+  it { expect(subject.new(nil)).to respond_to :resource }
 end
 
 RSpec.shared_examples 'court_data_adaptor query object' do
   it { is_expected.to respond_to :call }
-  it { expect(test_class.new(nil)).to respond_to :call }
-
-  describe '#call' do
-    it { expect { test_class.new(nil).call }.to raise_error StandardError, /Implement in subclass/ }
-  end
+  it { expect(subject.new(nil)).to respond_to :call, :term }
 end

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -31,4 +31,10 @@ RSpec.configure do |config|
         headers: { 'Content-Type' => 'application/vnd.api+json' }
       )
   end
+
+  config.around(:each, enable_net_connect: true) do |example|
+    WebMock.allow_net_connect!
+    example.run
+    load __FILE__
+  end
 end


### PR DESCRIPTION
#### What
Apply strategy pattern to search along with adaptors/queryers

#### Ticket

[CACP-169](https://dsdmoj.atlassian.net/browse/CACP-169)
[CACP-117](https://dsdmoj.atlassian.net/browse/CACP-117)

#### Why
As the main purpose of the app and with different
kinds of searches needing to be applied in future
iterations this pattern should, hopefully, make
extensibility easier.

#### How
Introduce the idea of an adaptor (or "queryor", could rename)
that handles particular kinds of searches against particular
resources/endpoints of the API.