### PR TITLE
Handle defendants with no name attributes

### DIFF
--- a/lib/court_data_adaptor/resource/defendant.rb
+++ b/lib/court_data_adaptor/resource/defendant.rb
@@ -7,7 +7,7 @@ module CourtDataAdaptor
       property :prosecution_case_reference, type: :string
 
       def name
-        first_name + ' ' + last_name
+        "#{first_name} #{last_name}" unless first_name.blank? && last_name.blank?
       end
     end
   end

--- a/spec/lib/court_data_adaptor/resource/defendant_spec.rb
+++ b/spec/lib/court_data_adaptor/resource/defendant_spec.rb
@@ -15,10 +15,20 @@ RSpec.describe CourtDataAdaptor::Resource::Defendant do
   describe '#name' do
     subject { defendant.name }
 
-    let(:defendant) { described_class.load(first_name: 'John', last_name: 'Smith') }
+    context 'when defendant is a person' do
+      let(:defendant) { described_class.load(first_name: 'John', last_name: 'Smith') }
 
-    it 'returns Firstname Surname' do
-      is_expected.to eql 'John Smith'
+      it 'returns Firstname Surname' do
+        is_expected.to eql 'John Smith'
+      end
+    end
+
+    context 'when defendant is organisation' do
+      let(:defendant) { described_class.load(first_name: nil, last_name: nil) }
+
+      it 'returns Firstname Surname' do
+        is_expected.to be nil
+      end
     end
   end
 end


### PR DESCRIPTION
#### What
prevent errors when defendant has no name attributes

#### Why
defendants can be orgnaisations in Common platform.

until such time, if ever, that the adaptor returns
equivalent details for organisation defendants from
CP we need to handle the possibility that a query
returns a defendant organsiation.