### PR TITLE
check yarn integrity

### DIFF
--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -52,9 +52,6 @@ development:
   <<: *default
   compile: true
 
-  # Verifies that correct packages and versions are installed by inspecting package.json, yarn.lock, and node_modules
-  check_yarn_integrity: true
-
   # Reference: https://webpack.js.org/configuration/dev-server/
   dev_server:
     https: false


### PR DESCRIPTION
#### What
Disable `check_yarn_integrity` on development environment.

#### Why
`yarn check --integrity` is run on `rails c`, thereby causing the rails console to err.

#### How
Remove the environment specific `check_yarn_integrity` setting and fallback to webpacker default.

