### PR TITLE
[CACP-119] Add axe accessbility test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'sidekiq', '~> 5.2.7'
 gem 'webpacker', '~> 4.0'
 
 group :test do
+  gem 'axe-matchers'
   gem 'brakeman'
   gem 'capybara'
   gem 'climate_control'
@@ -42,6 +43,7 @@ group :test do
   gem 'rubocop-rspec', require: false
   gem 'simplecov', '~> 0.17.1', require: false
   gem 'vcr'
+  gem 'webdrivers'
   gem 'webmock'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,13 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.0)
     awesome_print (1.8.0)
+    axe-matchers (2.6.0)
+      dumb_delegator (~> 0.8)
+      virtus (~> 1.0)
+    axiom-types (0.1.1)
+      descendants_tracker (~> 0.0.4)
+      ice_nine (~> 0.11.0)
+      thread_safe (~> 0.3, >= 0.3.1)
     bcrypt (3.1.13)
     bcrypt (3.1.13-java)
     bindex (0.8.1)
@@ -88,16 +95,21 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
+    childprocess (3.0.0)
     climate_control (0.2.0)
     codeclimate-test-reporter (1.0.7)
       simplecov
     coderay (1.1.2)
+    coercible (1.0.0)
+      descendants_tracker (~> 0.0.1)
     colorize (0.8.1)
     concurrent-ruby (1.1.6)
     connection_pool (2.2.2)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.6)
+    descendants_tracker (0.0.4)
+      thread_safe (~> 0.3, >= 0.3.1)
     devise (4.7.1)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -110,6 +122,8 @@ GEM
     dotenv-rails (2.7.5)
       dotenv (= 2.7.5)
       railties (>= 3.2, < 6.1)
+    dumb_delegator (0.8.1)
+    equalizer (0.0.11)
     erubi (1.9.0)
     erubis (2.7.0)
     factory_bot (5.1.1)
@@ -167,6 +181,7 @@ GEM
       rails-i18n
       rainbow (>= 2.2.2, < 4.0)
       terminal-table (>= 1.5.1)
+    ice_nine (0.11.2)
     jaro_winkler (1.5.4)
     jaro_winkler (1.5.4-java)
     json (2.3.0)
@@ -332,7 +347,11 @@ GEM
     ruby-progressbar (1.10.1)
     ruby_parser (3.14.2)
       sexp_processor (~> 4.9)
+    rubyzip (2.2.0)
     safe_yaml (1.0.5)
+    selenium-webdriver (3.142.7)
+      childprocess (>= 0.5, < 4.0)
+      rubyzip (>= 1.2.2)
     sexp_processor (4.14.1)
     sidekiq (5.2.8)
       connection_pool (~> 2.2, >= 2.2.2)
@@ -368,6 +387,11 @@ GEM
       tzinfo (>= 1.0.0)
     unicode-display_width (1.6.1)
     vcr (5.1.0)
+    virtus (1.0.5)
+      axiom-types (~> 0.1)
+      coercible (~> 1.0)
+      descendants_tracker (~> 0.0, >= 0.0.3)
+      equalizer (~> 0.0, >= 0.0.9)
     warden (1.2.8)
       rack (>= 2.0.6)
     web-console (4.0.1)
@@ -375,6 +399,10 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webdrivers (4.2.0)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (>= 3.0, < 4.0)
     webmock (3.8.3)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -401,6 +429,7 @@ PLATFORMS
 
 DEPENDENCIES
   awesome_print
+  axe-matchers
   bootsnap (>= 1.4.2)
   brakeman
   cancancan
@@ -445,6 +474,7 @@ DEPENDENCIES
   tzinfo-data
   vcr
   web-console (>= 3.3.0)
+  webdrivers
   webmock
   webpacker (~> 4.0)
 

--- a/spec/features/search/case_reference_spec.rb
+++ b/spec/features/search/case_reference_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.feature 'Case reference search', type: :feature, vcr: true do
+RSpec.feature 'Case reference search', type: :feature, vcr: true, js: true do
   let(:user) { create(:user) }
 
   before do
@@ -19,6 +19,8 @@ RSpec.feature 'Case reference search', type: :feature, vcr: true do
     within 'tbody.govuk-table__body' do
       expect(page).to have_content('MOGUERBXIZ', count: 4)
     end
+
+    expect(page).to be_accessible.within '#main-content'
   end
 
   scenario 'with non existent case URN' do
@@ -29,6 +31,8 @@ RSpec.feature 'Case reference search', type: :feature, vcr: true do
     fill_in 'search-term-field', with: 'non-existent-caseURN'
     click_button 'Search'
     expect(page).to have_css('.govuk-body', text: 'There are no matching results')
+
+    expect(page).to be_accessible.within '#main-content'
   end
 
   scenario 'with no case reference provided' do
@@ -46,5 +50,7 @@ RSpec.feature 'Case reference search', type: :feature, vcr: true do
     end
 
     expect(page).to have_css('#search-term-error', text: 'Search term required')
+
+    expect(page).to be_accessible.within '#main-content'
   end
 end

--- a/spec/features/search/defendant_by_name_spec.rb
+++ b/spec/features/search/defendant_by_name_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.feature 'Defendant by name and dob search', type: :feature do
+RSpec.feature 'Defendant by name and dob search', type: :feature, js: true do
   let(:user) { create(:user) }
 
   before do
@@ -29,6 +29,8 @@ RSpec.feature 'Defendant by name and dob search', type: :feature do
     within 'tbody.govuk-table__body' do
       expect(page).to have_content('Josefa Franecki').once
     end
+
+    expect(page).to be_accessible.within '#main-content'
   end
 
   scenario 'with no results', :vcr do
@@ -43,6 +45,8 @@ RSpec.feature 'Defendant by name and dob search', type: :feature do
     click_button 'Search'
 
     expect(page).to have_css('.govuk-body', text: 'There are no matching results')
+
+    expect(page).to be_accessible.within '#main-content'
   end
 
   scenario 'with no date of birth specified', :vcr do
@@ -60,5 +64,7 @@ RSpec.feature 'Defendant by name and dob search', type: :feature do
     end
 
     expect(page).to have_css('#search-dob-error', text: 'Defendant date of birth required')
+
+    expect(page).to be_accessible.within '#main-content'
   end
 end

--- a/spec/features/search/defendant_by_reference_spec.rb
+++ b/spec/features/search/defendant_by_reference_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.feature 'Defendant by reference search', type: :feature, vcr: true do
+RSpec.feature 'Defendant by reference search', type: :feature, vcr: true, js: true do
   let(:user) { create(:user) }
 
   before do
@@ -24,6 +24,8 @@ RSpec.feature 'Defendant by reference search', type: :feature, vcr: true do
       within 'tbody.govuk-table__body' do
         expect(page).to have_content('GP181930B').once
       end
+
+      expect(page).to be_accessible.within '#main-content'
     end
 
     scenario 'with no results' do
@@ -35,6 +37,8 @@ RSpec.feature 'Defendant by reference search', type: :feature, vcr: true do
       click_button 'Search'
 
       expect(page).to have_css('.govuk-body', text: 'There are no matching results')
+
+      expect(page).to be_accessible.within '#main-content'
     end
 
     scenario 'with no defendant reference specified' do
@@ -52,6 +56,8 @@ RSpec.feature 'Defendant by reference search', type: :feature, vcr: true do
       end
 
       expect(page).to have_css('#search-term-error', text: 'Search term required')
+
+      expect(page).to be_accessible.within '#main-content'
     end
   end
 end

--- a/spec/features/search/filters_spec.rb
+++ b/spec/features/search/filters_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.feature 'Search filters', type: :feature do
+RSpec.feature 'Search filters', type: :feature, js: true do
   let(:user) { create(:user) }
 
   before do
@@ -17,6 +17,8 @@ RSpec.feature 'Search filters', type: :feature do
                              text: 'Search for a defendant by reference')
     expect(page).to have_css('.govuk-radios__item',
                              text: 'Search for a defendant by name and date of birth')
+
+    expect(page).to be_accessible.within '#main-content'
   end
 
   scenario 'user chooses defendant filter' do
@@ -25,6 +27,8 @@ RSpec.feature 'Search filters', type: :feature do
     choose 'Search for a defendant by name and date of birth'
     click_button 'Continue'
     expect(page).to have_text('Find a defendant')
+
+    expect(page).to be_accessible.within '#main-content'
   end
 
   scenario 'user chooses case number filter' do
@@ -33,5 +37,7 @@ RSpec.feature 'Search filters', type: :feature do
     choose 'Search for a case by URN'
     click_button 'Continue'
     expect(page).to have_text('Find a case')
+
+    expect(page).to be_accessible.within '#main-content'
   end
 end

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.feature 'Sign in', type: :feature do
+RSpec.feature 'Sign in', type: :feature, js: true do
   let(:user) do
     create(:user,
            email: 'bob.smith@example.com',
@@ -14,6 +14,10 @@ RSpec.feature 'Sign in', type: :feature do
 
   it 'page header is displayed' do
     expect(page).to have_govuk_page_title(text: 'Sign in')
+  end
+
+  it 'page should be accessible' do
+    expect(page).to be_accessible.within '#main-content'
   end
 
   context 'with success' do

--- a/spec/features/users/edit_user_spec.rb
+++ b/spec/features/users/edit_user_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.feature 'Edit user', type: :feature do
+RSpec.feature 'Edit user', type: :feature, js: true do
   before do
     sign_in user
   end
@@ -36,6 +36,8 @@ RSpec.feature 'Edit user', type: :feature do
       expect(row).to have_link(other_user.name, href: user_path(other_user))
       expect(row).to have_link('Edit', href: edit_user_path(other_user))
 
+      expect(page).to be_accessible.within '#main-content'
+
       within(row) do
         click_link 'Edit'
       end
@@ -50,6 +52,8 @@ RSpec.feature 'Edit user', type: :feature do
       check 'Manager'
       fill_in 'Email', with: 'changed@example.com'
       fill_in 'Confirm email', with: 'changed@example.com'
+
+      expect(page).to be_accessible.within '#main-content'
 
       expect do
         click_button 'Save'

--- a/spec/features/users/password_change_spec.rb
+++ b/spec/features/users/password_change_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.feature 'Password change', type: :feature do
+RSpec.feature 'Password change', type: :feature, js: true do
   let(:user) { create(:user, :with_caseworker_role) }
 
   before do
@@ -22,6 +22,7 @@ RSpec.feature 'Password change', type: :feature do
     fill_in 'Current password', with: user.password
     fill_in 'New password', with: 'my-new-password'
     fill_in 'Confirm new password', with: 'my-new-password'
+    expect(page).to be_accessible.within '#main-content'
     expect do
       click_button 'Change password'
     end.to have_enqueued_job.on_queue('mailers')

--- a/spec/features/users/password_reset_spec.rb
+++ b/spec/features/users/password_reset_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.feature 'Password reset', type: :feature do
+RSpec.feature 'Password reset', type: :feature, js: true do
   let(:user) { create(:user, :with_caseworker_role) }
 
   let(:reset_flash_notice) do
@@ -23,6 +23,7 @@ RSpec.feature 'Password reset', type: :feature do
     click_link 'Forgot your password?'
 
     expect(page).to have_govuk_page_title(text: 'Forgot your password?')
+    expect(page).to be_accessible.within '#main-content'
     fill_in 'Email', with: user.email
     expect do
       click_button 'Send me reset password instructions'

--- a/spec/features/users/password_unlock_spec.rb
+++ b/spec/features/users/password_unlock_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.feature 'Password unlock', type: :feature do
+RSpec.feature 'Password unlock', type: :feature, js: true do
   let(:user) { create(:user, :with_caseworker_role) }
 
   let(:resent_flash_notice) do
@@ -43,6 +43,7 @@ RSpec.feature 'Password unlock', type: :feature do
     click_link 'Didn\'t receive unlock instructions?'
 
     expect(page).to have_govuk_page_title(text: 'Resend unlock instructions')
+    expect(page).to be_accessible.within '#main-content'
     fill_in 'Email', with: user.email
     expect do
       click_button 'Resend unlock instructions'

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -6,6 +6,7 @@
 # https://github.com/DavyJonesLocker/capybara-extensions
 #
 require_relative 'capybara_extensions'
+require 'axe/rspec'
 
 module Capybara
   module DSL
@@ -26,4 +27,12 @@ module Capybara
 
   Node::Base.include CapybaraExtensions::Matchers
   Node::Simple.include CapybaraExtensions::Matchers
+end
+
+Capybara.configure do |config|
+  # https://www.rubydoc.info/github/jnicklas/capybara/Capybara.configure
+  config.automatic_label_click = true
+  config.default_max_wait_time = 1
+  config.ignore_hidden_elements = false # Fix: matchers not finding elements
+  config.javascript_driver = :selenium_chrome_headless
 end


### PR DESCRIPTION
#### What
Conduct an accessibility audit of court data

#### Ticket
[CACP-119 Review accessibility](https://dsdmoj.atlassian.net/browse/CACP-119)

#### Why
To deliver an accessible product, to meet legal requirements, but best of all, to make sure all our users can easily use what we build.

#### How
 - [X] Test app using Voiceover
 - [X] Keyboard only audit
 - [X] Browser based tools [aXe, WAVE, CodeSniffer etc]
 - [X] Automated accessibility test for the CI process

