### PR TITLE
Prevent i18n translation error

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,4 +6,8 @@ module ApplicationHelper
   def service_name
     'View court data'
   end
+
+  def l(date, options = {})
+    super(date, options) if date
+  end
 end

--- a/app/views/searches/_results.html.haml
+++ b/app/views/searches/_results.html.haml
@@ -17,4 +17,4 @@
           %td.govuk-table__cell= result.prosecution_case_reference
           %td.govuk-table__cell= result.first_name
           %td.govuk-table__cell= result.last_name
-          %td.govuk-table__cell= l(result.date_of_birth.to_date)
+          %td.govuk-table__cell= l(result.date_of_birth&.to_date)


### PR DESCRIPTION
Prevent nil:Nilclass error and i18n::ArgumentError for nils.

Returned objects from API/adaptor does not have a DoB.
