### PR TITLE
upload coverage to codeclimate as part of rspec tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,6 +157,13 @@ commands:
           path: /tmp/test-results
           destination: test-results
 
+  upload-coverage:
+    steps:
+      - run:
+          name: Upload coverage results to Code Climate
+          command: |
+            tmp/cc-test-reporter sum-coverage --output - --parts 1 tmp/coverage/codeclimate.*.json | tmp/cc-test-reporter upload-coverage --input -
+
   load-code-climate:
     steps:
       - run:
@@ -224,15 +231,7 @@ jobs:
             - coverage/codeclimate.*.json
       - store_artifacts:
           path: tmp/coverage
-
-  upload-coverage:
-    executor: test-executor
-    steps:
-      - *attach-tmp-workspace
-      - run:
-          name: Upload coverage results to Code Climate
-          command: |
-            tmp/cc-test-reporter sum-coverage --output - --parts 1 tmp/coverage/codeclimate.*.json | tmp/cc-test-reporter upload-coverage --input -
+      - upload-coverage
 
   build-app-container:
     executor: cloud-platform-executor
@@ -265,13 +264,10 @@ workflows:
       - rspec-tests:
           requires:
             - build-test-container
-      - upload-coverage:
-          requires:
-            - rspec-tests
-            - linter-tests
       - build-app-container:
           requires:
-            - upload-coverage
+            - linter-tests
+            - rspec-tests
       - deploy-dev:
           requires:
             - build-app-container
@@ -289,14 +285,11 @@ workflows:
       - rspec-tests:
           requires:
             - build-test-container
-      - upload-coverage:
-          requires:
-            - rspec-tests
-            - linter-tests
       - branch-build-approval:
           type: approval
           requires:
-            - upload-coverage
+            - linter-tests
+            - rspec-tests
           filters:
             branches:
               ignore:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,6 +102,7 @@ commands:
     steps:
       - install-gems
       - install-compile-assets
+      - install-codeclimate-tt
 
   db-setup:
     steps:
@@ -164,10 +165,10 @@ commands:
           command: |
             tmp/cc-test-reporter sum-coverage --output - --parts 1 tmp/coverage/codeclimate.*.json | tmp/cc-test-reporter upload-coverage --input -
 
-  load-code-climate:
+  install-codeclimate-tt:
     steps:
       - run:
-          name: Load and persist code climate
+          name: Install codeclimate test reporter
           command: |
             mkdir -p tmp/
             mkdir -p tmp/coverage/
@@ -204,7 +205,6 @@ jobs:
     executor: test-executor
     steps:
       - checkout
-      - load-code-climate
       - build-base
 
   linter-tests:


### PR DESCRIPTION
only the rspec tests currently produce coverage
results and an extra job for upload seems redundant.