### PR TITLE
Reconnect with fresh token on query, if required

### DIFF
--- a/lib/court_data_adaptor/client.rb
+++ b/lib/court_data_adaptor/client.rb
@@ -5,11 +5,11 @@ module CourtDataAdaptor
     include Configurable
 
     def initialize
-      client
+      oauth_client
     end
 
-    def client
-      @client ||= OAuth2::Client.new(
+    def oauth_client
+      @oauth_client ||= OAuth2::Client.new(
         config.api_uid,
         config.api_secret,
         site: config.api_url
@@ -17,11 +17,22 @@ module CourtDataAdaptor
     end
 
     def access_token
-      client&.client_credentials&.get_token
+      @access_token = new_access_token if @access_token.nil? || @access_token.expired?
+      @access_token
     end
 
     def bearer_token
-      access_token&.token
+      config.test_mode? ? fake_bearer_token : access_token.token
+    end
+
+    private
+
+    def new_access_token
+      oauth_client.client_credentials.get_token
+    end
+
+    def fake_bearer_token
+      'fake-court-data-adaptor-bearer-token'
     end
   end
 end

--- a/lib/court_data_adaptor/query/defendant.rb
+++ b/lib/court_data_adaptor/query/defendant.rb
@@ -6,6 +6,8 @@ module CourtDataAdaptor
       acts_as_resource CourtDataAdaptor::Resource::ProsecutionCase
 
       def call
+        refresh_token_if_required!
+
         cases = resource
                 .includes(:defendants)
                 .where(

--- a/lib/court_data_adaptor/query/prosecution_case.rb
+++ b/lib/court_data_adaptor/query/prosecution_case.rb
@@ -6,6 +6,8 @@ module CourtDataAdaptor
       acts_as_resource CourtDataAdaptor::Resource::ProsecutionCase
 
       def call
+        refresh_token_if_required!
+
         resource
           .where(prosecution_case_reference: term)
           .includes(:defendants)

--- a/lib/court_data_adaptor/resource/base.rb
+++ b/lib/court_data_adaptor/resource/base.rb
@@ -8,30 +8,15 @@ module CourtDataAdaptor
       VERSION = '0.0.1'
       self.site = config.api_url
 
-      def self.bearer_token
-        config.test_mode? ? fake_bearer_token : client_bearer_token
-      end
-
-      def self.client_bearer_token
-        Client.new.bearer_token
-      end
-
-      def self.fake_bearer_token
-        'fake-court-data-adaptor-bearer-token'
-      end
+      cattr_accessor :client
+      self.client = Client.new
 
       connection do |conn|
         conn.use(
           FaradayMiddleware::OAuth2,
-          bearer_token,
+          client.bearer_token,
           token_type: :bearer
         )
-
-        # example setting response logging
-        # conn.use Faraday::Response::Logger
-
-        # example using custom middleware
-        # conn.use MyCustomMiddleware
       end
     end
   end

--- a/lib/court_data_adaptor/resource/queryable.rb
+++ b/lib/court_data_adaptor/resource/queryable.rb
@@ -19,6 +19,13 @@ module CourtDataAdaptor
         def resource
           self.class.resource
         end
+
+        def refresh_token_if_required!
+          resource.connection(true) do |conn|
+            conn.use FaradayMiddleware::OAuth2, resource.client.bearer_token, token_type: :bearer
+            # conn.use Faraday::Response::Logger
+          end
+        end
       end
     end
   end

--- a/spec/lib/court_data_adaptor/client_spec.rb
+++ b/spec/lib/court_data_adaptor/client_spec.rb
@@ -2,29 +2,41 @@
 
 require 'court_data_adaptor'
 
-RSpec.describe CourtDataAdaptor::Client, :stub_oauth_token do
+RSpec.describe CourtDataAdaptor::Client do
   subject(:client) { described_class.new }
 
-  it { is_expected.to respond_to :client, :access_token, :bearer_token }
+  it { is_expected.to respond_to :oauth_client, :access_token, :bearer_token }
 
-  describe '#client' do
-    subject { described_class.new.client }
+  describe '#oauth_client' do
+    subject { described_class.new.oauth_client }
 
     it { is_expected.to be_an OAuth2::Client }
     it { is_expected.to respond_to :client_credentials }
   end
 
-  describe '#access_token' do
+  describe '#access_token', :stub_oauth_token do
     subject(:access_token) { client.access_token }
 
     it { is_expected.to be_an OAuth2::AccessToken }
     it { is_expected.to respond_to :token }
+    it { expect(access_token.token).to eql 'test-bearer-token' }
+
+    context 'when token nil? or expired?' do
+      before do
+        allow(client).to receive(:new_access_token)
+      end
+
+      it 'retrieves new access_token' do
+        access_token
+        expect(client).to have_received(:new_access_token)
+      end
+    end
   end
 
   describe '#bearer_token' do
     subject(:bearer_token) { client.bearer_token }
 
     it { is_expected.to be_a String }
-    it { is_expected.to eql 'test-bearer-token' }
+    it { is_expected.to eql 'fake-court-data-adaptor-bearer-token' }
   end
 end

--- a/spec/lib/court_data_adaptor/query/defendant_spec.rb
+++ b/spec/lib/court_data_adaptor/query/defendant_spec.rb
@@ -15,17 +15,23 @@ RSpec.describe CourtDataAdaptor::Query::Defendant do
   it { expect(instance).to respond_to(:dob, :dob=) }
 
   describe '#call' do
-    subject(:call) { described_class.new(term, dob: dob).call }
+    subject(:call) { instance.call }
 
+    let(:instance) { described_class.new(term, dob: dob) }
     let(:resource) { CourtDataAdaptor::Resource::ProsecutionCase }
     let(:resultset) { instance_double('ResultSet') }
 
     before do
+      allow(instance).to receive(:refresh_token_if_required!)
       allow(resource).to receive(:includes).with(:defendants).and_return(resultset)
       allow(resultset).to receive(:where).and_return(resultset)
       allow(resultset).to receive(:all).and_return(resultset)
       allow(resultset).to receive(:each_with_object).and_return(Array)
       call
+    end
+
+    it 'refreshes access_token if required' do
+      expect(instance).to have_received(:refresh_token_if_required!)
     end
 
     it 'sends includes(:defendants) query to resource' do

--- a/spec/lib/court_data_adaptor/query/prosecution_case_spec.rb
+++ b/spec/lib/court_data_adaptor/query/prosecution_case_spec.rb
@@ -9,17 +9,23 @@ RSpec.describe CourtDataAdaptor::Query::ProsecutionCase do
   it_behaves_like 'court_data_adaptor query object'
 
   describe '#call' do
-    subject(:call) { described_class.new(term).call }
+    subject(:call) { instance.call }
 
+    let(:instance) { described_class.new(term) }
     let(:term) { 'a-case-urn' }
     let(:resource) { CourtDataAdaptor::Resource::ProsecutionCase }
     let(:resultset) { instance_double('ResultSet') }
 
     before do
+      allow(instance).to receive(:refresh_token_if_required!)
       allow(resource).to receive(:where).and_return(resultset)
       allow(resultset).to receive(:includes).with(:defendants).and_return(resultset)
       allow(resultset).to receive(:all)
       call
+    end
+
+    it 'refreshes access_token if required' do
+      expect(instance).to have_received(:refresh_token_if_required!)
     end
 
     it 'sends where query to resource' do

--- a/spec/lib/court_data_adaptor/resource/queryable_spec.rb
+++ b/spec/lib/court_data_adaptor/resource/queryable_spec.rb
@@ -29,4 +29,30 @@ RSpec.describe CourtDataAdaptor::Resource::Queryable, :concern do
 
     it { is_expected.to be :my_resource_class }
   end
+
+  describe '#refresh_token_if_required!' do
+    subject(:refresh) { resource_instance.refresh_token_if_required! }
+
+    let(:resource_instance) { test_class.new }
+    let(:resource) { class_double('MyResource') }
+    let(:client) { instance_double(CourtDataAdaptor::Client) }
+
+    before do
+      conn = instance_double(JsonApiClient::Connection)
+      allow(resource_instance).to receive(:resource).and_return(resource)
+      allow(resource).to receive(:connection).and_yield(conn)
+      allow(conn).to receive(:use)
+      allow(resource).to receive(:client).and_return(client)
+      allow(client).to receive(:bearer_token).and_return('test-token')
+      refresh
+    end
+
+    it 'rebuilds connection' do
+      expect(resource).to have_received(:connection).with(true)
+    end
+
+    it 'calls client bearer_token, which refreshes if required' do
+      expect(client).to have_received(:bearer_token)
+    end
+  end
 end

--- a/spec/support/shared_examples_for_court_adaptor.rb
+++ b/spec/support/shared_examples_for_court_adaptor.rb
@@ -3,6 +3,7 @@
 RSpec.shared_examples 'court_data_adaptor queryable object' do
   it { is_expected.to respond_to :acts_as_resource, :resource }
   it { expect(subject.new(nil)).to respond_to :resource }
+  it { expect(subject.new(nil)).to respond_to :refresh_token_if_required! }
 end
 
 RSpec.shared_examples 'court_data_adaptor query object' do


### PR DESCRIPTION
Fix unauthorized access on bearer token

#### What
This prevents unauthorized errors after token expiry (on master)

#### Ticket

[CACP-236](https://dsdmoj.atlassian.net/browse/CACP-236)

#### Why
adaptor implements a two hour expiry and the client is not currently retrieving a fresh token.
note that `client_credentials` do NOT implement `refresh_token` logic.

#### How
Reconnect with a fresh token on submission of a query. the retrieving of new token only occurs if the old one has expired - I believe Faraday::OAuth2 is doing this "magically"
