### PR TITLE
Correct LAA court data adaptor prod url

### DIFF
--- a/.k8s/production/deployment.yaml
+++ b/.k8s/production/deployment.yaml
@@ -56,7 +56,7 @@ spec:
             - name: DOMAIN_URL
               value: 'https://view-court-data.service.justice.gov.uk'
             - name: COURT_DATA_ADAPTOR_API_URL
-              value: https://laa-court-data-adaptor-prod.apps.live-1.cloud-platform.service.justice.gov.uk/api/internal/v1
+              value: https://laa-court-data-adaptor.apps.live-1.cloud-platform.service.justice.gov.uk/api/internal/v1
             - name: RAILS_SERVE_STATIC_FILES
               value: enabled
             - name: GA_TRACKING_ID


### PR DESCRIPTION
#### What

Correct the LAA court data adaptor url for prod environment.

#### Ticket

n/a

#### Why

Deployment of View Court Data to production was failing

#### How

Correct the value in deployment.yaml.

