### PR TITLE
Add unlinked case design flow

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,5 @@
 # DO NOT PUT SECRETS HERE
+# use with `source .env` in terminal to
+# prevent ruby 2.7 deprecation warnings.
+#
 export RUBYOPT='-W:no-deprecated'

--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+# DO NOT PUT SECRETS HERE
+export RUBYOPT='-W:no-deprecated'

--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,6 @@ Brewfile.lock.json
 
 # dotenv (gem) ignores
 # check https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use
-# .env
 .env.local
 .env.**.local
 

--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,7 @@ Brewfile.lock.json
 
 # dotenv (gem) ignores
 # check https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use
-.env
+# .env
 .env.local
 .env.**.local
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  include Breadcrumbs
+
   default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
   protect_from_forgery prepend: true, with: :exception
   before_action :authenticate_user!
@@ -19,21 +21,6 @@ class ApplicationController < ActionController::Base
     session[:current_search_filter]
   end
   helper_method :current_search_filter
-
-  def new_search_filter_name
-    I18n.t('search_filter.breadcrumb')
-  end
-  helper_method :new_search_filter_name
-
-  def search_breadcrumb_name
-    I18n.t('search.breadcrumb')
-  end
-  helper_method :search_breadcrumb_name
-
-  def search_breadcrumb_path
-    new_search_path(search: { filter: current_search_filter })
-  end
-  helper_method :search_breadcrumb_path
 
   protected
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,15 +20,13 @@ class ApplicationController < ActionController::Base
   end
   helper_method :current_search_filter
 
+  def new_search_filter_name
+    I18n.t('search_filter.breadcrumb')
+  end
+  helper_method :new_search_filter_name
+
   def search_breadcrumb_name
-    case current_search_filter
-    when 'case_reference'
-      'Case ref search'
-    when 'defendant_reference'
-      'Defendant ref search'
-    when 'defendant_name'
-      'Defendant name search'
-    end
+    I18n.t('search.breadcrumb')
   end
   helper_method :search_breadcrumb_name
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,14 +13,14 @@ class ApplicationController < ActionController::Base
   rescue_from Exception, with: :unexpected_exception_handler
   rescue_from CanCan::AccessDenied, with: :access_denied
 
-  def current_search_filter=(arg)
-    session[:current_search_filter] = arg
+  def current_search_params=(params)
+    session[:current_search_params] = params
   end
 
-  def current_search_filter
-    session[:current_search_filter]
+  def current_search_params
+    session[:current_search_params]
   end
-  helper_method :current_search_filter
+  helper_method :current_search_params
 
   protected
 

--- a/app/controllers/concerns/breadcrumbs.rb
+++ b/app/controllers/concerns/breadcrumbs.rb
@@ -15,7 +15,7 @@ module Breadcrumbs
     helper_method :search_breadcrumb_name
 
     def search_breadcrumb_path
-      new_search_path(search: { filter: current_search_filter })
+      searches_path(search: current_search_params)
     end
     helper_method :search_breadcrumb_path
 

--- a/app/controllers/concerns/breadcrumbs.rb
+++ b/app/controllers/concerns/breadcrumbs.rb
@@ -18,5 +18,10 @@ module Breadcrumbs
       new_search_path(search: { filter: current_search_filter })
     end
     helper_method :search_breadcrumb_path
+
+    def prosecution_case_name(reference)
+      I18n.t('prosecution_case.breadcrumb', prosecution_case_reference: reference)
+    end
+    helper_method :prosecution_case_name
   end
 end

--- a/app/controllers/concerns/breadcrumbs.rb
+++ b/app/controllers/concerns/breadcrumbs.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Breadcrumbs
+  extend ActiveSupport::Concern
+
+  included do
+    def search_filter_breadcrumb_name
+      I18n.t('search_filter.breadcrumb')
+    end
+    helper_method :search_filter_breadcrumb_name
+
+    def search_breadcrumb_name
+      I18n.t('search.breadcrumb')
+    end
+    helper_method :search_breadcrumb_name
+
+    def search_breadcrumb_path
+      new_search_path(search: { filter: current_search_filter })
+    end
+    helper_method :search_breadcrumb_path
+  end
+end

--- a/app/controllers/defendants_controller.rb
+++ b/app/controllers/defendants_controller.rb
@@ -3,7 +3,7 @@
 class DefendantsController < ApplicationController
   before_action :load_and_authorize_search
 
-  add_breadcrumb 'Search filters', :new_search_filter_path
+  add_breadcrumb :new_search_filter_name, :new_search_filter_path
   add_breadcrumb :search_breadcrumb_name, :search_breadcrumb_path
   add_breadcrumb 'Case details',
                  (proc { |v| v.prosecution_case_path(v.controller.defendant.prosecution_case_reference) })

--- a/app/controllers/defendants_controller.rb
+++ b/app/controllers/defendants_controller.rb
@@ -3,9 +3,9 @@
 class DefendantsController < ApplicationController
   before_action :load_and_authorize_search
 
-  add_breadcrumb :new_search_filter_name, :new_search_filter_path
+  add_breadcrumb :search_filter_breadcrumb_name, :new_search_filter_path
   add_breadcrumb :search_breadcrumb_name, :search_breadcrumb_path
-  add_breadcrumb 'Case details',
+  add_breadcrumb (proc { |v| v.prosecution_case_name(v.controller.defendant.prosecution_case_reference) }),
                  (proc { |v| v.prosecution_case_path(v.controller.defendant.prosecution_case_reference) })
 
   def show

--- a/app/controllers/laa_references_controller.rb
+++ b/app/controllers/laa_references_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class LaaReferencesController < ApplicationController
+  # link
+  def create
+    authorize! :create, :link_maat_reference, message: I18n.t('unauthorized.default')
+    @laa_reference = link_laa_reference(laa_reference_params)
+    flash[:notice] = "TODO: MAAT ID #{laa_reference_params[:maat_reference]} linked"
+    redirect_to defendant_path(laa_reference_params[:id])
+  end
+
+  private
+
+  def link_laa_reference(options)
+    # TODO: query and update
+    # resource = CourtDataAdaptor::Resource::LaaReferences
+    # resource.find().update_attributes
+  end
+
+  def laa_reference_params
+    params.permit(
+      :id,
+      :defendant_id,
+      :maat_reference
+    )
+  end
+end

--- a/app/controllers/prosecution_cases_controller.rb
+++ b/app/controllers/prosecution_cases_controller.rb
@@ -3,7 +3,7 @@
 class ProsecutionCasesController < ApplicationController
   before_action :load_and_authorize_search
 
-  add_breadcrumb 'Search filters', :new_search_filter_path
+  add_breadcrumb :new_search_filter_name, :new_search_filter_path
   add_breadcrumb :search_breadcrumb_name, :search_breadcrumb_path
 
   def show

--- a/app/controllers/prosecution_cases_controller.rb
+++ b/app/controllers/prosecution_cases_controller.rb
@@ -3,13 +3,14 @@
 class ProsecutionCasesController < ApplicationController
   before_action :load_and_authorize_search
 
-  add_breadcrumb :new_search_filter_name, :new_search_filter_path
+  add_breadcrumb :search_filter_breadcrumb_name, :new_search_filter_path
   add_breadcrumb :search_breadcrumb_name, :search_breadcrumb_path
 
   def show
     @results = @search.execute
     @prosecution_case = @results.first
-    add_breadcrumb 'Case details', prosecution_case_path(@prosecution_case.prosecution_case_reference)
+    add_breadcrumb prosecution_case_name(@prosecution_case.prosecution_case_reference),
+                   prosecution_case_path(@prosecution_case.prosecution_case_reference)
   end
 
   private

--- a/app/controllers/search_filters_controller.rb
+++ b/app/controllers/search_filters_controller.rb
@@ -18,7 +18,6 @@ class SearchFiltersController < ApplicationController
 
   def set_filter
     @search_filter = SearchFilter.new(id: params.fetch(:search_filter, nil)&.fetch(:id, nil))
-    self.current_search_filter = @search_filter.id
   end
 
   def search_filter_params

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -5,7 +5,7 @@ class SearchesController < ApplicationController
 
   rescue_from JsonApiClient::Errors::ConnectionError, with: :connection_error
 
-  add_breadcrumb :new_search_filter_name, :new_search_filter_path
+  add_breadcrumb :search_filter_breadcrumb_name, :new_search_filter_path
   add_breadcrumb :search_breadcrumb_name, :search_breadcrumb_path
 
   def new

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class SearchesController < ApplicationController
-  before_action :set_view_options
+  before_action :set_search_options
 
   rescue_from JsonApiClient::Errors::ConnectionError, with: :connection_error
 
@@ -49,6 +49,14 @@ class SearchesController < ApplicationController
       if day.present? && month.present? && year.present?
   rescue Date::Error
     nil
+  end
+
+  def set_search_options
+    filter
+    term
+    dob
+    set_view_options
+    self.current_search_params = search_params
   end
 
   def set_view_options

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -52,16 +52,13 @@ class SearchesController < ApplicationController
   end
 
   def set_view_options
-    case filter
-    when 'defendant_reference'
-      @label = I18n.t('search.term.defendant_reference_label')
-      @hint = I18n.t('search.term.defendant_reference_label_hint')
-    when 'defendant_name'
-      @label = I18n.t('search.term.defendant_name_label')
-      @hint = I18n.t('search.term.defendant_name_label_hint')
-    else
-      @label = I18n.t('search.term.case_reference_label')
-      @hint = I18n.t('search.term.case_reference_label_hint')
-    end
+    @label = case filter
+             when 'defendant_reference'
+               I18n.t('search.term.defendant_reference_label')
+             when 'defendant_name'
+               I18n.t('search.term.defendant_name_label')
+             else
+               I18n.t('search.term.case_reference_label')
+             end
   end
 end

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -5,7 +5,7 @@ class SearchesController < ApplicationController
 
   rescue_from JsonApiClient::Errors::ConnectionError, with: :connection_error
 
-  add_breadcrumb 'Search filters', :new_search_filter_path
+  add_breadcrumb :new_search_filter_name, :new_search_filter_path
   add_breadcrumb :search_breadcrumb_name, :search_breadcrumb_path
 
   def new

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable Style/GuardClause
 class Ability
   include CanCan::Ability
 
@@ -38,31 +37,39 @@ class Ability
 
     alias_action :change_password, :update_password, to: :manage_password
 
-    if user.caseworker?
-      can_search
-      can_manage_self
-    end
-
-    if user.manager?
-      can_search
-      can :manage, User
-    end
-
-    if user.admin?
-      can_search
-      can_manage_self
-    end
+    caseworker_abilities if user.caseworker?
+    manager_abilities if user.manager?
+    admin_abilities if user.admin?
   end
 
   private
+
+  def caseworker_abilities
+    can_search
+    can_manage_links
+    can_manage_self
+  end
+
+  def manager_abilities
+    can_search
+    can_manage_links
+    can :manage, User
+  end
+
+  def admin_abilities
+    caseworker_abilities
+  end
 
   def can_search
     can %i[new create], SearchFilter
     can %i[new create], Search
   end
 
+  def can_manage_links
+    can :create, :link_maat_reference
+  end
+
   def can_manage_self
     can %i[show manage_password], User, id: user.id
   end
 end
-# rubocop:enable Style/GuardClause

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -5,19 +5,18 @@ require 'court_data_adaptor'
 class Search
   include ActiveModel::Model
 
+  # rubocop:disable Rails/OutputSafety
   def self.filters
     [
       _filter(id: :case_reference,
-              name: I18n.t('search_filter.radio_case_reference_label'),
-              description: I18n.t('search_filter.radio_case_reference_label_hint')),
+              name: I18n.t('search_filter.radio_case_reference_label')),
       _filter(id: :defendant_reference,
-              name: I18n.t('search_filter.radio_defendant_reference_label'),
-              description: I18n.t('search_filter.radio_defendant_reference_label_hint')),
+              name: I18n.t('search_filter.radio_defendant_reference_label_html').html_safe),
       _filter(id: :defendant_name,
-              name: I18n.t('search_filter.radio_defendant_name_label'),
-              description: I18n.t('search_filter.radio_defendant_name_label_hint'))
+              name: I18n.t('search_filter.radio_defendant_name_label_html').html_safe)
     ]
   end
+  # rubocop:enable Rails/OutputSafety
 
   private_class_method def self._filter(args)
     SearchFilter.new(**args)

--- a/app/views/defendants/show.html.haml
+++ b/app/views/defendants/show.html.haml
@@ -45,3 +45,5 @@
           Not yet available
         %td.govuk-table__cell
           = offence.mode_of_trial
+
+= render 'laa_references/form', locals: @defendant

--- a/app/views/laa_references/_form.html.haml
+++ b/app/views/laa_references/_form.html.haml
@@ -1,0 +1,10 @@
+= form_with(url: '/laa_references', local: true) do |f|
+  = f.hidden_field(:id, value: params[:id])
+  = f.hidden_field(:defendant_id, value: @defendant.id)
+
+  = f.govuk_text_field :maat_reference,
+    value: nil,
+    label: { text: t('laa_reference.maat_reference.label') },
+    hint_text: t('laa_reference.maat_reference.hint')
+
+  = f.govuk_submit(t('laa_reference.submit'))

--- a/app/views/prosecution_cases/show.html.haml
+++ b/app/views/prosecution_cases/show.html.haml
@@ -19,4 +19,7 @@
           %td.govuk-table__cell
             = l(defendant.date_of_birth&.to_date)
           %td.govuk-table__cell
-            = 'Not linked'
+            - if defendant.linked?
+              = 'TODO: retrieve MAAT reference'
+            - else
+              = t('search.result.defendant.unlinked')

--- a/app/views/search_filters/_form.html.haml
+++ b/app/views/search_filters/_form.html.haml
@@ -5,8 +5,6 @@
     Search.filters,
     :id,
     :name,
-    :description,
-    legend: { text: t('search_filter.legend_text'), size: 'xl' },
-    hint_text: t('search_filter.label_hint')
+    legend: { text: t('search_filter.legend_text'), size: 'xl' }
 
   = f.govuk_submit( t('generic.continue') )

--- a/app/views/search_filters/new.html.haml
+++ b/app/views/search_filters/new.html.haml
@@ -1,3 +1,1 @@
-= govuk_page_title(t('search_filter.page_title'))
-
 = render 'form'

--- a/app/views/searches/_form.html.haml
+++ b/app/views/searches/_form.html.haml
@@ -1,7 +1,7 @@
 = form_with model: @search, local: true do |f|
   = f.govuk_error_summary
   = f.hidden_field(:filter, value: @filter)
-  = f.govuk_text_field(:term, value: @term, label: { text: @label }, hint_text: @hint )
+  = f.govuk_text_field(:term, value: @term, label: { text: @label })
 
   - if @filter.eql?('defendant_name')
     = f.govuk_date_field :dob,

--- a/app/views/searches/_form.html.haml
+++ b/app/views/searches/_form.html.haml
@@ -4,8 +4,8 @@
   = f.govuk_text_field(:term, value: @term, label: { text: @label })
 
   - if @filter.eql?('defendant_name')
-    = f.govuk_date_field :dob,
-      legend: { text: t('search.dob.legend_text') },
-      hint_text: t('search.dob.hint_text')
+    .govuk-date-fieldset-m
+      = f.govuk_date_field :dob,
+        legend: { text: t('search.dob.legend_text') }
 
   = f.govuk_submit( t('generic.search') )

--- a/app/webpack/stylesheets/application.scss
+++ b/app/webpack/stylesheets/application.scss
@@ -11,4 +11,5 @@ $govuk-image-url-function: frontend-image-url;
 @import "~govuk-frontend/govuk/all";
 
 @import "components/cookie_banner";
+@import "components/forms";
 @import "components/summary";

--- a/app/webpack/stylesheets/components/_forms.scss
+++ b/app/webpack/stylesheets/components/_forms.scss
@@ -1,0 +1,4 @@
+.govuk-date-fieldset-m .govuk-fieldset__heading {
+  @include govuk-font($size: 19)
+  margin-bottom: govuk-spacing(1);
+}

--- a/config/locales/en/views/laa_references.yml
+++ b/config/locales/en/views/laa_references.yml
@@ -1,0 +1,7 @@
+---
+en:
+  laa_reference:
+    maat_reference:
+      hint: Enter the MAAT ID so this case can be linked to the court data source
+      label: MAAT ID
+    submit: Create link to court data

--- a/config/locales/en/views/searches.yml
+++ b/config/locales/en/views/searches.yml
@@ -42,12 +42,7 @@ en:
       defendant_reference_label_hint: Enter full national insurance number or arrest summons number
   search_filter:
     breadcrumb: Home
-    label_hint: Choose an option
-    legend_text: How do you want to search?
-    page_title: Search filters
-    radio_case_reference_label: Search for a case by URN
-    radio_case_reference_label_hint: Unique reference number
-    radio_defendant_name_label: Search for a defendant by name and date of birth
-    radio_defendant_name_label_hint: Name and date of birth
-    radio_defendant_reference_label: Search for a defendant by reference
-    radio_defendant_reference_label_hint: National insurance or Arrest summons number
+    legend_text: Search for
+    radio_case_reference_label: A case by URN
+    radio_defendant_name_label_html: A defendant by name <b>and</b> date of birth
+    radio_defendant_reference_label_html: A defendant by ASN <b>or</b> National insurance number

--- a/config/locales/en/views/searches.yml
+++ b/config/locales/en/views/searches.yml
@@ -26,6 +26,7 @@ en:
         name: Name
         national_insurance_number: NI number
         prosecution_case_reference: Case URN
+        unlinked: Not linked
       heading: Search results for "%{term}"
       heading_with_dob: Search results for "%{term}, %{dob}"
       offence:

--- a/config/locales/en/views/searches.yml
+++ b/config/locales/en/views/searches.yml
@@ -36,12 +36,9 @@ en:
         plea: Plea
         title: Offence
     term:
-      case_reference_label: Find a case
-      case_reference_label_hint: Enter full case unique reference number
-      defendant_name_label: Find a defendant
-      defendant_name_label_hint: Enter full name of defendant
-      defendant_reference_label: Find a defendant
-      defendant_reference_label_hint: Enter full national insurance number or arrest summons number
+      case_reference_label: Unique reference number
+      defendant_name_label: Defendant name
+      defendant_reference_label: Defendant ASN or National insurance number
   search_filter:
     breadcrumb: Home
     legend_text: Search for

--- a/config/locales/en/views/searches.yml
+++ b/config/locales/en/views/searches.yml
@@ -1,6 +1,7 @@
 ---
 en:
   search:
+    breadcrumb: Search
     connection_error: Connection error, please try again soon!
     dob:
       hint_text: For example, 31 3 1980
@@ -40,6 +41,7 @@ en:
       defendant_reference_label: Find a defendant
       defendant_reference_label_hint: Enter full national insurance number or arrest summons number
   search_filter:
+    breadcrumb: Home
     label_hint: Choose an option
     legend_text: How do you want to search?
     page_title: Search filters

--- a/config/locales/en/views/searches.yml
+++ b/config/locales/en/views/searches.yml
@@ -6,7 +6,6 @@ en:
     breadcrumb: Search
     connection_error: Connection error, please try again soon!
     dob:
-      hint_text: For example, 31 3 1980
       legend_text: Defendant date of birth
     no_result:
       body: There are no matching results.

--- a/config/locales/en/views/searches.yml
+++ b/config/locales/en/views/searches.yml
@@ -1,5 +1,7 @@
 ---
 en:
+  prosecution_case:
+    breadcrumb: Case %{prosecution_case_reference}
   search:
     breadcrumb: Search
     connection_error: Connection error, please try again soon!

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
   resources :searches, only: %i[new create]
   resources :prosecution_cases, only: %i[show]
   resources :defendants, only: %i[show]
+  resources :laa_references, only: %i[create destroy]
 
   devise_for :users, controllers: {
     confirmations: 'users/confirmations',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,10 @@ Rails.application.routes.draw do
   end
 
   resources :search_filters, only: %i[new create]
-  resources :searches, only: %i[new create]
+  resources :searches, only: %i[new create] do
+    get :create, on: :collection
+  end
+
   resources :prosecution_cases, only: %i[show]
   resources :defendants, only: %i[show]
   resources :laa_references, only: %i[create destroy]

--- a/docs/development.md
+++ b/docs/development.md
@@ -126,6 +126,11 @@ RUBYOPT=-W:no-deprecated rails server
 RUBYOPT=-W:no-deprecated rails console
 ```
 
+Alternatively there is an `.env` file in the root app to set this generally
+```
+source .env
+```
+
 ### A note on assets
 
 The rails asset pipeline is disabled and all related config is commented out (it does not seem possible to remove sprockets entirely). We are using `webpacker` gem wrapper for `webpack`, and `yarn` for js dependency management.

--- a/lib/court_data_adaptor/resource/defendant.rb
+++ b/lib/court_data_adaptor/resource/defendant.rb
@@ -9,6 +9,12 @@ module CourtDataAdaptor
       def name
         "#{first_name} #{last_name}" unless first_name.blank? && last_name.blank?
       end
+
+      def linked?
+        is_linked
+      rescue NameError
+        false
+      end
     end
   end
 end

--- a/lib/gds_design_system_breadcrumb_builder.rb
+++ b/lib/gds_design_system_breadcrumb_builder.rb
@@ -8,27 +8,27 @@ class GdsDesignSystemBreadcrumbBuilder < BreadcrumbsOnRails::Breadcrumbs::Builde
   def render
     @context.content_tag(:div, class: 'govuk-breadcrumbs') do
       @context.content_tag(:ol, class: 'govuk-breadcrumbs__list') do
-        @elements.collect do |element|
-          render_element(element)
+        @elements.collect.with_index do |element, idx|
+          render_element(element, last: idx.eql?(@elements.size - 1))
         end.join('').html_safe
       end
     end
   end
 
-  def render_element(element)
+  def render_element(element, last: false)
     content = if element.path.nil?
                 compute_name(element)
               else
-                @context.link_to_unless_current(
-                  compute_name(element),
-                  compute_path(element),
-                  element.options.merge(class: 'govuk-breadcrumbs__link')
-                )
+                name = compute_name(element)
+                path = compute_path(element)
+                options = element.options.merge(class: 'govuk-breadcrumbs__link')
+                is_current = @context.current_page?(path) || last
+                @context.link_to_unless(is_current, name, path, options)
               end
 
     tag_options = {}
     tag_options[:class] = 'govuk-breadcrumbs__list-item'
-    tag_options['aria-current'] = 'page' if @context.current_page?(compute_path(element))
+    tag_options['aria-current'] = 'page' if is_current
     @context.content_tag(:li, content, tag_options)
   end
 end

--- a/spec/features/breadcrumbs_spec.rb
+++ b/spec/features/breadcrumbs_spec.rb
@@ -30,21 +30,21 @@ RSpec.feature 'Breadcrumb', type: :feature do
     context 'when on case reference search page' do
       scenario 'expected breadcrumbs are displayed' do
         when_i_choose_search_filter 'Search for a case by URN'
-        then_has_case_ref_breadcrumbs
+        then_has_case_ref_search_breadcrumbs
       end
     end
 
     context 'when on defendant reference search page' do
       scenario 'expected breadcrumbs are displayed' do
         when_i_choose_search_filter 'Search for a defendant by reference'
-        then_has_defendant_ref_breadcrumbs
+        then_has_defendant_ref_search_breadcrumbs
       end
     end
 
     context 'when on defendant name and dob search page' do
       scenario 'expected breadcrumbs are displayed' do
         when_i_choose_search_filter 'Search for a defendant by name and date of birth'
-        then_has_defendant_name_breadcrumbs
+        then_has_defendant_name_search_breadcrumbs
       end
     end
 
@@ -67,11 +67,11 @@ RSpec.feature 'Breadcrumb', type: :feature do
       expect(page).to have_current_path(prosecution_case_path('MOGUERBXIZ'))
       then_has_case_details_breadcrumbs
 
-      click_breadcrumb 'Case ref search'
+      click_breadcrumb 'Search'
       expect(page).to have_current_path(new_search_path(search: { filter: 'case_reference' }))
-      then_has_case_ref_breadcrumbs
+      then_has_case_ref_search_breadcrumbs
 
-      click_breadcrumb 'Search filters'
+      click_breadcrumb 'Home'
       expect(page).to have_current_path(new_search_filter_path)
       then_breadcrumbs_are_not_displayed
     end
@@ -105,34 +105,34 @@ RSpec.feature 'Breadcrumb', type: :feature do
     end
   end
 
-  def then_has_case_ref_breadcrumbs
-    expect(page).to have_govuk_breadcrumb_link('Search filters')
-    expect(page).not_to have_govuk_breadcrumb_link('Case ref search')
-    expect(page).to have_govuk_breadcrumb('Case ref search', aria_current: true)
+  def then_has_case_ref_search_breadcrumbs
+    expect(page).to have_govuk_breadcrumb_link('Home', href: '/search_filters/new')
+    expect(page).not_to have_govuk_breadcrumb_link('Search')
+    expect(page).to have_govuk_breadcrumb('Search', aria_current: true)
   end
 
-  def then_has_defendant_ref_breadcrumbs
-    expect(page).to have_govuk_breadcrumb_link('Search filters')
-    expect(page).not_to have_govuk_breadcrumb_link('Defendant ref search')
-    expect(page).to have_govuk_breadcrumb('Defendant ref search', aria_current: true)
+  def then_has_defendant_ref_search_breadcrumbs
+    expect(page).to have_govuk_breadcrumb_link('Home')
+    expect(page).not_to have_govuk_breadcrumb_link('Search')
+    expect(page).to have_govuk_breadcrumb('Search', aria_current: true)
   end
 
-  def then_has_defendant_name_breadcrumbs
-    expect(page).to have_govuk_breadcrumb_link('Search filters')
-    expect(page).not_to have_govuk_breadcrumb_link('Defendant name search')
-    expect(page).to have_govuk_breadcrumb('Defendant name search', aria_current: true)
+  def then_has_defendant_name_search_breadcrumbs
+    expect(page).to have_govuk_breadcrumb_link('Home')
+    expect(page).not_to have_govuk_breadcrumb_link('Search')
+    expect(page).to have_govuk_breadcrumb('Search', aria_current: true)
   end
 
   def then_has_case_details_breadcrumbs
-    expect(page).to have_govuk_breadcrumb_link('Search filters')
-    expect(page).to have_govuk_breadcrumb_link('Case ref search')
+    expect(page).to have_govuk_breadcrumb_link('Home')
+    expect(page).to have_govuk_breadcrumb_link('Search', href: '/searches/new?search[filter]=case_reference')
     expect(page).not_to have_govuk_breadcrumb_link('Case details')
     expect(page).to have_govuk_breadcrumb('Case details', aria_current: true)
   end
 
   def then_has_defendant_details_breadcrumbs(defendant_name)
-    expect(page).to have_govuk_breadcrumb_link('Search filters')
-    expect(page).to have_govuk_breadcrumb_link('Case ref search')
+    expect(page).to have_govuk_breadcrumb_link('Home')
+    expect(page).to have_govuk_breadcrumb_link('Search')
     expect(page).to have_govuk_breadcrumb_link('Case details')
     expect(page).not_to have_govuk_breadcrumb_link(defendant_name)
     expect(page).to have_govuk_breadcrumb(defendant_name, aria_current: true)

--- a/spec/features/breadcrumbs_spec.rb
+++ b/spec/features/breadcrumbs_spec.rb
@@ -55,17 +55,17 @@ RSpec.feature 'Breadcrumb', type: :feature do
       click_link('MOGUERBXIZ', match: :first)
       expect(page).to have_current_path(prosecution_case_path('MOGUERBXIZ'))
 
-      then_has_case_details_breadcrumbs
+      then_has_case_details_breadcrumbs('MOGUERBXIZ')
 
       click_link('Josefa Franecki')
       expect(page).to have_current_path(%r{\/defendants\/.+})
 
-      then_has_defendant_details_breadcrumbs('Josefa Franecki')
+      then_has_defendant_details_breadcrumbs('MOGUERBXIZ', 'Josefa Franecki')
 
-      click_breadcrumb 'Case details'
+      click_breadcrumb 'Case MOGUERBXIZ'
 
       expect(page).to have_current_path(prosecution_case_path('MOGUERBXIZ'))
-      then_has_case_details_breadcrumbs
+      then_has_case_details_breadcrumbs('MOGUERBXIZ')
 
       click_breadcrumb 'Search'
       expect(page).to have_current_path(new_search_path(search: { filter: 'case_reference' }))
@@ -123,17 +123,17 @@ RSpec.feature 'Breadcrumb', type: :feature do
     expect(page).to have_govuk_breadcrumb('Search', aria_current: true)
   end
 
-  def then_has_case_details_breadcrumbs
+  def then_has_case_details_breadcrumbs(case_ref)
     expect(page).to have_govuk_breadcrumb_link('Home')
     expect(page).to have_govuk_breadcrumb_link('Search', href: '/searches/new?search[filter]=case_reference')
-    expect(page).not_to have_govuk_breadcrumb_link('Case details')
-    expect(page).to have_govuk_breadcrumb('Case details', aria_current: true)
+    expect(page).not_to have_govuk_breadcrumb_link(/Case/)
+    expect(page).to have_govuk_breadcrumb("Case #{case_ref}", aria_current: true)
   end
 
-  def then_has_defendant_details_breadcrumbs(defendant_name)
+  def then_has_defendant_details_breadcrumbs(case_ref, defendant_name)
     expect(page).to have_govuk_breadcrumb_link('Home')
     expect(page).to have_govuk_breadcrumb_link('Search')
-    expect(page).to have_govuk_breadcrumb_link('Case details')
+    expect(page).to have_govuk_breadcrumb_link("Case #{case_ref}")
     expect(page).not_to have_govuk_breadcrumb_link(defendant_name)
     expect(page).to have_govuk_breadcrumb(defendant_name, aria_current: true)
   end

--- a/spec/features/breadcrumbs_spec.rb
+++ b/spec/features/breadcrumbs_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.ffeature 'Breadcrumb', type: :feature do
+RSpec.feature 'Breadcrumb', type: :feature do
   let(:user) { create(:user) }
 
   context 'when not signed in' do
@@ -68,7 +68,14 @@ RSpec.ffeature 'Breadcrumb', type: :feature do
       then_has_case_details_breadcrumbs('MOGUERBXIZ')
 
       click_breadcrumb 'Search'
-      expect(page).to have_current_path(searches_path(search: { filter: 'case_reference', term: 'MOGUERBXIZ' }))
+      expect(page).to have_current_path(
+        searches_path(
+          search: {
+            filter: 'case_reference',
+            term: 'MOGUERBXIZ'
+          }
+        )
+      )
       then_has_case_ref_search_breadcrumbs
 
       click_breadcrumb 'Home'
@@ -125,7 +132,10 @@ RSpec.ffeature 'Breadcrumb', type: :feature do
 
   def then_has_case_details_breadcrumbs(case_ref)
     expect(page).to have_govuk_breadcrumb_link('Home')
-    expect(page).to have_govuk_breadcrumb_link('Search', href: "/searches?search[filter]=case_reference&search[term]=#{case_ref}")
+    expect(page).to have_govuk_breadcrumb_link(
+      'Search',
+      href: %r{\/searches\?search.*#{case_ref}}
+    )
     expect(page).not_to have_govuk_breadcrumb_link(/Case/)
     expect(page).to have_govuk_breadcrumb("Case #{case_ref}", aria_current: true)
   end

--- a/spec/features/breadcrumbs_spec.rb
+++ b/spec/features/breadcrumbs_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.feature 'Breadcrumb', type: :feature do
+RSpec.ffeature 'Breadcrumb', type: :feature do
   let(:user) { create(:user) }
 
   context 'when not signed in' do
@@ -68,7 +68,7 @@ RSpec.feature 'Breadcrumb', type: :feature do
       then_has_case_details_breadcrumbs('MOGUERBXIZ')
 
       click_breadcrumb 'Search'
-      expect(page).to have_current_path(new_search_path(search: { filter: 'case_reference' }))
+      expect(page).to have_current_path(searches_path(search: { filter: 'case_reference', term: 'MOGUERBXIZ' }))
       then_has_case_ref_search_breadcrumbs
 
       click_breadcrumb 'Home'
@@ -125,7 +125,7 @@ RSpec.feature 'Breadcrumb', type: :feature do
 
   def then_has_case_details_breadcrumbs(case_ref)
     expect(page).to have_govuk_breadcrumb_link('Home')
-    expect(page).to have_govuk_breadcrumb_link('Search', href: '/searches/new?search[filter]=case_reference')
+    expect(page).to have_govuk_breadcrumb_link('Search', href: "/searches?search[filter]=case_reference&search[term]=#{case_ref}")
     expect(page).not_to have_govuk_breadcrumb_link(/Case/)
     expect(page).to have_govuk_breadcrumb("Case #{case_ref}", aria_current: true)
   end

--- a/spec/features/breadcrumbs_spec.rb
+++ b/spec/features/breadcrumbs_spec.rb
@@ -29,27 +29,27 @@ RSpec.feature 'Breadcrumb', type: :feature do
 
     context 'when on case reference search page' do
       scenario 'expected breadcrumbs are displayed' do
-        when_i_choose_search_filter 'Search for a case by URN'
+        when_i_choose_search_filter 'A case by URN'
         then_has_case_ref_search_breadcrumbs
       end
     end
 
     context 'when on defendant reference search page' do
       scenario 'expected breadcrumbs are displayed' do
-        when_i_choose_search_filter 'Search for a defendant by reference'
+        when_i_choose_search_filter 'A defendant by ASN or National insurance number'
         then_has_defendant_ref_search_breadcrumbs
       end
     end
 
     context 'when on defendant name and dob search page' do
       scenario 'expected breadcrumbs are displayed' do
-        when_i_choose_search_filter 'Search for a defendant by name and date of birth'
+        when_i_choose_search_filter 'A defendant by name and date of birth'
         then_has_defendant_name_search_breadcrumbs
       end
     end
 
     scenario 'user navigates search, prosecution case and defendant details pages', :vcr do
-      when_i_choose_search_filter 'Search for a case by URN'
+      when_i_choose_search_filter 'A case by URN'
       when_i_search_for 'MOGUERBXIZ'
 
       click_link('MOGUERBXIZ', match: :first)

--- a/spec/features/search/case_reference_spec.rb
+++ b/spec/features/search/case_reference_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature 'Case reference search', type: :feature, vcr: true, js: true do
   scenario 'with multiple defendants on case' do
     visit '/'
 
-    choose 'Search for a case by URN'
+    choose 'A case by URN'
     click_button 'Continue'
     fill_in 'search-term-field', with: 'MOGUERBXIZ'
     click_button 'Search'
@@ -26,7 +26,7 @@ RSpec.feature 'Case reference search', type: :feature, vcr: true, js: true do
   scenario 'with non existent case URN' do
     visit '/'
 
-    choose 'Search for a case by URN'
+    choose 'A case by URN'
     click_button 'Continue'
     fill_in 'search-term-field', with: 'non-existent-caseURN'
     click_button 'Search'
@@ -38,7 +38,7 @@ RSpec.feature 'Case reference search', type: :feature, vcr: true, js: true do
   scenario 'with no case reference provided' do
     visit '/'
 
-    choose 'Search for a case by URN'
+    choose 'A case by URN'
     click_button 'Continue'
     fill_in 'search-term-field', with: ''
     click_button 'Search'

--- a/spec/features/search/defendant_by_name_spec.rb
+++ b/spec/features/search/defendant_by_name_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature 'Defendant by name and dob search', type: :feature, js: true do
   scenario 'with one result', :vcr do
     visit '/'
 
-    choose 'Search for a defendant by name and date of birth'
+    choose 'A defendant by name and date of birth'
     click_button 'Continue'
     fill_in 'search-term-field', with: 'Josefa Franecki'
     fill_in 'search_dob_3i', with: '15'
@@ -36,7 +36,7 @@ RSpec.feature 'Defendant by name and dob search', type: :feature, js: true do
   scenario 'with no results', :vcr do
     visit '/'
 
-    choose 'Search for a defendant by name and date of birth'
+    choose 'A defendant by name and date of birth'
     click_button 'Continue'
     fill_in 'search-term-field', with: 'Fred Bloggs'
     fill_in 'search_dob_3i', with: '28'
@@ -52,7 +52,7 @@ RSpec.feature 'Defendant by name and dob search', type: :feature, js: true do
   scenario 'with no date of birth specified', :vcr do
     visit '/'
 
-    choose 'Search for a defendant by name and date of birth'
+    choose 'A defendant by name and date of birth'
     click_button 'Continue'
     fill_in 'search-term-field', with: 'Mickey Mouse'
     click_button 'Search'

--- a/spec/features/search/defendant_by_name_spec.rb
+++ b/spec/features/search/defendant_by_name_spec.rb
@@ -21,7 +21,7 @@ RSpec.feature 'Defendant by name and dob search', type: :feature, js: true do
     expect(page).to have_text(
       'Search results for "Josefa Franecki, 15 June 1961"'
     )
-    expect(page).to have_field('Find a defendant', with: 'Josefa Franecki')
+    expect(page).to have_field('Defendant name', with: 'Josefa Franecki')
     expect(page).to have_field('Day', with: '15')
     expect(page).to have_field('Month', with: '6')
     expect(page).to have_field('Year', with: '1961')

--- a/spec/features/search/defendant_by_name_spec.rb
+++ b/spec/features/search/defendant_by_name_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature 'Defendant by name and dob search', type: :feature, js: true do
     expect(page).to have_field('Year', with: '1961')
 
     within 'tbody.govuk-table__body' do
-      expect(page).to have_content('Josefa Franecki').once
+      expect(page).to have_content('Josefa Franecki', minimum: 1)
     end
 
     expect(page).to be_accessible.within '#main-content'

--- a/spec/features/search/defendant_by_reference_spec.rb
+++ b/spec/features/search/defendant_by_reference_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature 'Defendant by reference search', type: :feature, vcr: true, js: tr
       expect(page).to have_text(
         'Search results for "GP181930B"'
       )
-      expect(page).to have_field('Find a defendant', with: 'GP181930B')
+      expect(page).to have_field('Defendant ASN or National insurance number', with: 'GP181930B')
 
       within 'tbody.govuk-table__body' do
         expect(page).to have_content('GP181930B').once

--- a/spec/features/search/defendant_by_reference_spec.rb
+++ b/spec/features/search/defendant_by_reference_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature 'Defendant by reference search', type: :feature, vcr: true, js: tr
     scenario 'with one result' do
       visit '/'
 
-      choose 'Search for a defendant by reference'
+      choose 'A defendant by ASN or National insurance number'
       click_button 'Continue'
       fill_in 'search-term-field', with: 'GP181930B'
       click_button 'Search'
@@ -31,7 +31,7 @@ RSpec.feature 'Defendant by reference search', type: :feature, vcr: true, js: tr
     scenario 'with no results' do
       visit '/'
 
-      choose 'Search for a defendant by reference'
+      choose 'A defendant by ASN or National insurance number'
       click_button 'Continue'
       fill_in 'search-term-field', with: 'GP999999B'
       click_button 'Search'
@@ -44,7 +44,7 @@ RSpec.feature 'Defendant by reference search', type: :feature, vcr: true, js: tr
     scenario 'with no defendant reference specified' do
       visit '/'
 
-      choose 'Search for a defendant by reference'
+      choose 'A defendant by ASN or National insurance number'
       click_button 'Continue'
       fill_in 'search-term-field', with: ''
       click_button 'Search'

--- a/spec/features/search/filters_spec.rb
+++ b/spec/features/search/filters_spec.rb
@@ -21,12 +21,22 @@ RSpec.feature 'Search filters', type: :feature, js: true do
     expect(page).to be_accessible.within '#main-content'
   end
 
-  scenario 'user chooses defendant filter' do
+  scenario 'user chooses defendant ASN or NI filter' do
+    visit '/'
+
+    choose 'A defendant by ASN or National insurance number'
+    click_button 'Continue'
+    expect(page).to have_text('Defendant ASN or National insurance number')
+
+    expect(page).to be_accessible.within '#main-content'
+  end
+
+  scenario 'user chooses defendant name filter' do
     visit '/'
 
     choose 'A defendant by name and date of birth'
     click_button 'Continue'
-    expect(page).to have_text('Find a defendant')
+    expect(page).to have_text('Defendant name')
 
     expect(page).to be_accessible.within '#main-content'
   end
@@ -36,7 +46,7 @@ RSpec.feature 'Search filters', type: :feature, js: true do
 
     choose 'A case by URN'
     click_button 'Continue'
-    expect(page).to have_text('Find a case')
+    expect(page).to have_text('Unique reference number')
 
     expect(page).to be_accessible.within '#main-content'
   end

--- a/spec/features/search/filters_spec.rb
+++ b/spec/features/search/filters_spec.rb
@@ -10,13 +10,13 @@ RSpec.feature 'Search filters', type: :feature, js: true do
   scenario 'user visits search filter options' do
     visit '/'
 
-    expect(page).to have_text('How do you want to search?')
+    expect(page).to have_css('h1', text: 'Search for')
     expect(page).to have_css('.govuk-radios__item',
-                             text: 'Search for a case by URN')
+                             text: 'A case by URN')
     expect(page).to have_css('.govuk-radios__item',
-                             text: 'Search for a defendant by reference')
+                             text: 'A defendant by ASN or National insurance number')
     expect(page).to have_css('.govuk-radios__item',
-                             text: 'Search for a defendant by name and date of birth')
+                             text: 'A defendant by name and date of birth')
 
     expect(page).to be_accessible.within '#main-content'
   end
@@ -24,7 +24,7 @@ RSpec.feature 'Search filters', type: :feature, js: true do
   scenario 'user chooses defendant filter' do
     visit '/'
 
-    choose 'Search for a defendant by name and date of birth'
+    choose 'A defendant by name and date of birth'
     click_button 'Continue'
     expect(page).to have_text('Find a defendant')
 
@@ -34,7 +34,7 @@ RSpec.feature 'Search filters', type: :feature, js: true do
   scenario 'user chooses case number filter' do
     visit '/'
 
-    choose 'Search for a case by URN'
+    choose 'A case by URN'
     click_button 'Continue'
     expect(page).to have_text('Find a case')
 

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -32,11 +32,11 @@ RSpec.feature 'Sign in', type: :feature, js: true do
     end
 
     it 'search filters page is displayed' do
-      expect(page).to have_govuk_page_title(text: 'Search filters')
+      expect(page).to have_selector('h1', text: 'Search for')
     end
 
     it 'navigation bar is displayed' do
-      expect(page).to have_css('nav ul.govuk-header__navigation')
+      expect(page).to have_selector('nav ul.govuk-header__navigation')
     end
 
     describe 'navigation bar' do

--- a/spec/features/unlinked_defendant_flow_spec.rb
+++ b/spec/features/unlinked_defendant_flow_spec.rb
@@ -30,6 +30,7 @@ RSpec.feature 'Unlinked defendant page flow', type: :feature, vcr: true do
     then_defendant_view_displayed_for('Josefa Franecki')
     then_has_defendant_details
     then_has_offence_details
+    then_has_laa_reference_forms
   end
 
   def when_viewing_case(case_urn)
@@ -91,5 +92,10 @@ RSpec.feature 'Unlinked defendant page flow', type: :feature, vcr: true do
       expect(page).to have_css('.govuk-table__header', text: 'Plea')
       expect(page).to have_css('.govuk-table__header', text: 'Mode of trial')
     end
+  end
+
+  def then_has_laa_reference_forms
+    expect(page).to have_field('MAAT ID')
+    expect(page).to have_button('Create link to court data')
   end
 end

--- a/spec/features/unlinked_defendant_flow_spec.rb
+++ b/spec/features/unlinked_defendant_flow_spec.rb
@@ -64,6 +64,7 @@ RSpec.feature 'Unlinked defendant page flow', type: :feature, vcr: true do
         cells = row.all('.govuk-table__cell')
         expect(cells[0]).to have_link(nil, href: %r{\/defendants\/.*})
         expect(cells[1].text).to match(%r{[0-3][0-9]\/[0-1][0-9]\/[1-2][0|9](?:[0-9]{2})?})
+        expect(cells[2].text).to eql 'Not linked'
       end
     end
   end

--- a/spec/fixtures/vcr_cassettes/spec/features/breadcrumbs_spec.yml
+++ b/spec/fixtures/vcr_cassettes/spec/features/breadcrumbs_spec.yml
@@ -14,7 +14,7 @@ http_interactions:
       Accept:
       - application/vnd.api+json
       Authorization:
-      - Bearer vb2--pPRlGnS4Y7y8Q_Q6COQQqFIP9_e8Kl7mgGHZFA
+      - Bearer <BEARER_TOKEN>
       Accept-Encoding:
       - gzip,deflate
   response:
@@ -37,20 +37,20 @@ http_interactions:
       Content-Type:
       - application/vnd.api+json; charset=utf-8
       Etag:
-      - W/"8a12fdc9fe22451b2b47b6b480cca375"
+      - W/"42834ebed17802c1ddc37cb0bf83c105"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 10647323-7d3c-4584-83ca-83afac5a779d
+      - 35375210-0182-4aea-b1f5-c1a355a1b3fe
       X-Runtime:
-      - '0.085648'
-      Transfer-Encoding:
-      - chunked
+      - '0.105915'
+      Content-Length:
+      - '1878'
     body:
       encoding: UTF-8
-      string: '{"data":[{"id":"2dc8dd46-d930-4878-a0a6-68ae8642cd9e","type":"prosecution_cases","attributes":{"prosecution_case_reference":"MOGUERBXIZ"},"relationships":{"defendants":{"data":[{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants"},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants"},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants"},{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants"}]}}}],"included":[{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants","attributes":{"first_name":"Andy","last_name":"Sawayn","date_of_birth":"1987-10-19","national_insurance_number":"EA382617F","arrest_summons_number":"KX5SWEFJQ3DL"},"relationships":{"offences":{"data":[{"id":"5aff5a05-8f43-40e0-82e6-08c658ffca00","type":"offences"}]}}},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants","attributes":{"first_name":"Aracely","last_name":"Zulauf","date_of_birth":"1955-09-27","national_insurance_number":"HH481835D","arrest_summons_number":"F79K0TDDZK40"},"relationships":{"offences":{"data":[{"id":"0fcb44b6-1ca7-4360-b6ed-1d57ff9423e0","type":"offences"}]}}},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants","attributes":{"first_name":"Florene","last_name":"DuBuque","date_of_birth":"1983-10-17","national_insurance_number":"XE675428D","arrest_summons_number":"C2ZXXPBNGVR0"},"relationships":{"offences":{"data":[{"id":"45d5e934-72d0-4a14-b43c-cad750d4ff3c","type":"offences"}]}}},{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants","attributes":{"first_name":"Josefa","last_name":"Franecki","date_of_birth":"1961-06-15","national_insurance_number":"HR669639D","arrest_summons_number":"Y1NDQNW9NCN6"},"relationships":{"offences":{"data":[{"id":"6de5bcf7-c3bd-47cd-9c74-a79d06aaf3dc","type":"offences"}]}}}]}'
+      string: '{"data":[{"id":"2dc8dd46-d930-4878-a0a6-68ae8642cd9e","type":"prosecution_cases","attributes":{"prosecution_case_reference":"MOGUERBXIZ"},"relationships":{"defendants":{"data":[{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants"},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants"},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants"},{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants"}]}}}],"included":[{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants","attributes":{"first_name":"Josefa","last_name":"Franecki","date_of_birth":"1961-06-15","national_insurance_number":"HR669639D","arrest_summons_number":"Y1NDQNW9NCN6","is_linked":false},"relationships":{"offences":{"data":[{"id":"6de5bcf7-c3bd-47cd-9c74-a79d06aaf3dc","type":"offences"}]}}},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants","attributes":{"first_name":"Florene","last_name":"DuBuque","date_of_birth":"1983-10-17","national_insurance_number":"XE675428D","arrest_summons_number":"C2ZXXPBNGVR0","is_linked":false},"relationships":{"offences":{"data":[{"id":"45d5e934-72d0-4a14-b43c-cad750d4ff3c","type":"offences"}]}}},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants","attributes":{"first_name":"Aracely","last_name":"Zulauf","date_of_birth":"1955-09-27","national_insurance_number":"HH481835D","arrest_summons_number":"F79K0TDDZK40","is_linked":false},"relationships":{"offences":{"data":[{"id":"0fcb44b6-1ca7-4360-b6ed-1d57ff9423e0","type":"offences"}]}}},{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants","attributes":{"first_name":"Andy","last_name":"Sawayn","date_of_birth":"1987-10-19","national_insurance_number":"EA382617F","arrest_summons_number":"KX5SWEFJQ3DL","is_linked":false},"relationships":{"offences":{"data":[{"id":"5aff5a05-8f43-40e0-82e6-08c658ffca00","type":"offences"}]}}}]}'
     http_version: null
-  recorded_at: Fri, 13 Mar 2020 16:59:34 GMT
+  recorded_at: Thu, 26 Mar 2020 14:56:44 GMT
 - request:
     method: get
     uri: http://localhost:9292/api/internal/v1/prosecution_cases?filter%5Bprosecution_case_reference%5D=MOGUERBXIZ&include=defendants
@@ -65,7 +65,7 @@ http_interactions:
       Accept:
       - application/vnd.api+json
       Authorization:
-      - Bearer vb2--pPRlGnS4Y7y8Q_Q6COQQqFIP9_e8Kl7mgGHZFA
+      - Bearer <BEARER_TOKEN>
       Accept-Encoding:
       - gzip,deflate
   response:
@@ -88,20 +88,20 @@ http_interactions:
       Content-Type:
       - application/vnd.api+json; charset=utf-8
       Etag:
-      - W/"8a12fdc9fe22451b2b47b6b480cca375"
+      - W/"42834ebed17802c1ddc37cb0bf83c105"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 20599b2f-c9cc-4453-8ce4-cc38213f91b9
+      - 72290273-a195-407b-ba8c-7677022f827c
       X-Runtime:
-      - '0.070315'
-      Transfer-Encoding:
-      - chunked
+      - '0.078600'
+      Content-Length:
+      - '1878'
     body:
       encoding: UTF-8
-      string: '{"data":[{"id":"2dc8dd46-d930-4878-a0a6-68ae8642cd9e","type":"prosecution_cases","attributes":{"prosecution_case_reference":"MOGUERBXIZ"},"relationships":{"defendants":{"data":[{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants"},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants"},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants"},{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants"}]}}}],"included":[{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants","attributes":{"first_name":"Andy","last_name":"Sawayn","date_of_birth":"1987-10-19","national_insurance_number":"EA382617F","arrest_summons_number":"KX5SWEFJQ3DL"},"relationships":{"offences":{"data":[{"id":"5aff5a05-8f43-40e0-82e6-08c658ffca00","type":"offences"}]}}},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants","attributes":{"first_name":"Aracely","last_name":"Zulauf","date_of_birth":"1955-09-27","national_insurance_number":"HH481835D","arrest_summons_number":"F79K0TDDZK40"},"relationships":{"offences":{"data":[{"id":"0fcb44b6-1ca7-4360-b6ed-1d57ff9423e0","type":"offences"}]}}},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants","attributes":{"first_name":"Florene","last_name":"DuBuque","date_of_birth":"1983-10-17","national_insurance_number":"XE675428D","arrest_summons_number":"C2ZXXPBNGVR0"},"relationships":{"offences":{"data":[{"id":"45d5e934-72d0-4a14-b43c-cad750d4ff3c","type":"offences"}]}}},{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants","attributes":{"first_name":"Josefa","last_name":"Franecki","date_of_birth":"1961-06-15","national_insurance_number":"HR669639D","arrest_summons_number":"Y1NDQNW9NCN6"},"relationships":{"offences":{"data":[{"id":"6de5bcf7-c3bd-47cd-9c74-a79d06aaf3dc","type":"offences"}]}}}]}'
+      string: '{"data":[{"id":"2dc8dd46-d930-4878-a0a6-68ae8642cd9e","type":"prosecution_cases","attributes":{"prosecution_case_reference":"MOGUERBXIZ"},"relationships":{"defendants":{"data":[{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants"},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants"},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants"},{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants"}]}}}],"included":[{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants","attributes":{"first_name":"Josefa","last_name":"Franecki","date_of_birth":"1961-06-15","national_insurance_number":"HR669639D","arrest_summons_number":"Y1NDQNW9NCN6","is_linked":false},"relationships":{"offences":{"data":[{"id":"6de5bcf7-c3bd-47cd-9c74-a79d06aaf3dc","type":"offences"}]}}},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants","attributes":{"first_name":"Florene","last_name":"DuBuque","date_of_birth":"1983-10-17","national_insurance_number":"XE675428D","arrest_summons_number":"C2ZXXPBNGVR0","is_linked":false},"relationships":{"offences":{"data":[{"id":"45d5e934-72d0-4a14-b43c-cad750d4ff3c","type":"offences"}]}}},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants","attributes":{"first_name":"Aracely","last_name":"Zulauf","date_of_birth":"1955-09-27","national_insurance_number":"HH481835D","arrest_summons_number":"F79K0TDDZK40","is_linked":false},"relationships":{"offences":{"data":[{"id":"0fcb44b6-1ca7-4360-b6ed-1d57ff9423e0","type":"offences"}]}}},{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants","attributes":{"first_name":"Andy","last_name":"Sawayn","date_of_birth":"1987-10-19","national_insurance_number":"EA382617F","arrest_summons_number":"KX5SWEFJQ3DL","is_linked":false},"relationships":{"offences":{"data":[{"id":"5aff5a05-8f43-40e0-82e6-08c658ffca00","type":"offences"}]}}}]}'
     http_version: null
-  recorded_at: Fri, 13 Mar 2020 16:59:34 GMT
+  recorded_at: Thu, 26 Mar 2020 14:56:44 GMT
 - request:
     method: get
     uri: http://localhost:9292/api/internal/v1/prosecution_cases?filter%5Barrest_summons_number%5D=Y1NDQNW9NCN6&include=defendants,defendants.offences
@@ -116,7 +116,7 @@ http_interactions:
       Accept:
       - application/vnd.api+json
       Authorization:
-      - Bearer vb2--pPRlGnS4Y7y8Q_Q6COQQqFIP9_e8Kl7mgGHZFA
+      - Bearer <BEARER_TOKEN>
       Accept-Encoding:
       - gzip,deflate
   response:
@@ -139,24 +139,29 @@ http_interactions:
       Content-Type:
       - application/vnd.api+json; charset=utf-8
       Etag:
-      - W/"4e7e850b3adba4da111599773e308540"
+      - W/"c9ef7a8a709f7efd8c24352301cec458"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - f7d4b817-2e5c-45ca-9a47-254ef809e1f2
+      - 033d1ab3-dbbe-4157-bb94-e9ca7228e981
       X-Runtime:
-      - '0.075805'
-      Transfer-Encoding:
-      - chunked
+      - '0.148687'
+      Content-Length:
+      - '5719'
     body:
       encoding: UTF-8
-      string: '{"data":[{"id":"2dc8dd46-d930-4878-a0a6-68ae8642cd9e","type":"prosecution_cases","attributes":{"prosecution_case_reference":"MOGUERBXIZ"},"relationships":{"defendants":{"data":[{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants"},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants"},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants"},{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants"}]}}}],"included":[{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants","attributes":{"first_name":"Andy","last_name":"Sawayn","date_of_birth":"1987-10-19","national_insurance_number":"EA382617F","arrest_summons_number":"KX5SWEFJQ3DL"},"relationships":{"offences":{"data":[{"id":"5aff5a05-8f43-40e0-82e6-08c658ffca00","type":"offences"}]}}},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants","attributes":{"first_name":"Aracely","last_name":"Zulauf","date_of_birth":"1955-09-27","national_insurance_number":"HH481835D","arrest_summons_number":"F79K0TDDZK40"},"relationships":{"offences":{"data":[{"id":"0fcb44b6-1ca7-4360-b6ed-1d57ff9423e0","type":"offences"}]}}},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants","attributes":{"first_name":"Florene","last_name":"DuBuque","date_of_birth":"1983-10-17","national_insurance_number":"XE675428D","arrest_summons_number":"C2ZXXPBNGVR0"},"relationships":{"offences":{"data":[{"id":"45d5e934-72d0-4a14-b43c-cad750d4ff3c","type":"offences"}]}}},{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants","attributes":{"first_name":"Josefa","last_name":"Franecki","date_of_birth":"1961-06-15","national_insurance_number":"HR669639D","arrest_summons_number":"Y1NDQNW9NCN6"},"relationships":{"offences":{"data":[{"id":"6de5bcf7-c3bd-47cd-9c74-a79d06aaf3dc","type":"offences"}]}}},{"id":"5aff5a05-8f43-40e0-82e6-08c658ffca00","type":"offences","attributes":{"code":"Random
-        string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"0fcb44b6-1ca7-4360-b6ed-1d57ff9423e0","type":"offences","attributes":{"code":"Random
+      string: '{"data":[{"id":"2dc8dd46-d930-4878-a0a6-68ae8642cd9e","type":"prosecution_cases","attributes":{"prosecution_case_reference":"MOGUERBXIZ"},"relationships":{"defendants":{"data":[{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants"},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants"},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants"},{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants"}]}}},{"id":"45181ba4-0230-4d76-bd1f-8dd283cc2504","type":"prosecution_cases","attributes":{"prosecution_case_reference":"LJSQNTUNNC"},"relationships":{"defendants":{"data":[{"id":"9ad9161f-776d-4139-bd0a-e4d5c0650305","type":"defendants"},{"id":"a21d8531-5eaf-42df-8dc5-348bbd071f07","type":"defendants"},{"id":"e6d2dd73-b95b-4f98-a1ac-795c181791fe","type":"defendants"},{"id":"1ed04150-0dd8-45a0-80cf-29f0dcf104b5","type":"defendants"},{"id":"2f7fd30b-3bff-4493-bc0f-254e2bd71734","type":"defendants"}]}}}],"included":[{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants","attributes":{"first_name":"Josefa","last_name":"Franecki","date_of_birth":"1961-06-15","national_insurance_number":"HR669639D","arrest_summons_number":"Y1NDQNW9NCN6","is_linked":false},"relationships":{"offences":{"data":[{"id":"6de5bcf7-c3bd-47cd-9c74-a79d06aaf3dc","type":"offences"}]}}},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants","attributes":{"first_name":"Florene","last_name":"DuBuque","date_of_birth":"1983-10-17","national_insurance_number":"XE675428D","arrest_summons_number":"C2ZXXPBNGVR0","is_linked":false},"relationships":{"offences":{"data":[{"id":"45d5e934-72d0-4a14-b43c-cad750d4ff3c","type":"offences"}]}}},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants","attributes":{"first_name":"Aracely","last_name":"Zulauf","date_of_birth":"1955-09-27","national_insurance_number":"HH481835D","arrest_summons_number":"F79K0TDDZK40","is_linked":false},"relationships":{"offences":{"data":[{"id":"0fcb44b6-1ca7-4360-b6ed-1d57ff9423e0","type":"offences"}]}}},{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants","attributes":{"first_name":"Andy","last_name":"Sawayn","date_of_birth":"1987-10-19","national_insurance_number":"EA382617F","arrest_summons_number":"KX5SWEFJQ3DL","is_linked":false},"relationships":{"offences":{"data":[{"id":"5aff5a05-8f43-40e0-82e6-08c658ffca00","type":"offences"}]}}},{"id":"6de5bcf7-c3bd-47cd-9c74-a79d06aaf3dc","type":"offences","attributes":{"code":"Random
         string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"45d5e934-72d0-4a14-b43c-cad750d4ff3c","type":"offences","attributes":{"code":"Random
-        string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"6de5bcf7-c3bd-47cd-9c74-a79d06aaf3dc","type":"offences","attributes":{"code":"Random
+        string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"0fcb44b6-1ca7-4360-b6ed-1d57ff9423e0","type":"offences","attributes":{"code":"Random
+        string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"5aff5a05-8f43-40e0-82e6-08c658ffca00","type":"offences","attributes":{"code":"Random
+        string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"9ad9161f-776d-4139-bd0a-e4d5c0650305","type":"defendants","attributes":{"first_name":"Josefa","last_name":"Franecki","date_of_birth":"1961-06-15","national_insurance_number":"HR669639D","arrest_summons_number":"Y1NDQNW9NCN6","is_linked":false},"relationships":{"offences":{"data":[{"id":"28689c87-c6da-4fdf-9b69-ac763fd7fc7a","type":"offences"}]}}},{"id":"a21d8531-5eaf-42df-8dc5-348bbd071f07","type":"defendants","attributes":{"first_name":"Quincy","last_name":"O''Kon","date_of_birth":"1993-09-02","national_insurance_number":"GP181930B","arrest_summons_number":"GFNBCQEY8RBP","is_linked":false},"relationships":{"offences":{"data":[{"id":"d250b0f1-c89c-4715-889e-46045e164753","type":"offences"}]}}},{"id":"e6d2dd73-b95b-4f98-a1ac-795c181791fe","type":"defendants","attributes":{"first_name":"Jolynn","last_name":"Schinner","date_of_birth":"1991-03-01","national_insurance_number":"YE744478B","arrest_summons_number":"A5W1R4OGUX7C","is_linked":false},"relationships":{"offences":{"data":[{"id":"c7726d30-dda1-4b19-8f62-f06529197da3","type":"offences"}]}}},{"id":"1ed04150-0dd8-45a0-80cf-29f0dcf104b5","type":"defendants","attributes":{"first_name":"Russell","last_name":"Waters","date_of_birth":"1986-12-14","national_insurance_number":"GP592510D","arrest_summons_number":"JRUG82AGN111","is_linked":false},"relationships":{"offences":{"data":[{"id":"15d01c69-e9ee-4243-8398-376b64cff0cb","type":"offences"}]}}},{"id":"2f7fd30b-3bff-4493-bc0f-254e2bd71734","type":"defendants","attributes":{"first_name":"Marion","last_name":"Swift","date_of_birth":"1999-12-30","national_insurance_number":"GX188228C","arrest_summons_number":"N80TNY2CGZGV","is_linked":false},"relationships":{"offences":{"data":[{"id":"f651b45d-5968-4d6b-b615-6f74c1050ca9","type":"offences"}]}}},{"id":"28689c87-c6da-4fdf-9b69-ac763fd7fc7a","type":"offences","attributes":{"code":"Random
+        string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"d250b0f1-c89c-4715-889e-46045e164753","type":"offences","attributes":{"code":"Random
+        string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"c7726d30-dda1-4b19-8f62-f06529197da3","type":"offences","attributes":{"code":"Random
+        string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"15d01c69-e9ee-4243-8398-376b64cff0cb","type":"offences","attributes":{"code":"Random
+        string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"f651b45d-5968-4d6b-b615-6f74c1050ca9","type":"offences","attributes":{"code":"Random
         string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}}]}'
     http_version: null
-  recorded_at: Fri, 13 Mar 2020 16:59:34 GMT
+  recorded_at: Thu, 26 Mar 2020 14:56:44 GMT
 - request:
     method: get
     uri: http://localhost:9292/api/internal/v1/prosecution_cases?filter%5Bprosecution_case_reference%5D=MOGUERBXIZ&include=defendants
@@ -171,7 +176,7 @@ http_interactions:
       Accept:
       - application/vnd.api+json
       Authorization:
-      - Bearer _RAVHZJZpMcJd1c1miC7i6nOdLQhskWiJnccxxZY_CI
+      - Bearer <BEARER_TOKEN>
       Accept-Encoding:
       - gzip,deflate
   response:
@@ -194,69 +199,69 @@ http_interactions:
       Content-Type:
       - application/vnd.api+json; charset=utf-8
       Etag:
-      - W/"6f63d14d3c99469f169456298e96ba3d"
+      - W/"42834ebed17802c1ddc37cb0bf83c105"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 1507c85e-bf94-4cf9-9b71-81d4bdb6abcf
+      - 6008146c-75d1-4183-960d-bfdcd7aca2bf
       X-Runtime:
-      - '0.108245'
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: '{"data":[{"id":"2dc8dd46-d930-4878-a0a6-68ae8642cd9e","type":"prosecution_cases","attributes":{"prosecution_case_reference":"MOGUERBXIZ"},"relationships":{"defendants":{"data":[{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants"},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants"},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants"},{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants"}]}}}],"included":[{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants","attributes":{"first_name":"Josefa","last_name":"Franecki","date_of_birth":"1961-06-15","national_insurance_number":"HR669639D","arrest_summons_number":"Y1NDQNW9NCN6"},"relationships":{"offences":{"data":[{"id":"6de5bcf7-c3bd-47cd-9c74-a79d06aaf3dc","type":"offences"}]}}},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants","attributes":{"first_name":"Florene","last_name":"DuBuque","date_of_birth":"1983-10-17","national_insurance_number":"XE675428D","arrest_summons_number":"C2ZXXPBNGVR0"},"relationships":{"offences":{"data":[{"id":"45d5e934-72d0-4a14-b43c-cad750d4ff3c","type":"offences"}]}}},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants","attributes":{"first_name":"Aracely","last_name":"Zulauf","date_of_birth":"1955-09-27","national_insurance_number":"HH481835D","arrest_summons_number":"F79K0TDDZK40"},"relationships":{"offences":{"data":[{"id":"0fcb44b6-1ca7-4360-b6ed-1d57ff9423e0","type":"offences"}]}}},{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants","attributes":{"first_name":"Andy","last_name":"Sawayn","date_of_birth":"1987-10-19","national_insurance_number":"EA382617F","arrest_summons_number":"KX5SWEFJQ3DL"},"relationships":{"offences":{"data":[{"id":"5aff5a05-8f43-40e0-82e6-08c658ffca00","type":"offences"}]}}}]}'
-    http_version: null
-  recorded_at: Fri, 13 Mar 2020 17:08:35 GMT
-- request:
-    method: get
-    uri: http://localhost:9292/api/internal/v1/prosecution_cases?filter%5Bprosecution_case_reference%5D=MOGUERBXIZ&include=defendants
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v0.17.3
-      Content-Type:
-      - application/vnd.api+json
-      Accept:
-      - application/vnd.api+json
-      Authorization:
-      - Bearer wXmu2gFJnWvJn6eIgDc-6WJChw68wJPxQz7ZVfaQD84
-      Accept-Encoding:
-      - gzip,deflate
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      Referrer-Policy:
-      - strict-origin-when-cross-origin
-      Content-Type:
-      - application/vnd.api+json; charset=utf-8
-      Etag:
-      - W/"8a12fdc9fe22451b2b47b6b480cca375"
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 1f3e9a6a-824b-4f73-b165-2c1731ced1fd
-      X-Runtime:
-      - '0.088557'
+      - '0.091202'
       Content-Length:
-      - '1806'
+      - '1878'
     body:
       encoding: UTF-8
-      string: '{"data":[{"id":"2dc8dd46-d930-4878-a0a6-68ae8642cd9e","type":"prosecution_cases","attributes":{"prosecution_case_reference":"MOGUERBXIZ"},"relationships":{"defendants":{"data":[{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants"},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants"},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants"},{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants"}]}}}],"included":[{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants","attributes":{"first_name":"Andy","last_name":"Sawayn","date_of_birth":"1987-10-19","national_insurance_number":"EA382617F","arrest_summons_number":"KX5SWEFJQ3DL"},"relationships":{"offences":{"data":[{"id":"5aff5a05-8f43-40e0-82e6-08c658ffca00","type":"offences"}]}}},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants","attributes":{"first_name":"Aracely","last_name":"Zulauf","date_of_birth":"1955-09-27","national_insurance_number":"HH481835D","arrest_summons_number":"F79K0TDDZK40"},"relationships":{"offences":{"data":[{"id":"0fcb44b6-1ca7-4360-b6ed-1d57ff9423e0","type":"offences"}]}}},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants","attributes":{"first_name":"Florene","last_name":"DuBuque","date_of_birth":"1983-10-17","national_insurance_number":"XE675428D","arrest_summons_number":"C2ZXXPBNGVR0"},"relationships":{"offences":{"data":[{"id":"45d5e934-72d0-4a14-b43c-cad750d4ff3c","type":"offences"}]}}},{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants","attributes":{"first_name":"Josefa","last_name":"Franecki","date_of_birth":"1961-06-15","national_insurance_number":"HR669639D","arrest_summons_number":"Y1NDQNW9NCN6"},"relationships":{"offences":{"data":[{"id":"6de5bcf7-c3bd-47cd-9c74-a79d06aaf3dc","type":"offences"}]}}}]}'
+      string: '{"data":[{"id":"2dc8dd46-d930-4878-a0a6-68ae8642cd9e","type":"prosecution_cases","attributes":{"prosecution_case_reference":"MOGUERBXIZ"},"relationships":{"defendants":{"data":[{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants"},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants"},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants"},{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants"}]}}}],"included":[{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants","attributes":{"first_name":"Josefa","last_name":"Franecki","date_of_birth":"1961-06-15","national_insurance_number":"HR669639D","arrest_summons_number":"Y1NDQNW9NCN6","is_linked":false},"relationships":{"offences":{"data":[{"id":"6de5bcf7-c3bd-47cd-9c74-a79d06aaf3dc","type":"offences"}]}}},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants","attributes":{"first_name":"Florene","last_name":"DuBuque","date_of_birth":"1983-10-17","national_insurance_number":"XE675428D","arrest_summons_number":"C2ZXXPBNGVR0","is_linked":false},"relationships":{"offences":{"data":[{"id":"45d5e934-72d0-4a14-b43c-cad750d4ff3c","type":"offences"}]}}},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants","attributes":{"first_name":"Aracely","last_name":"Zulauf","date_of_birth":"1955-09-27","national_insurance_number":"HH481835D","arrest_summons_number":"F79K0TDDZK40","is_linked":false},"relationships":{"offences":{"data":[{"id":"0fcb44b6-1ca7-4360-b6ed-1d57ff9423e0","type":"offences"}]}}},{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants","attributes":{"first_name":"Andy","last_name":"Sawayn","date_of_birth":"1987-10-19","national_insurance_number":"EA382617F","arrest_summons_number":"KX5SWEFJQ3DL","is_linked":false},"relationships":{"offences":{"data":[{"id":"5aff5a05-8f43-40e0-82e6-08c658ffca00","type":"offences"}]}}}]}'
     http_version: null
-  recorded_at: Tue, 24 Mar 2020 13:28:12 GMT
+  recorded_at: Thu, 26 Mar 2020 14:56:45 GMT
+- request:
+    method: get
+    uri: http://localhost:9292/api/internal/v1/prosecution_cases?filter%5Bprosecution_case_reference%5D=MOGUERBXIZ&include=defendants
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Content-Type:
+      - application/vnd.api+json
+      Accept:
+      - application/vnd.api+json
+      Authorization:
+      - Bearer <BEARER_TOKEN>
+      Accept-Encoding:
+      - gzip,deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Type:
+      - application/vnd.api+json; charset=utf-8
+      Etag:
+      - W/"7497a3636a45f300c84f93f31487f802"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - aa54d323-c896-444e-a77e-8bcba2d2b43f
+      X-Runtime:
+      - '0.081714'
+      Content-Length:
+      - '1878'
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"id":"2dc8dd46-d930-4878-a0a6-68ae8642cd9e","type":"prosecution_cases","attributes":{"prosecution_case_reference":"MOGUERBXIZ"},"relationships":{"defendants":{"data":[{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants"},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants"},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants"},{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants"}]}}}],"included":[{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants","attributes":{"first_name":"Andy","last_name":"Sawayn","date_of_birth":"1987-10-19","national_insurance_number":"EA382617F","arrest_summons_number":"KX5SWEFJQ3DL","is_linked":false},"relationships":{"offences":{"data":[{"id":"5aff5a05-8f43-40e0-82e6-08c658ffca00","type":"offences"}]}}},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants","attributes":{"first_name":"Aracely","last_name":"Zulauf","date_of_birth":"1955-09-27","national_insurance_number":"HH481835D","arrest_summons_number":"F79K0TDDZK40","is_linked":false},"relationships":{"offences":{"data":[{"id":"0fcb44b6-1ca7-4360-b6ed-1d57ff9423e0","type":"offences"}]}}},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants","attributes":{"first_name":"Florene","last_name":"DuBuque","date_of_birth":"1983-10-17","national_insurance_number":"XE675428D","arrest_summons_number":"C2ZXXPBNGVR0","is_linked":false},"relationships":{"offences":{"data":[{"id":"45d5e934-72d0-4a14-b43c-cad750d4ff3c","type":"offences"}]}}},{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants","attributes":{"first_name":"Josefa","last_name":"Franecki","date_of_birth":"1961-06-15","national_insurance_number":"HR669639D","arrest_summons_number":"Y1NDQNW9NCN6","is_linked":false},"relationships":{"offences":{"data":[{"id":"6de5bcf7-c3bd-47cd-9c74-a79d06aaf3dc","type":"offences"}]}}}]}'
+    http_version: null
+  recorded_at: Thu, 26 Mar 2020 14:56:45 GMT
 recorded_with: VCR 5.1.0

--- a/spec/fixtures/vcr_cassettes/spec/features/breadcrumbs_spec.yml
+++ b/spec/fixtures/vcr_cassettes/spec/features/breadcrumbs_spec.yml
@@ -208,4 +208,55 @@ http_interactions:
       string: '{"data":[{"id":"2dc8dd46-d930-4878-a0a6-68ae8642cd9e","type":"prosecution_cases","attributes":{"prosecution_case_reference":"MOGUERBXIZ"},"relationships":{"defendants":{"data":[{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants"},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants"},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants"},{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants"}]}}}],"included":[{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants","attributes":{"first_name":"Josefa","last_name":"Franecki","date_of_birth":"1961-06-15","national_insurance_number":"HR669639D","arrest_summons_number":"Y1NDQNW9NCN6"},"relationships":{"offences":{"data":[{"id":"6de5bcf7-c3bd-47cd-9c74-a79d06aaf3dc","type":"offences"}]}}},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants","attributes":{"first_name":"Florene","last_name":"DuBuque","date_of_birth":"1983-10-17","national_insurance_number":"XE675428D","arrest_summons_number":"C2ZXXPBNGVR0"},"relationships":{"offences":{"data":[{"id":"45d5e934-72d0-4a14-b43c-cad750d4ff3c","type":"offences"}]}}},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants","attributes":{"first_name":"Aracely","last_name":"Zulauf","date_of_birth":"1955-09-27","national_insurance_number":"HH481835D","arrest_summons_number":"F79K0TDDZK40"},"relationships":{"offences":{"data":[{"id":"0fcb44b6-1ca7-4360-b6ed-1d57ff9423e0","type":"offences"}]}}},{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants","attributes":{"first_name":"Andy","last_name":"Sawayn","date_of_birth":"1987-10-19","national_insurance_number":"EA382617F","arrest_summons_number":"KX5SWEFJQ3DL"},"relationships":{"offences":{"data":[{"id":"5aff5a05-8f43-40e0-82e6-08c658ffca00","type":"offences"}]}}}]}'
     http_version: null
   recorded_at: Fri, 13 Mar 2020 17:08:35 GMT
+- request:
+    method: get
+    uri: http://localhost:9292/api/internal/v1/prosecution_cases?filter%5Bprosecution_case_reference%5D=MOGUERBXIZ&include=defendants
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Content-Type:
+      - application/vnd.api+json
+      Accept:
+      - application/vnd.api+json
+      Authorization:
+      - Bearer wXmu2gFJnWvJn6eIgDc-6WJChw68wJPxQz7ZVfaQD84
+      Accept-Encoding:
+      - gzip,deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Type:
+      - application/vnd.api+json; charset=utf-8
+      Etag:
+      - W/"8a12fdc9fe22451b2b47b6b480cca375"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 1f3e9a6a-824b-4f73-b165-2c1731ced1fd
+      X-Runtime:
+      - '0.088557'
+      Content-Length:
+      - '1806'
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"id":"2dc8dd46-d930-4878-a0a6-68ae8642cd9e","type":"prosecution_cases","attributes":{"prosecution_case_reference":"MOGUERBXIZ"},"relationships":{"defendants":{"data":[{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants"},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants"},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants"},{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants"}]}}}],"included":[{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants","attributes":{"first_name":"Andy","last_name":"Sawayn","date_of_birth":"1987-10-19","national_insurance_number":"EA382617F","arrest_summons_number":"KX5SWEFJQ3DL"},"relationships":{"offences":{"data":[{"id":"5aff5a05-8f43-40e0-82e6-08c658ffca00","type":"offences"}]}}},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants","attributes":{"first_name":"Aracely","last_name":"Zulauf","date_of_birth":"1955-09-27","national_insurance_number":"HH481835D","arrest_summons_number":"F79K0TDDZK40"},"relationships":{"offences":{"data":[{"id":"0fcb44b6-1ca7-4360-b6ed-1d57ff9423e0","type":"offences"}]}}},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants","attributes":{"first_name":"Florene","last_name":"DuBuque","date_of_birth":"1983-10-17","national_insurance_number":"XE675428D","arrest_summons_number":"C2ZXXPBNGVR0"},"relationships":{"offences":{"data":[{"id":"45d5e934-72d0-4a14-b43c-cad750d4ff3c","type":"offences"}]}}},{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants","attributes":{"first_name":"Josefa","last_name":"Franecki","date_of_birth":"1961-06-15","national_insurance_number":"HR669639D","arrest_summons_number":"Y1NDQNW9NCN6"},"relationships":{"offences":{"data":[{"id":"6de5bcf7-c3bd-47cd-9c74-a79d06aaf3dc","type":"offences"}]}}}]}'
+    http_version: null
+  recorded_at: Tue, 24 Mar 2020 13:28:12 GMT
 recorded_with: VCR 5.1.0

--- a/spec/fixtures/vcr_cassettes/spec/features/search/case_reference_spec.yml
+++ b/spec/fixtures/vcr_cassettes/spec/features/search/case_reference_spec.yml
@@ -14,7 +14,7 @@ http_interactions:
       Accept:
       - application/vnd.api+json
       Authorization:
-      - Bearer daiZwixV6yDuzpBuU_Eci_V5ph13IVl7i-t_PmHRmBc
+      - Bearer <BEARER_TOKEN>
       Accept-Encoding:
       - gzip,deflate
   response:
@@ -37,71 +37,20 @@ http_interactions:
       Content-Type:
       - application/vnd.api+json; charset=utf-8
       Etag:
-      - W/"6f63d14d3c99469f169456298e96ba3d"
+      - W/"7497a3636a45f300c84f93f31487f802"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 3d685636-de1c-4da0-a300-cbb2beeb57bf
+      - 13a5516a-6927-4563-ab6c-8e293f912dfa
       X-Runtime:
-      - '0.830241'
-      Transfer-Encoding:
-      - chunked
+      - '0.084496'
+      Content-Length:
+      - '1878'
     body:
       encoding: UTF-8
-      string: '{"data":[{"id":"2dc8dd46-d930-4878-a0a6-68ae8642cd9e","type":"prosecution_cases","attributes":{"prosecution_case_reference":"MOGUERBXIZ"},"relationships":{"defendants":{"data":[{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants"},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants"},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants"},{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants"}]}}}],"included":[{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants","attributes":{"first_name":"Josefa","last_name":"Franecki","date_of_birth":"1961-06-15","national_insurance_number":"HR669639D","arrest_summons_number":"Y1NDQNW9NCN6"},"relationships":{"offences":{"data":[{"id":"6de5bcf7-c3bd-47cd-9c74-a79d06aaf3dc","type":"offences"}]}}},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants","attributes":{"first_name":"Florene","last_name":"DuBuque","date_of_birth":"1983-10-17","national_insurance_number":"XE675428D","arrest_summons_number":"C2ZXXPBNGVR0"},"relationships":{"offences":{"data":[{"id":"45d5e934-72d0-4a14-b43c-cad750d4ff3c","type":"offences"}]}}},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants","attributes":{"first_name":"Aracely","last_name":"Zulauf","date_of_birth":"1955-09-27","national_insurance_number":"HH481835D","arrest_summons_number":"F79K0TDDZK40"},"relationships":{"offences":{"data":[{"id":"0fcb44b6-1ca7-4360-b6ed-1d57ff9423e0","type":"offences"}]}}},{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants","attributes":{"first_name":"Andy","last_name":"Sawayn","date_of_birth":"1987-10-19","national_insurance_number":"EA382617F","arrest_summons_number":"KX5SWEFJQ3DL"},"relationships":{"offences":{"data":[{"id":"5aff5a05-8f43-40e0-82e6-08c658ffca00","type":"offences"}]}}}]}'
+      string: '{"data":[{"id":"2dc8dd46-d930-4878-a0a6-68ae8642cd9e","type":"prosecution_cases","attributes":{"prosecution_case_reference":"MOGUERBXIZ"},"relationships":{"defendants":{"data":[{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants"},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants"},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants"},{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants"}]}}}],"included":[{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants","attributes":{"first_name":"Andy","last_name":"Sawayn","date_of_birth":"1987-10-19","national_insurance_number":"EA382617F","arrest_summons_number":"KX5SWEFJQ3DL","is_linked":false},"relationships":{"offences":{"data":[{"id":"5aff5a05-8f43-40e0-82e6-08c658ffca00","type":"offences"}]}}},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants","attributes":{"first_name":"Aracely","last_name":"Zulauf","date_of_birth":"1955-09-27","national_insurance_number":"HH481835D","arrest_summons_number":"F79K0TDDZK40","is_linked":false},"relationships":{"offences":{"data":[{"id":"0fcb44b6-1ca7-4360-b6ed-1d57ff9423e0","type":"offences"}]}}},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants","attributes":{"first_name":"Florene","last_name":"DuBuque","date_of_birth":"1983-10-17","national_insurance_number":"XE675428D","arrest_summons_number":"C2ZXXPBNGVR0","is_linked":false},"relationships":{"offences":{"data":[{"id":"45d5e934-72d0-4a14-b43c-cad750d4ff3c","type":"offences"}]}}},{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants","attributes":{"first_name":"Josefa","last_name":"Franecki","date_of_birth":"1961-06-15","national_insurance_number":"HR669639D","arrest_summons_number":"Y1NDQNW9NCN6","is_linked":false},"relationships":{"offences":{"data":[{"id":"6de5bcf7-c3bd-47cd-9c74-a79d06aaf3dc","type":"offences"}]}}}]}'
     http_version: null
-  recorded_at: Tue, 10 Mar 2020 17:41:14 GMT
-- request:
-    method: get
-    uri: http://localhost:9292/api/internal/v1/prosecution_cases?filter%5Bprosecution_case_reference%5D=non-existent-caseURN&include=defendants
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v0.17.3
-      Content-Type:
-      - application/vnd.api+json
-      Accept:
-      - application/vnd.api+json
-      Authorization:
-      - Bearer daiZwixV6yDuzpBuU_Eci_V5ph13IVl7i-t_PmHRmBc
-      Accept-Encoding:
-      - gzip,deflate
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      Referrer-Policy:
-      - strict-origin-when-cross-origin
-      Content-Type:
-      - application/vnd.api+json; charset=utf-8
-      Etag:
-      - W/"ba5f3ea40e95f49bce11942f375ebd38"
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - e0c6decb-27b4-4995-b2cc-e9813f548653
-      X-Runtime:
-      - '0.207464'
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: '{"data":null}'
-    http_version: null
-  recorded_at: Tue, 10 Mar 2020 17:41:15 GMT
+  recorded_at: Thu, 26 Mar 2020 14:56:50 GMT
 - request:
     method: get
     uri: http://localhost:9292/api/internal/v1/prosecution_cases?filter%5Bprosecution_case_reference%5D=NONEXISTENTCASEURN&include=defendants
@@ -116,7 +65,7 @@ http_interactions:
       Accept:
       - application/vnd.api+json
       Authorization:
-      - Bearer PDwcSII2YJz_01puZ-vPX7gYsytOOYKSREG-6R0Xo0c
+      - Bearer <BEARER_TOKEN>
       Accept-Encoding:
       - gzip,deflate
   response:
@@ -143,14 +92,14 @@ http_interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - ddcbe71c-e56f-476b-9f49-04a3910f6f8e
+      - 07745023-19cf-488c-aec8-7d38fe44ee42
       X-Runtime:
-      - '0.096573'
+      - '0.052807'
       Content-Length:
       - '13'
     body:
       encoding: UTF-8
       string: '{"data":null}'
     http_version: null
-  recorded_at: Tue, 17 Mar 2020 11:21:34 GMT
+  recorded_at: Thu, 26 Mar 2020 14:56:52 GMT
 recorded_with: VCR 5.1.0

--- a/spec/fixtures/vcr_cassettes/spec/features/search/defendant_by_name_spec.yml
+++ b/spec/fixtures/vcr_cassettes/spec/features/search/defendant_by_name_spec.yml
@@ -14,7 +14,7 @@ http_interactions:
       Accept:
       - application/vnd.api+json
       Authorization:
-      - Bearer vfVUr7Ul8zpCdRzp_6DG6KhJqjU69ut1VoKkzf42284
+      - Bearer <BEARER_TOKEN>
       Accept-Encoding:
       - gzip,deflate
   response:
@@ -37,20 +37,20 @@ http_interactions:
       Content-Type:
       - application/vnd.api+json; charset=utf-8
       Etag:
-      - W/"20d4caa56eb85af31b2ccd5901fcd779"
+      - W/"aaa825417c06a05d5b625f1a83a3c925"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - b1eda570-cf91-49d0-99ad-6a25e2eb7384
+      - caffe32f-5bfa-470c-98df-c59917e00d93
       X-Runtime:
-      - '0.092066'
-      Transfer-Encoding:
-      - chunked
+      - '0.149980'
+      Content-Length:
+      - '4153'
     body:
       encoding: UTF-8
-      string: '{"data":[{"id":"2dc8dd46-d930-4878-a0a6-68ae8642cd9e","type":"prosecution_cases","attributes":{"prosecution_case_reference":"MOGUERBXIZ"},"relationships":{"defendants":{"data":[{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants"},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants"},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants"},{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants"}]}}}],"included":[{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants","attributes":{"first_name":"Josefa","last_name":"Franecki","date_of_birth":"1961-06-15","national_insurance_number":"HR669639M","arrest_summons_number":"Y1NDQNW9NCN6"},"relationships":{"offences":{"data":[{"id":"6de5bcf7-c3bd-47cd-9c74-a79d06aaf3dc","type":"offences"}]}}},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants","attributes":{"first_name":"Florene","last_name":"DuBuque","date_of_birth":"1983-10-17","national_insurance_number":"XE675428D","arrest_summons_number":"C2ZXXPBNGVR0"},"relationships":{"offences":{"data":[{"id":"45d5e934-72d0-4a14-b43c-cad750d4ff3c","type":"offences"}]}}},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants","attributes":{"first_name":"Aracely","last_name":"Zulauf","date_of_birth":"1955-09-27","national_insurance_number":"HH481835D","arrest_summons_number":"F79K0TDDZK40"},"relationships":{"offences":{"data":[{"id":"0fcb44b6-1ca7-4360-b6ed-1d57ff9423e0","type":"offences"}]}}},{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants","attributes":{"first_name":"Andy","last_name":"Sawayn","date_of_birth":"1987-10-19","national_insurance_number":"EA382617F","arrest_summons_number":"KX5SWEFJQ3DL"},"relationships":{"offences":{"data":[{"id":"5aff5a05-8f43-40e0-82e6-08c658ffca00","type":"offences"}]}}}]}'
+      string: '{"data":[{"id":"2dc8dd46-d930-4878-a0a6-68ae8642cd9e","type":"prosecution_cases","attributes":{"prosecution_case_reference":"MOGUERBXIZ"},"relationships":{"defendants":{"data":[{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants"},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants"},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants"},{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants"}]}}},{"id":"45181ba4-0230-4d76-bd1f-8dd283cc2504","type":"prosecution_cases","attributes":{"prosecution_case_reference":"LJSQNTUNNC"},"relationships":{"defendants":{"data":[{"id":"2f7fd30b-3bff-4493-bc0f-254e2bd71734","type":"defendants"},{"id":"1ed04150-0dd8-45a0-80cf-29f0dcf104b5","type":"defendants"},{"id":"e6d2dd73-b95b-4f98-a1ac-795c181791fe","type":"defendants"},{"id":"a21d8531-5eaf-42df-8dc5-348bbd071f07","type":"defendants"},{"id":"9ad9161f-776d-4139-bd0a-e4d5c0650305","type":"defendants"}]}}}],"included":[{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants","attributes":{"first_name":"Andy","last_name":"Sawayn","date_of_birth":"1987-10-19","national_insurance_number":"EA382617F","arrest_summons_number":"KX5SWEFJQ3DL","is_linked":false},"relationships":{"offences":{"data":[{"id":"5aff5a05-8f43-40e0-82e6-08c658ffca00","type":"offences"}]}}},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants","attributes":{"first_name":"Aracely","last_name":"Zulauf","date_of_birth":"1955-09-27","national_insurance_number":"HH481835D","arrest_summons_number":"F79K0TDDZK40","is_linked":false},"relationships":{"offences":{"data":[{"id":"0fcb44b6-1ca7-4360-b6ed-1d57ff9423e0","type":"offences"}]}}},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants","attributes":{"first_name":"Florene","last_name":"DuBuque","date_of_birth":"1983-10-17","national_insurance_number":"XE675428D","arrest_summons_number":"C2ZXXPBNGVR0","is_linked":false},"relationships":{"offences":{"data":[{"id":"45d5e934-72d0-4a14-b43c-cad750d4ff3c","type":"offences"}]}}},{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants","attributes":{"first_name":"Josefa","last_name":"Franecki","date_of_birth":"1961-06-15","national_insurance_number":"HR669639D","arrest_summons_number":"Y1NDQNW9NCN6","is_linked":false},"relationships":{"offences":{"data":[{"id":"6de5bcf7-c3bd-47cd-9c74-a79d06aaf3dc","type":"offences"}]}}},{"id":"2f7fd30b-3bff-4493-bc0f-254e2bd71734","type":"defendants","attributes":{"first_name":"Marion","last_name":"Swift","date_of_birth":"1999-12-30","national_insurance_number":"GX188228C","arrest_summons_number":"N80TNY2CGZGV","is_linked":false},"relationships":{"offences":{"data":[{"id":"f651b45d-5968-4d6b-b615-6f74c1050ca9","type":"offences"}]}}},{"id":"1ed04150-0dd8-45a0-80cf-29f0dcf104b5","type":"defendants","attributes":{"first_name":"Russell","last_name":"Waters","date_of_birth":"1986-12-14","national_insurance_number":"GP592510D","arrest_summons_number":"JRUG82AGN111","is_linked":false},"relationships":{"offences":{"data":[{"id":"15d01c69-e9ee-4243-8398-376b64cff0cb","type":"offences"}]}}},{"id":"e6d2dd73-b95b-4f98-a1ac-795c181791fe","type":"defendants","attributes":{"first_name":"Jolynn","last_name":"Schinner","date_of_birth":"1991-03-01","national_insurance_number":"YE744478B","arrest_summons_number":"A5W1R4OGUX7C","is_linked":false},"relationships":{"offences":{"data":[{"id":"c7726d30-dda1-4b19-8f62-f06529197da3","type":"offences"}]}}},{"id":"a21d8531-5eaf-42df-8dc5-348bbd071f07","type":"defendants","attributes":{"first_name":"Quincy","last_name":"O''Kon","date_of_birth":"1993-09-02","national_insurance_number":"GP181930B","arrest_summons_number":"GFNBCQEY8RBP","is_linked":false},"relationships":{"offences":{"data":[{"id":"d250b0f1-c89c-4715-889e-46045e164753","type":"offences"}]}}},{"id":"9ad9161f-776d-4139-bd0a-e4d5c0650305","type":"defendants","attributes":{"first_name":"Josefa","last_name":"Franecki","date_of_birth":"1961-06-15","national_insurance_number":"HR669639D","arrest_summons_number":"Y1NDQNW9NCN6","is_linked":false},"relationships":{"offences":{"data":[{"id":"28689c87-c6da-4fdf-9b69-ac763fd7fc7a","type":"offences"}]}}}]}'
     http_version: null
-  recorded_at: Mon, 09 Mar 2020 11:54:55 GMT
+  recorded_at: Thu, 26 Mar 2020 14:56:57 GMT
 - request:
     method: get
     uri: http://localhost:9292/api/internal/v1/prosecution_cases?filter%5Bdate_of_birth%5D=1928-11-28&filter%5Bfirst_name%5D=Fred&filter%5Blast_name%5D=Bloggs&include=defendants
@@ -65,7 +65,7 @@ http_interactions:
       Accept:
       - application/vnd.api+json
       Authorization:
-      - Bearer vfVUr7Ul8zpCdRzp_6DG6KhJqjU69ut1VoKkzf42284
+      - Bearer <BEARER_TOKEN>
       Accept-Encoding:
       - gzip,deflate
   response:
@@ -92,14 +92,14 @@ http_interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - c1c74c77-8824-4fb0-9b34-4f5dd947544a
+      - 83e7f866-daf4-4300-8457-1c32bf489582
       X-Runtime:
-      - '0.036724'
-      Transfer-Encoding:
-      - chunked
+      - '0.051569'
+      Content-Length:
+      - '13'
     body:
       encoding: UTF-8
       string: '{"data":null}'
     http_version: null
-  recorded_at: Mon, 09 Mar 2020 11:54:55 GMT
+  recorded_at: Thu, 26 Mar 2020 14:56:59 GMT
 recorded_with: VCR 5.1.0

--- a/spec/fixtures/vcr_cassettes/spec/features/search/defendant_by_reference_spec.yml
+++ b/spec/fixtures/vcr_cassettes/spec/features/search/defendant_by_reference_spec.yml
@@ -14,7 +14,7 @@ http_interactions:
       Accept:
       - application/vnd.api+json
       Authorization:
-      - Bearer M7zYuvcFnAzfc9OP1oZAuM2z2AAv8LqUmDVrvbBOcwU
+      - Bearer <BEARER_TOKEN>
       Accept-Encoding:
       - gzip,deflate
   response:
@@ -37,24 +37,25 @@ http_interactions:
       Content-Type:
       - application/vnd.api+json; charset=utf-8
       Etag:
-      - W/"6016f43e07dcbd2f4f5aa8a4c974f38d"
+      - W/"65bb9d9f1853b6a4ecb2d3786a645e99"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - be7f7a1c-8f0c-4fb7-abc3-449231bcce5a
+      - a5ffffd9-2f92-4aa5-a187-51869b2b711d
       X-Runtime:
-      - '0.110026'
-      Transfer-Encoding:
-      - chunked
+      - '0.097022'
+      Content-Length:
+      - '3168'
     body:
       encoding: UTF-8
-      string: '{"data":[{"id":"45181ba4-0230-4d76-bd1f-8dd283cc2504","type":"prosecution_cases","attributes":{"prosecution_case_reference":"LJSQNTUNNC"},"relationships":{"defendants":{"data":[{"id":"a21d8531-5eaf-42df-8dc5-348bbd071f07","type":"defendants"},{"id":"e6d2dd73-b95b-4f98-a1ac-795c181791fe","type":"defendants"},{"id":"1ed04150-0dd8-45a0-80cf-29f0dcf104b5","type":"defendants"},{"id":"2f7fd30b-3bff-4493-bc0f-254e2bd71734","type":"defendants"}]}}}],"included":[{"id":"a21d8531-5eaf-42df-8dc5-348bbd071f07","type":"defendants","attributes":{"first_name":"Quincy","last_name":"O''Kon","date_of_birth":"1993-09-02","national_insurance_number":"GP181930B","arrest_summons_number":"GFNBCQEY8RBP"},"relationships":{"offences":{"data":[{"id":"d250b0f1-c89c-4715-889e-46045e164753","type":"offences"}]}}},{"id":"e6d2dd73-b95b-4f98-a1ac-795c181791fe","type":"defendants","attributes":{"first_name":"Jolynn","last_name":"Schinner","date_of_birth":"1991-03-01","national_insurance_number":"YE744478B","arrest_summons_number":"A5W1R4OGUX7C"},"relationships":{"offences":{"data":[{"id":"c7726d30-dda1-4b19-8f62-f06529197da3","type":"offences"}]}}},{"id":"1ed04150-0dd8-45a0-80cf-29f0dcf104b5","type":"defendants","attributes":{"first_name":"Russell","last_name":"Waters","date_of_birth":"1986-12-14","national_insurance_number":"GP592510D","arrest_summons_number":"JRUG82AGN111"},"relationships":{"offences":{"data":[{"id":"15d01c69-e9ee-4243-8398-376b64cff0cb","type":"offences"}]}}},{"id":"2f7fd30b-3bff-4493-bc0f-254e2bd71734","type":"defendants","attributes":{"first_name":"Marion","last_name":"Swift","date_of_birth":"1999-12-30","national_insurance_number":"GX188228C","arrest_summons_number":"N80TNY2CGZGV"},"relationships":{"offences":{"data":[{"id":"f651b45d-5968-4d6b-b615-6f74c1050ca9","type":"offences"}]}}},{"id":"d250b0f1-c89c-4715-889e-46045e164753","type":"offences","attributes":{"code":"Random
-        string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"c7726d30-dda1-4b19-8f62-f06529197da3","type":"offences","attributes":{"code":"Random
+      string: '{"data":[{"id":"45181ba4-0230-4d76-bd1f-8dd283cc2504","type":"prosecution_cases","attributes":{"prosecution_case_reference":"LJSQNTUNNC"},"relationships":{"defendants":{"data":[{"id":"2f7fd30b-3bff-4493-bc0f-254e2bd71734","type":"defendants"},{"id":"1ed04150-0dd8-45a0-80cf-29f0dcf104b5","type":"defendants"},{"id":"e6d2dd73-b95b-4f98-a1ac-795c181791fe","type":"defendants"},{"id":"a21d8531-5eaf-42df-8dc5-348bbd071f07","type":"defendants"},{"id":"9ad9161f-776d-4139-bd0a-e4d5c0650305","type":"defendants"}]}}}],"included":[{"id":"2f7fd30b-3bff-4493-bc0f-254e2bd71734","type":"defendants","attributes":{"first_name":"Marion","last_name":"Swift","date_of_birth":"1999-12-30","national_insurance_number":"GX188228C","arrest_summons_number":"N80TNY2CGZGV","is_linked":false},"relationships":{"offences":{"data":[{"id":"f651b45d-5968-4d6b-b615-6f74c1050ca9","type":"offences"}]}}},{"id":"1ed04150-0dd8-45a0-80cf-29f0dcf104b5","type":"defendants","attributes":{"first_name":"Russell","last_name":"Waters","date_of_birth":"1986-12-14","national_insurance_number":"GP592510D","arrest_summons_number":"JRUG82AGN111","is_linked":false},"relationships":{"offences":{"data":[{"id":"15d01c69-e9ee-4243-8398-376b64cff0cb","type":"offences"}]}}},{"id":"e6d2dd73-b95b-4f98-a1ac-795c181791fe","type":"defendants","attributes":{"first_name":"Jolynn","last_name":"Schinner","date_of_birth":"1991-03-01","national_insurance_number":"YE744478B","arrest_summons_number":"A5W1R4OGUX7C","is_linked":false},"relationships":{"offences":{"data":[{"id":"c7726d30-dda1-4b19-8f62-f06529197da3","type":"offences"}]}}},{"id":"a21d8531-5eaf-42df-8dc5-348bbd071f07","type":"defendants","attributes":{"first_name":"Quincy","last_name":"O''Kon","date_of_birth":"1993-09-02","national_insurance_number":"GP181930B","arrest_summons_number":"GFNBCQEY8RBP","is_linked":false},"relationships":{"offences":{"data":[{"id":"d250b0f1-c89c-4715-889e-46045e164753","type":"offences"}]}}},{"id":"9ad9161f-776d-4139-bd0a-e4d5c0650305","type":"defendants","attributes":{"first_name":"Josefa","last_name":"Franecki","date_of_birth":"1961-06-15","national_insurance_number":"HR669639D","arrest_summons_number":"Y1NDQNW9NCN6","is_linked":false},"relationships":{"offences":{"data":[{"id":"28689c87-c6da-4fdf-9b69-ac763fd7fc7a","type":"offences"}]}}},{"id":"f651b45d-5968-4d6b-b615-6f74c1050ca9","type":"offences","attributes":{"code":"Random
         string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"15d01c69-e9ee-4243-8398-376b64cff0cb","type":"offences","attributes":{"code":"Random
-        string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"f651b45d-5968-4d6b-b615-6f74c1050ca9","type":"offences","attributes":{"code":"Random
+        string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"c7726d30-dda1-4b19-8f62-f06529197da3","type":"offences","attributes":{"code":"Random
+        string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"d250b0f1-c89c-4715-889e-46045e164753","type":"offences","attributes":{"code":"Random
+        string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"28689c87-c6da-4fdf-9b69-ac763fd7fc7a","type":"offences","attributes":{"code":"Random
         string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}}]}'
     http_version: null
-  recorded_at: Thu, 12 Mar 2020 09:58:34 GMT
+  recorded_at: Thu, 26 Mar 2020 14:57:03 GMT
 - request:
     method: get
     uri: http://localhost:9292/api/internal/v1/prosecution_cases?filter%5Bnational_insurance_number%5D=GP999999B&include=defendants,defendants.offences
@@ -69,7 +70,7 @@ http_interactions:
       Accept:
       - application/vnd.api+json
       Authorization:
-      - Bearer M7zYuvcFnAzfc9OP1oZAuM2z2AAv8LqUmDVrvbBOcwU
+      - Bearer <BEARER_TOKEN>
       Accept-Encoding:
       - gzip,deflate
   response:
@@ -96,14 +97,14 @@ http_interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - a77bb87d-79c2-4692-8c83-7362a2499e97
+      - 3952275f-f1d3-438e-a603-94652f349fcb
       X-Runtime:
-      - '0.048485'
-      Transfer-Encoding:
-      - chunked
+      - '0.035789'
+      Content-Length:
+      - '13'
     body:
       encoding: UTF-8
       string: '{"data":null}'
     http_version: null
-  recorded_at: Thu, 12 Mar 2020 09:58:35 GMT
+  recorded_at: Thu, 26 Mar 2020 14:57:05 GMT
 recorded_with: VCR 5.1.0

--- a/spec/fixtures/vcr_cassettes/spec/features/unlinked_defendant_flow_spec.yml
+++ b/spec/fixtures/vcr_cassettes/spec/features/unlinked_defendant_flow_spec.yml
@@ -14,7 +14,7 @@ http_interactions:
       Accept:
       - application/vnd.api+json
       Authorization:
-      - Bearer ZCd4DQST_G-ppahrzHOTCUTmquascUB-AuIbik72gIE
+      - Bearer <BEARER_TOKEN>
       Accept-Encoding:
       - gzip,deflate
   response:
@@ -37,20 +37,20 @@ http_interactions:
       Content-Type:
       - application/vnd.api+json; charset=utf-8
       Etag:
-      - W/"8a12fdc9fe22451b2b47b6b480cca375"
+      - W/"7497a3636a45f300c84f93f31487f802"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 4996e492-0276-455e-aebf-fb82513e160f
+      - 1420878e-b4a3-457b-9581-bafc86f44635
       X-Runtime:
-      - '0.071679'
-      Transfer-Encoding:
-      - chunked
+      - '0.091601'
+      Content-Length:
+      - '1878'
     body:
       encoding: UTF-8
-      string: '{"data":[{"id":"2dc8dd46-d930-4878-a0a6-68ae8642cd9e","type":"prosecution_cases","attributes":{"prosecution_case_reference":"MOGUERBXIZ"},"relationships":{"defendants":{"data":[{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants"},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants"},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants"},{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants"}]}}}],"included":[{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants","attributes":{"first_name":"Andy","last_name":"Sawayn","date_of_birth":"1987-10-19","national_insurance_number":"EA382617F","arrest_summons_number":"KX5SWEFJQ3DL"},"relationships":{"offences":{"data":[{"id":"5aff5a05-8f43-40e0-82e6-08c658ffca00","type":"offences"}]}}},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants","attributes":{"first_name":"Aracely","last_name":"Zulauf","date_of_birth":"1955-09-27","national_insurance_number":"HH481835D","arrest_summons_number":"F79K0TDDZK40"},"relationships":{"offences":{"data":[{"id":"0fcb44b6-1ca7-4360-b6ed-1d57ff9423e0","type":"offences"}]}}},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants","attributes":{"first_name":"Florene","last_name":"DuBuque","date_of_birth":"1983-10-17","national_insurance_number":"XE675428D","arrest_summons_number":"C2ZXXPBNGVR0"},"relationships":{"offences":{"data":[{"id":"45d5e934-72d0-4a14-b43c-cad750d4ff3c","type":"offences"}]}}},{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants","attributes":{"first_name":"Josefa","last_name":"Franecki","date_of_birth":"1961-06-15","national_insurance_number":"HR669639D","arrest_summons_number":"Y1NDQNW9NCN6"},"relationships":{"offences":{"data":[{"id":"6de5bcf7-c3bd-47cd-9c74-a79d06aaf3dc","type":"offences"}]}}}]}'
+      string: '{"data":[{"id":"2dc8dd46-d930-4878-a0a6-68ae8642cd9e","type":"prosecution_cases","attributes":{"prosecution_case_reference":"MOGUERBXIZ"},"relationships":{"defendants":{"data":[{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants"},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants"},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants"},{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants"}]}}}],"included":[{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants","attributes":{"first_name":"Andy","last_name":"Sawayn","date_of_birth":"1987-10-19","national_insurance_number":"EA382617F","arrest_summons_number":"KX5SWEFJQ3DL","is_linked":false},"relationships":{"offences":{"data":[{"id":"5aff5a05-8f43-40e0-82e6-08c658ffca00","type":"offences"}]}}},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants","attributes":{"first_name":"Aracely","last_name":"Zulauf","date_of_birth":"1955-09-27","national_insurance_number":"HH481835D","arrest_summons_number":"F79K0TDDZK40","is_linked":false},"relationships":{"offences":{"data":[{"id":"0fcb44b6-1ca7-4360-b6ed-1d57ff9423e0","type":"offences"}]}}},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants","attributes":{"first_name":"Florene","last_name":"DuBuque","date_of_birth":"1983-10-17","national_insurance_number":"XE675428D","arrest_summons_number":"C2ZXXPBNGVR0","is_linked":false},"relationships":{"offences":{"data":[{"id":"45d5e934-72d0-4a14-b43c-cad750d4ff3c","type":"offences"}]}}},{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants","attributes":{"first_name":"Josefa","last_name":"Franecki","date_of_birth":"1961-06-15","national_insurance_number":"HR669639D","arrest_summons_number":"Y1NDQNW9NCN6","is_linked":false},"relationships":{"offences":{"data":[{"id":"6de5bcf7-c3bd-47cd-9c74-a79d06aaf3dc","type":"offences"}]}}}]}'
     http_version: null
-  recorded_at: Thu, 12 Mar 2020 14:31:09 GMT
+  recorded_at: Thu, 26 Mar 2020 14:57:21 GMT
 - request:
     method: get
     uri: http://localhost:9292/api/internal/v1/prosecution_cases?filter%5Barrest_summons_number%5D=Y1NDQNW9NCN6&include=defendants,defendants.offences
@@ -65,7 +65,7 @@ http_interactions:
       Accept:
       - application/vnd.api+json
       Authorization:
-      - Bearer ZCd4DQST_G-ppahrzHOTCUTmquascUB-AuIbik72gIE
+      - Bearer <BEARER_TOKEN>
       Accept-Encoding:
       - gzip,deflate
   response:
@@ -88,24 +88,29 @@ http_interactions:
       Content-Type:
       - application/vnd.api+json; charset=utf-8
       Etag:
-      - W/"4e7e850b3adba4da111599773e308540"
+      - W/"42fc0961f3c0970a0aff2edb0cf75876"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 04ada6c5-c4d5-4cae-9369-2a02346e0a23
+      - f0ad8618-9f43-46bd-b89e-e46117164de4
       X-Runtime:
-      - '0.086739'
-      Transfer-Encoding:
-      - chunked
+      - '0.128448'
+      Content-Length:
+      - '5719'
     body:
       encoding: UTF-8
-      string: '{"data":[{"id":"2dc8dd46-d930-4878-a0a6-68ae8642cd9e","type":"prosecution_cases","attributes":{"prosecution_case_reference":"MOGUERBXIZ"},"relationships":{"defendants":{"data":[{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants"},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants"},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants"},{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants"}]}}}],"included":[{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants","attributes":{"first_name":"Andy","last_name":"Sawayn","date_of_birth":"1987-10-19","national_insurance_number":"EA382617F","arrest_summons_number":"KX5SWEFJQ3DL"},"relationships":{"offences":{"data":[{"id":"5aff5a05-8f43-40e0-82e6-08c658ffca00","type":"offences"}]}}},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants","attributes":{"first_name":"Aracely","last_name":"Zulauf","date_of_birth":"1955-09-27","national_insurance_number":"HH481835D","arrest_summons_number":"F79K0TDDZK40"},"relationships":{"offences":{"data":[{"id":"0fcb44b6-1ca7-4360-b6ed-1d57ff9423e0","type":"offences"}]}}},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants","attributes":{"first_name":"Florene","last_name":"DuBuque","date_of_birth":"1983-10-17","national_insurance_number":"XE675428D","arrest_summons_number":"C2ZXXPBNGVR0"},"relationships":{"offences":{"data":[{"id":"45d5e934-72d0-4a14-b43c-cad750d4ff3c","type":"offences"}]}}},{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants","attributes":{"first_name":"Josefa","last_name":"Franecki","date_of_birth":"1961-06-15","national_insurance_number":"HR669639D","arrest_summons_number":"Y1NDQNW9NCN6"},"relationships":{"offences":{"data":[{"id":"6de5bcf7-c3bd-47cd-9c74-a79d06aaf3dc","type":"offences"}]}}},{"id":"5aff5a05-8f43-40e0-82e6-08c658ffca00","type":"offences","attributes":{"code":"Random
+      string: '{"data":[{"id":"2dc8dd46-d930-4878-a0a6-68ae8642cd9e","type":"prosecution_cases","attributes":{"prosecution_case_reference":"MOGUERBXIZ"},"relationships":{"defendants":{"data":[{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants"},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants"},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants"},{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants"}]}}},{"id":"45181ba4-0230-4d76-bd1f-8dd283cc2504","type":"prosecution_cases","attributes":{"prosecution_case_reference":"LJSQNTUNNC"},"relationships":{"defendants":{"data":[{"id":"2f7fd30b-3bff-4493-bc0f-254e2bd71734","type":"defendants"},{"id":"1ed04150-0dd8-45a0-80cf-29f0dcf104b5","type":"defendants"},{"id":"e6d2dd73-b95b-4f98-a1ac-795c181791fe","type":"defendants"},{"id":"a21d8531-5eaf-42df-8dc5-348bbd071f07","type":"defendants"},{"id":"9ad9161f-776d-4139-bd0a-e4d5c0650305","type":"defendants"}]}}}],"included":[{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants","attributes":{"first_name":"Andy","last_name":"Sawayn","date_of_birth":"1987-10-19","national_insurance_number":"EA382617F","arrest_summons_number":"KX5SWEFJQ3DL","is_linked":false},"relationships":{"offences":{"data":[{"id":"5aff5a05-8f43-40e0-82e6-08c658ffca00","type":"offences"}]}}},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants","attributes":{"first_name":"Aracely","last_name":"Zulauf","date_of_birth":"1955-09-27","national_insurance_number":"HH481835D","arrest_summons_number":"F79K0TDDZK40","is_linked":false},"relationships":{"offences":{"data":[{"id":"0fcb44b6-1ca7-4360-b6ed-1d57ff9423e0","type":"offences"}]}}},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants","attributes":{"first_name":"Florene","last_name":"DuBuque","date_of_birth":"1983-10-17","national_insurance_number":"XE675428D","arrest_summons_number":"C2ZXXPBNGVR0","is_linked":false},"relationships":{"offences":{"data":[{"id":"45d5e934-72d0-4a14-b43c-cad750d4ff3c","type":"offences"}]}}},{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants","attributes":{"first_name":"Josefa","last_name":"Franecki","date_of_birth":"1961-06-15","national_insurance_number":"HR669639D","arrest_summons_number":"Y1NDQNW9NCN6","is_linked":false},"relationships":{"offences":{"data":[{"id":"6de5bcf7-c3bd-47cd-9c74-a79d06aaf3dc","type":"offences"}]}}},{"id":"5aff5a05-8f43-40e0-82e6-08c658ffca00","type":"offences","attributes":{"code":"Random
         string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"0fcb44b6-1ca7-4360-b6ed-1d57ff9423e0","type":"offences","attributes":{"code":"Random
         string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"45d5e934-72d0-4a14-b43c-cad750d4ff3c","type":"offences","attributes":{"code":"Random
         string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"6de5bcf7-c3bd-47cd-9c74-a79d06aaf3dc","type":"offences","attributes":{"code":"Random
+        string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"2f7fd30b-3bff-4493-bc0f-254e2bd71734","type":"defendants","attributes":{"first_name":"Marion","last_name":"Swift","date_of_birth":"1999-12-30","national_insurance_number":"GX188228C","arrest_summons_number":"N80TNY2CGZGV","is_linked":false},"relationships":{"offences":{"data":[{"id":"f651b45d-5968-4d6b-b615-6f74c1050ca9","type":"offences"}]}}},{"id":"1ed04150-0dd8-45a0-80cf-29f0dcf104b5","type":"defendants","attributes":{"first_name":"Russell","last_name":"Waters","date_of_birth":"1986-12-14","national_insurance_number":"GP592510D","arrest_summons_number":"JRUG82AGN111","is_linked":false},"relationships":{"offences":{"data":[{"id":"15d01c69-e9ee-4243-8398-376b64cff0cb","type":"offences"}]}}},{"id":"e6d2dd73-b95b-4f98-a1ac-795c181791fe","type":"defendants","attributes":{"first_name":"Jolynn","last_name":"Schinner","date_of_birth":"1991-03-01","national_insurance_number":"YE744478B","arrest_summons_number":"A5W1R4OGUX7C","is_linked":false},"relationships":{"offences":{"data":[{"id":"c7726d30-dda1-4b19-8f62-f06529197da3","type":"offences"}]}}},{"id":"a21d8531-5eaf-42df-8dc5-348bbd071f07","type":"defendants","attributes":{"first_name":"Quincy","last_name":"O''Kon","date_of_birth":"1993-09-02","national_insurance_number":"GP181930B","arrest_summons_number":"GFNBCQEY8RBP","is_linked":false},"relationships":{"offences":{"data":[{"id":"d250b0f1-c89c-4715-889e-46045e164753","type":"offences"}]}}},{"id":"9ad9161f-776d-4139-bd0a-e4d5c0650305","type":"defendants","attributes":{"first_name":"Josefa","last_name":"Franecki","date_of_birth":"1961-06-15","national_insurance_number":"HR669639D","arrest_summons_number":"Y1NDQNW9NCN6","is_linked":false},"relationships":{"offences":{"data":[{"id":"28689c87-c6da-4fdf-9b69-ac763fd7fc7a","type":"offences"}]}}},{"id":"f651b45d-5968-4d6b-b615-6f74c1050ca9","type":"offences","attributes":{"code":"Random
+        string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"15d01c69-e9ee-4243-8398-376b64cff0cb","type":"offences","attributes":{"code":"Random
+        string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"c7726d30-dda1-4b19-8f62-f06529197da3","type":"offences","attributes":{"code":"Random
+        string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"d250b0f1-c89c-4715-889e-46045e164753","type":"offences","attributes":{"code":"Random
+        string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"28689c87-c6da-4fdf-9b69-ac763fd7fc7a","type":"offences","attributes":{"code":"Random
         string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}}]}'
     http_version: null
-  recorded_at: Thu, 12 Mar 2020 14:31:09 GMT
+  recorded_at: Thu, 26 Mar 2020 14:57:22 GMT
 - request:
     method: get
     uri: http://localhost:9292/api/internal/v1/prosecution_cases?filter%5Bnational_insurance_number%5D=HR669639D&include=defendants,defendants.offences
@@ -120,7 +125,7 @@ http_interactions:
       Accept:
       - application/vnd.api+json
       Authorization:
-      - Bearer ZCd4DQST_G-ppahrzHOTCUTmquascUB-AuIbik72gIE
+      - Bearer <BEARER_TOKEN>
       Accept-Encoding:
       - gzip,deflate
   response:
@@ -143,22 +148,27 @@ http_interactions:
       Content-Type:
       - application/vnd.api+json; charset=utf-8
       Etag:
-      - W/"4e7e850b3adba4da111599773e308540"
+      - W/"42fc0961f3c0970a0aff2edb0cf75876"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 8ce0b44d-b648-46e8-b1ee-58a701bd8e86
+      - a342aff9-2bfe-40cc-a0c5-161f1cac760f
       X-Runtime:
-      - '0.073005'
-      Transfer-Encoding:
-      - chunked
+      - '0.145114'
+      Content-Length:
+      - '5719'
     body:
       encoding: UTF-8
-      string: '{"data":[{"id":"2dc8dd46-d930-4878-a0a6-68ae8642cd9e","type":"prosecution_cases","attributes":{"prosecution_case_reference":"MOGUERBXIZ"},"relationships":{"defendants":{"data":[{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants"},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants"},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants"},{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants"}]}}}],"included":[{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants","attributes":{"first_name":"Andy","last_name":"Sawayn","date_of_birth":"1987-10-19","national_insurance_number":"EA382617F","arrest_summons_number":"KX5SWEFJQ3DL"},"relationships":{"offences":{"data":[{"id":"5aff5a05-8f43-40e0-82e6-08c658ffca00","type":"offences"}]}}},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants","attributes":{"first_name":"Aracely","last_name":"Zulauf","date_of_birth":"1955-09-27","national_insurance_number":"HH481835D","arrest_summons_number":"F79K0TDDZK40"},"relationships":{"offences":{"data":[{"id":"0fcb44b6-1ca7-4360-b6ed-1d57ff9423e0","type":"offences"}]}}},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants","attributes":{"first_name":"Florene","last_name":"DuBuque","date_of_birth":"1983-10-17","national_insurance_number":"XE675428D","arrest_summons_number":"C2ZXXPBNGVR0"},"relationships":{"offences":{"data":[{"id":"45d5e934-72d0-4a14-b43c-cad750d4ff3c","type":"offences"}]}}},{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants","attributes":{"first_name":"Josefa","last_name":"Franecki","date_of_birth":"1961-06-15","national_insurance_number":"HR669639D","arrest_summons_number":"Y1NDQNW9NCN6"},"relationships":{"offences":{"data":[{"id":"6de5bcf7-c3bd-47cd-9c74-a79d06aaf3dc","type":"offences"}]}}},{"id":"5aff5a05-8f43-40e0-82e6-08c658ffca00","type":"offences","attributes":{"code":"Random
+      string: '{"data":[{"id":"2dc8dd46-d930-4878-a0a6-68ae8642cd9e","type":"prosecution_cases","attributes":{"prosecution_case_reference":"MOGUERBXIZ"},"relationships":{"defendants":{"data":[{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants"},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants"},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants"},{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants"}]}}},{"id":"45181ba4-0230-4d76-bd1f-8dd283cc2504","type":"prosecution_cases","attributes":{"prosecution_case_reference":"LJSQNTUNNC"},"relationships":{"defendants":{"data":[{"id":"2f7fd30b-3bff-4493-bc0f-254e2bd71734","type":"defendants"},{"id":"1ed04150-0dd8-45a0-80cf-29f0dcf104b5","type":"defendants"},{"id":"e6d2dd73-b95b-4f98-a1ac-795c181791fe","type":"defendants"},{"id":"a21d8531-5eaf-42df-8dc5-348bbd071f07","type":"defendants"},{"id":"9ad9161f-776d-4139-bd0a-e4d5c0650305","type":"defendants"}]}}}],"included":[{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants","attributes":{"first_name":"Andy","last_name":"Sawayn","date_of_birth":"1987-10-19","national_insurance_number":"EA382617F","arrest_summons_number":"KX5SWEFJQ3DL","is_linked":false},"relationships":{"offences":{"data":[{"id":"5aff5a05-8f43-40e0-82e6-08c658ffca00","type":"offences"}]}}},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants","attributes":{"first_name":"Aracely","last_name":"Zulauf","date_of_birth":"1955-09-27","national_insurance_number":"HH481835D","arrest_summons_number":"F79K0TDDZK40","is_linked":false},"relationships":{"offences":{"data":[{"id":"0fcb44b6-1ca7-4360-b6ed-1d57ff9423e0","type":"offences"}]}}},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants","attributes":{"first_name":"Florene","last_name":"DuBuque","date_of_birth":"1983-10-17","national_insurance_number":"XE675428D","arrest_summons_number":"C2ZXXPBNGVR0","is_linked":false},"relationships":{"offences":{"data":[{"id":"45d5e934-72d0-4a14-b43c-cad750d4ff3c","type":"offences"}]}}},{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants","attributes":{"first_name":"Josefa","last_name":"Franecki","date_of_birth":"1961-06-15","national_insurance_number":"HR669639D","arrest_summons_number":"Y1NDQNW9NCN6","is_linked":false},"relationships":{"offences":{"data":[{"id":"6de5bcf7-c3bd-47cd-9c74-a79d06aaf3dc","type":"offences"}]}}},{"id":"5aff5a05-8f43-40e0-82e6-08c658ffca00","type":"offences","attributes":{"code":"Random
         string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"0fcb44b6-1ca7-4360-b6ed-1d57ff9423e0","type":"offences","attributes":{"code":"Random
         string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"45d5e934-72d0-4a14-b43c-cad750d4ff3c","type":"offences","attributes":{"code":"Random
         string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"6de5bcf7-c3bd-47cd-9c74-a79d06aaf3dc","type":"offences","attributes":{"code":"Random
+        string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"2f7fd30b-3bff-4493-bc0f-254e2bd71734","type":"defendants","attributes":{"first_name":"Marion","last_name":"Swift","date_of_birth":"1999-12-30","national_insurance_number":"GX188228C","arrest_summons_number":"N80TNY2CGZGV","is_linked":false},"relationships":{"offences":{"data":[{"id":"f651b45d-5968-4d6b-b615-6f74c1050ca9","type":"offences"}]}}},{"id":"1ed04150-0dd8-45a0-80cf-29f0dcf104b5","type":"defendants","attributes":{"first_name":"Russell","last_name":"Waters","date_of_birth":"1986-12-14","national_insurance_number":"GP592510D","arrest_summons_number":"JRUG82AGN111","is_linked":false},"relationships":{"offences":{"data":[{"id":"15d01c69-e9ee-4243-8398-376b64cff0cb","type":"offences"}]}}},{"id":"e6d2dd73-b95b-4f98-a1ac-795c181791fe","type":"defendants","attributes":{"first_name":"Jolynn","last_name":"Schinner","date_of_birth":"1991-03-01","national_insurance_number":"YE744478B","arrest_summons_number":"A5W1R4OGUX7C","is_linked":false},"relationships":{"offences":{"data":[{"id":"c7726d30-dda1-4b19-8f62-f06529197da3","type":"offences"}]}}},{"id":"a21d8531-5eaf-42df-8dc5-348bbd071f07","type":"defendants","attributes":{"first_name":"Quincy","last_name":"O''Kon","date_of_birth":"1993-09-02","national_insurance_number":"GP181930B","arrest_summons_number":"GFNBCQEY8RBP","is_linked":false},"relationships":{"offences":{"data":[{"id":"d250b0f1-c89c-4715-889e-46045e164753","type":"offences"}]}}},{"id":"9ad9161f-776d-4139-bd0a-e4d5c0650305","type":"defendants","attributes":{"first_name":"Josefa","last_name":"Franecki","date_of_birth":"1961-06-15","national_insurance_number":"HR669639D","arrest_summons_number":"Y1NDQNW9NCN6","is_linked":false},"relationships":{"offences":{"data":[{"id":"28689c87-c6da-4fdf-9b69-ac763fd7fc7a","type":"offences"}]}}},{"id":"f651b45d-5968-4d6b-b615-6f74c1050ca9","type":"offences","attributes":{"code":"Random
+        string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"15d01c69-e9ee-4243-8398-376b64cff0cb","type":"offences","attributes":{"code":"Random
+        string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"c7726d30-dda1-4b19-8f62-f06529197da3","type":"offences","attributes":{"code":"Random
+        string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"d250b0f1-c89c-4715-889e-46045e164753","type":"offences","attributes":{"code":"Random
+        string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"28689c87-c6da-4fdf-9b69-ac763fd7fc7a","type":"offences","attributes":{"code":"Random
         string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}}]}'
     http_version: null
-  recorded_at: Thu, 12 Mar 2020 14:31:10 GMT
+  recorded_at: Thu, 26 Mar 2020 14:57:22 GMT
 recorded_with: VCR 5.1.0

--- a/spec/fixtures/vcr_cassettes/spec/lib/court_data_adaptor/query/defendant/by_name_spec.yml
+++ b/spec/fixtures/vcr_cassettes/spec/lib/court_data_adaptor/query/defendant/by_name_spec.yml
@@ -14,7 +14,7 @@ http_interactions:
       Accept:
       - application/vnd.api+json
       Authorization:
-      - Bearer 63prLT9mgISO3tv2JXO4O2v124MafJBTKAEvlrJHMIw
+      - Bearer <BEARER_TOKEN>
       Accept-Encoding:
       - gzip,deflate
   response:
@@ -35,20 +35,20 @@ http_interactions:
       Referrer-Policy:
       - strict-origin-when-cross-origin
       Content-Type:
-      - application/json; charset=utf-8
+      - application/vnd.api+json; charset=utf-8
       Etag:
-      - W/"b2a279c98c1b2e0e4383fa290df0f2e2"
+      - W/"aaa825417c06a05d5b625f1a83a3c925"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - e43dd98c-1534-4757-9294-d2f67d1f03fa
+      - 1e252f07-2682-4412-98e5-90f0ff63c243
       X-Runtime:
-      - '0.141282'
-      Transfer-Encoding:
-      - chunked
+      - '0.139643'
+      Content-Length:
+      - '4153'
     body:
       encoding: UTF-8
-      string: '{"data":[{"id":"2dc8dd46-d930-4878-a0a6-68ae8642cd9e","type":"prosecution_cases","attributes":{"prosecution_case_reference":"MOGUERBXIZ"},"relationships":{"defendants":{"data":[{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants"},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants"},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants"},{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants"}]},"hearing_summaries":{"data":[]}}}],"included":[{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants","attributes":{"first_name":"Josefa","last_name":"Franecki","date_of_birth":"1961-06-15","national_insurance_number":"HR669639M","gender":null,"address_1":null,"address_2":null,"address_3":null,"address_4":null,"address_5":null,"postcode":null},"relationships":{"offences":{"data":[{"id":"6de5bcf7-c3bd-47cd-9c74-a79d06aaf3dc","type":"offences"}]}}},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants","attributes":{"first_name":"Florene","last_name":"DuBuque","date_of_birth":"1983-10-17","national_insurance_number":"XE675428D","gender":null,"address_1":null,"address_2":null,"address_3":null,"address_4":null,"address_5":null,"postcode":null},"relationships":{"offences":{"data":[{"id":"45d5e934-72d0-4a14-b43c-cad750d4ff3c","type":"offences"}]}}},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants","attributes":{"first_name":"Aracely","last_name":"Zulauf","date_of_birth":"1955-09-27","national_insurance_number":"HH481835D","gender":null,"address_1":null,"address_2":null,"address_3":null,"address_4":null,"address_5":null,"postcode":null},"relationships":{"offences":{"data":[{"id":"0fcb44b6-1ca7-4360-b6ed-1d57ff9423e0","type":"offences"}]}}},{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants","attributes":{"first_name":"Andy","last_name":"Sawayn","date_of_birth":"1987-10-19","national_insurance_number":"EA382617F","gender":null,"address_1":null,"address_2":null,"address_3":null,"address_4":null,"address_5":null,"postcode":null},"relationships":{"offences":{"data":[{"id":"5aff5a05-8f43-40e0-82e6-08c658ffca00","type":"offences"}]}}}]}'
+      string: '{"data":[{"id":"2dc8dd46-d930-4878-a0a6-68ae8642cd9e","type":"prosecution_cases","attributes":{"prosecution_case_reference":"MOGUERBXIZ"},"relationships":{"defendants":{"data":[{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants"},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants"},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants"},{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants"}]}}},{"id":"45181ba4-0230-4d76-bd1f-8dd283cc2504","type":"prosecution_cases","attributes":{"prosecution_case_reference":"LJSQNTUNNC"},"relationships":{"defendants":{"data":[{"id":"2f7fd30b-3bff-4493-bc0f-254e2bd71734","type":"defendants"},{"id":"1ed04150-0dd8-45a0-80cf-29f0dcf104b5","type":"defendants"},{"id":"e6d2dd73-b95b-4f98-a1ac-795c181791fe","type":"defendants"},{"id":"a21d8531-5eaf-42df-8dc5-348bbd071f07","type":"defendants"},{"id":"9ad9161f-776d-4139-bd0a-e4d5c0650305","type":"defendants"}]}}}],"included":[{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants","attributes":{"first_name":"Andy","last_name":"Sawayn","date_of_birth":"1987-10-19","national_insurance_number":"EA382617F","arrest_summons_number":"KX5SWEFJQ3DL","is_linked":false},"relationships":{"offences":{"data":[{"id":"5aff5a05-8f43-40e0-82e6-08c658ffca00","type":"offences"}]}}},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants","attributes":{"first_name":"Aracely","last_name":"Zulauf","date_of_birth":"1955-09-27","national_insurance_number":"HH481835D","arrest_summons_number":"F79K0TDDZK40","is_linked":false},"relationships":{"offences":{"data":[{"id":"0fcb44b6-1ca7-4360-b6ed-1d57ff9423e0","type":"offences"}]}}},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants","attributes":{"first_name":"Florene","last_name":"DuBuque","date_of_birth":"1983-10-17","national_insurance_number":"XE675428D","arrest_summons_number":"C2ZXXPBNGVR0","is_linked":false},"relationships":{"offences":{"data":[{"id":"45d5e934-72d0-4a14-b43c-cad750d4ff3c","type":"offences"}]}}},{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants","attributes":{"first_name":"Josefa","last_name":"Franecki","date_of_birth":"1961-06-15","national_insurance_number":"HR669639D","arrest_summons_number":"Y1NDQNW9NCN6","is_linked":false},"relationships":{"offences":{"data":[{"id":"6de5bcf7-c3bd-47cd-9c74-a79d06aaf3dc","type":"offences"}]}}},{"id":"2f7fd30b-3bff-4493-bc0f-254e2bd71734","type":"defendants","attributes":{"first_name":"Marion","last_name":"Swift","date_of_birth":"1999-12-30","national_insurance_number":"GX188228C","arrest_summons_number":"N80TNY2CGZGV","is_linked":false},"relationships":{"offences":{"data":[{"id":"f651b45d-5968-4d6b-b615-6f74c1050ca9","type":"offences"}]}}},{"id":"1ed04150-0dd8-45a0-80cf-29f0dcf104b5","type":"defendants","attributes":{"first_name":"Russell","last_name":"Waters","date_of_birth":"1986-12-14","national_insurance_number":"GP592510D","arrest_summons_number":"JRUG82AGN111","is_linked":false},"relationships":{"offences":{"data":[{"id":"15d01c69-e9ee-4243-8398-376b64cff0cb","type":"offences"}]}}},{"id":"e6d2dd73-b95b-4f98-a1ac-795c181791fe","type":"defendants","attributes":{"first_name":"Jolynn","last_name":"Schinner","date_of_birth":"1991-03-01","national_insurance_number":"YE744478B","arrest_summons_number":"A5W1R4OGUX7C","is_linked":false},"relationships":{"offences":{"data":[{"id":"c7726d30-dda1-4b19-8f62-f06529197da3","type":"offences"}]}}},{"id":"a21d8531-5eaf-42df-8dc5-348bbd071f07","type":"defendants","attributes":{"first_name":"Quincy","last_name":"O''Kon","date_of_birth":"1993-09-02","national_insurance_number":"GP181930B","arrest_summons_number":"GFNBCQEY8RBP","is_linked":false},"relationships":{"offences":{"data":[{"id":"d250b0f1-c89c-4715-889e-46045e164753","type":"offences"}]}}},{"id":"9ad9161f-776d-4139-bd0a-e4d5c0650305","type":"defendants","attributes":{"first_name":"Josefa","last_name":"Franecki","date_of_birth":"1961-06-15","national_insurance_number":"HR669639D","arrest_summons_number":"Y1NDQNW9NCN6","is_linked":false},"relationships":{"offences":{"data":[{"id":"28689c87-c6da-4fdf-9b69-ac763fd7fc7a","type":"offences"}]}}}]}'
     http_version: null
-  recorded_at: Wed, 04 Mar 2020 09:21:19 GMT
+  recorded_at: Thu, 26 Mar 2020 14:57:36 GMT
 recorded_with: VCR 5.1.0

--- a/spec/fixtures/vcr_cassettes/spec/lib/court_data_adaptor/query/defendant/by_reference_spec.yml
+++ b/spec/fixtures/vcr_cassettes/spec/lib/court_data_adaptor/query/defendant/by_reference_spec.yml
@@ -14,7 +14,7 @@ http_interactions:
       Accept:
       - application/vnd.api+json
       Authorization:
-      - Bearer 0xQLSvOm_8WYdoH3hZd3mkqJ5rL-ecGU8b_m9M6l2nY
+      - Bearer <BEARER_TOKEN>
       Accept-Encoding:
       - gzip,deflate
   response:
@@ -37,24 +37,25 @@ http_interactions:
       Content-Type:
       - application/vnd.api+json; charset=utf-8
       Etag:
-      - W/"6016f43e07dcbd2f4f5aa8a4c974f38d"
+      - W/"65bb9d9f1853b6a4ecb2d3786a645e99"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 21cf81c7-9795-4039-927e-74871767d533
+      - dd64e74e-cb4f-4557-b6c6-ae5ec8c12ca0
       X-Runtime:
-      - '0.075129'
-      Transfer-Encoding:
-      - chunked
+      - '0.088689'
+      Content-Length:
+      - '3168'
     body:
       encoding: UTF-8
-      string: '{"data":[{"id":"45181ba4-0230-4d76-bd1f-8dd283cc2504","type":"prosecution_cases","attributes":{"prosecution_case_reference":"LJSQNTUNNC"},"relationships":{"defendants":{"data":[{"id":"a21d8531-5eaf-42df-8dc5-348bbd071f07","type":"defendants"},{"id":"e6d2dd73-b95b-4f98-a1ac-795c181791fe","type":"defendants"},{"id":"1ed04150-0dd8-45a0-80cf-29f0dcf104b5","type":"defendants"},{"id":"2f7fd30b-3bff-4493-bc0f-254e2bd71734","type":"defendants"}]}}}],"included":[{"id":"a21d8531-5eaf-42df-8dc5-348bbd071f07","type":"defendants","attributes":{"first_name":"Quincy","last_name":"O''Kon","date_of_birth":"1993-09-02","national_insurance_number":"GP181930B","arrest_summons_number":"GFNBCQEY8RBP"},"relationships":{"offences":{"data":[{"id":"d250b0f1-c89c-4715-889e-46045e164753","type":"offences"}]}}},{"id":"e6d2dd73-b95b-4f98-a1ac-795c181791fe","type":"defendants","attributes":{"first_name":"Jolynn","last_name":"Schinner","date_of_birth":"1991-03-01","national_insurance_number":"YE744478B","arrest_summons_number":"A5W1R4OGUX7C"},"relationships":{"offences":{"data":[{"id":"c7726d30-dda1-4b19-8f62-f06529197da3","type":"offences"}]}}},{"id":"1ed04150-0dd8-45a0-80cf-29f0dcf104b5","type":"defendants","attributes":{"first_name":"Russell","last_name":"Waters","date_of_birth":"1986-12-14","national_insurance_number":"GP592510D","arrest_summons_number":"JRUG82AGN111"},"relationships":{"offences":{"data":[{"id":"15d01c69-e9ee-4243-8398-376b64cff0cb","type":"offences"}]}}},{"id":"2f7fd30b-3bff-4493-bc0f-254e2bd71734","type":"defendants","attributes":{"first_name":"Marion","last_name":"Swift","date_of_birth":"1999-12-30","national_insurance_number":"GX188228C","arrest_summons_number":"N80TNY2CGZGV"},"relationships":{"offences":{"data":[{"id":"f651b45d-5968-4d6b-b615-6f74c1050ca9","type":"offences"}]}}},{"id":"d250b0f1-c89c-4715-889e-46045e164753","type":"offences","attributes":{"code":"Random
-        string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"c7726d30-dda1-4b19-8f62-f06529197da3","type":"offences","attributes":{"code":"Random
+      string: '{"data":[{"id":"45181ba4-0230-4d76-bd1f-8dd283cc2504","type":"prosecution_cases","attributes":{"prosecution_case_reference":"LJSQNTUNNC"},"relationships":{"defendants":{"data":[{"id":"2f7fd30b-3bff-4493-bc0f-254e2bd71734","type":"defendants"},{"id":"1ed04150-0dd8-45a0-80cf-29f0dcf104b5","type":"defendants"},{"id":"e6d2dd73-b95b-4f98-a1ac-795c181791fe","type":"defendants"},{"id":"a21d8531-5eaf-42df-8dc5-348bbd071f07","type":"defendants"},{"id":"9ad9161f-776d-4139-bd0a-e4d5c0650305","type":"defendants"}]}}}],"included":[{"id":"2f7fd30b-3bff-4493-bc0f-254e2bd71734","type":"defendants","attributes":{"first_name":"Marion","last_name":"Swift","date_of_birth":"1999-12-30","national_insurance_number":"GX188228C","arrest_summons_number":"N80TNY2CGZGV","is_linked":false},"relationships":{"offences":{"data":[{"id":"f651b45d-5968-4d6b-b615-6f74c1050ca9","type":"offences"}]}}},{"id":"1ed04150-0dd8-45a0-80cf-29f0dcf104b5","type":"defendants","attributes":{"first_name":"Russell","last_name":"Waters","date_of_birth":"1986-12-14","national_insurance_number":"GP592510D","arrest_summons_number":"JRUG82AGN111","is_linked":false},"relationships":{"offences":{"data":[{"id":"15d01c69-e9ee-4243-8398-376b64cff0cb","type":"offences"}]}}},{"id":"e6d2dd73-b95b-4f98-a1ac-795c181791fe","type":"defendants","attributes":{"first_name":"Jolynn","last_name":"Schinner","date_of_birth":"1991-03-01","national_insurance_number":"YE744478B","arrest_summons_number":"A5W1R4OGUX7C","is_linked":false},"relationships":{"offences":{"data":[{"id":"c7726d30-dda1-4b19-8f62-f06529197da3","type":"offences"}]}}},{"id":"a21d8531-5eaf-42df-8dc5-348bbd071f07","type":"defendants","attributes":{"first_name":"Quincy","last_name":"O''Kon","date_of_birth":"1993-09-02","national_insurance_number":"GP181930B","arrest_summons_number":"GFNBCQEY8RBP","is_linked":false},"relationships":{"offences":{"data":[{"id":"d250b0f1-c89c-4715-889e-46045e164753","type":"offences"}]}}},{"id":"9ad9161f-776d-4139-bd0a-e4d5c0650305","type":"defendants","attributes":{"first_name":"Josefa","last_name":"Franecki","date_of_birth":"1961-06-15","national_insurance_number":"HR669639D","arrest_summons_number":"Y1NDQNW9NCN6","is_linked":false},"relationships":{"offences":{"data":[{"id":"28689c87-c6da-4fdf-9b69-ac763fd7fc7a","type":"offences"}]}}},{"id":"f651b45d-5968-4d6b-b615-6f74c1050ca9","type":"offences","attributes":{"code":"Random
         string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"15d01c69-e9ee-4243-8398-376b64cff0cb","type":"offences","attributes":{"code":"Random
-        string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"f651b45d-5968-4d6b-b615-6f74c1050ca9","type":"offences","attributes":{"code":"Random
+        string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"c7726d30-dda1-4b19-8f62-f06529197da3","type":"offences","attributes":{"code":"Random
+        string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"d250b0f1-c89c-4715-889e-46045e164753","type":"offences","attributes":{"code":"Random
+        string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"28689c87-c6da-4fdf-9b69-ac763fd7fc7a","type":"offences","attributes":{"code":"Random
         string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}}]}'
     http_version: null
-  recorded_at: Thu, 12 Mar 2020 08:40:01 GMT
+  recorded_at: Thu, 26 Mar 2020 14:57:37 GMT
 - request:
     method: get
     uri: http://localhost:9292/api/internal/v1/prosecution_cases?filter%5Barrest_summons_number%5D=N80TNY2CGZGV&include=defendants,defendants.offences
@@ -69,7 +70,7 @@ http_interactions:
       Accept:
       - application/vnd.api+json
       Authorization:
-      - Bearer 0xQLSvOm_8WYdoH3hZd3mkqJ5rL-ecGU8b_m9M6l2nY
+      - Bearer <BEARER_TOKEN>
       Accept-Encoding:
       - gzip,deflate
   response:
@@ -92,22 +93,23 @@ http_interactions:
       Content-Type:
       - application/vnd.api+json; charset=utf-8
       Etag:
-      - W/"6016f43e07dcbd2f4f5aa8a4c974f38d"
+      - W/"65bb9d9f1853b6a4ecb2d3786a645e99"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - ea0b5057-0376-4ab9-b14e-6e11aca539a5
+      - fc43e077-80f8-40cc-aa46-679d4235e369
       X-Runtime:
-      - '0.090081'
-      Transfer-Encoding:
-      - chunked
+      - '0.111740'
+      Content-Length:
+      - '3168'
     body:
       encoding: UTF-8
-      string: '{"data":[{"id":"45181ba4-0230-4d76-bd1f-8dd283cc2504","type":"prosecution_cases","attributes":{"prosecution_case_reference":"LJSQNTUNNC"},"relationships":{"defendants":{"data":[{"id":"a21d8531-5eaf-42df-8dc5-348bbd071f07","type":"defendants"},{"id":"e6d2dd73-b95b-4f98-a1ac-795c181791fe","type":"defendants"},{"id":"1ed04150-0dd8-45a0-80cf-29f0dcf104b5","type":"defendants"},{"id":"2f7fd30b-3bff-4493-bc0f-254e2bd71734","type":"defendants"}]}}}],"included":[{"id":"a21d8531-5eaf-42df-8dc5-348bbd071f07","type":"defendants","attributes":{"first_name":"Quincy","last_name":"O''Kon","date_of_birth":"1993-09-02","national_insurance_number":"GP181930B","arrest_summons_number":"GFNBCQEY8RBP"},"relationships":{"offences":{"data":[{"id":"d250b0f1-c89c-4715-889e-46045e164753","type":"offences"}]}}},{"id":"e6d2dd73-b95b-4f98-a1ac-795c181791fe","type":"defendants","attributes":{"first_name":"Jolynn","last_name":"Schinner","date_of_birth":"1991-03-01","national_insurance_number":"YE744478B","arrest_summons_number":"A5W1R4OGUX7C"},"relationships":{"offences":{"data":[{"id":"c7726d30-dda1-4b19-8f62-f06529197da3","type":"offences"}]}}},{"id":"1ed04150-0dd8-45a0-80cf-29f0dcf104b5","type":"defendants","attributes":{"first_name":"Russell","last_name":"Waters","date_of_birth":"1986-12-14","national_insurance_number":"GP592510D","arrest_summons_number":"JRUG82AGN111"},"relationships":{"offences":{"data":[{"id":"15d01c69-e9ee-4243-8398-376b64cff0cb","type":"offences"}]}}},{"id":"2f7fd30b-3bff-4493-bc0f-254e2bd71734","type":"defendants","attributes":{"first_name":"Marion","last_name":"Swift","date_of_birth":"1999-12-30","national_insurance_number":"GX188228C","arrest_summons_number":"N80TNY2CGZGV"},"relationships":{"offences":{"data":[{"id":"f651b45d-5968-4d6b-b615-6f74c1050ca9","type":"offences"}]}}},{"id":"d250b0f1-c89c-4715-889e-46045e164753","type":"offences","attributes":{"code":"Random
-        string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"c7726d30-dda1-4b19-8f62-f06529197da3","type":"offences","attributes":{"code":"Random
+      string: '{"data":[{"id":"45181ba4-0230-4d76-bd1f-8dd283cc2504","type":"prosecution_cases","attributes":{"prosecution_case_reference":"LJSQNTUNNC"},"relationships":{"defendants":{"data":[{"id":"2f7fd30b-3bff-4493-bc0f-254e2bd71734","type":"defendants"},{"id":"1ed04150-0dd8-45a0-80cf-29f0dcf104b5","type":"defendants"},{"id":"e6d2dd73-b95b-4f98-a1ac-795c181791fe","type":"defendants"},{"id":"a21d8531-5eaf-42df-8dc5-348bbd071f07","type":"defendants"},{"id":"9ad9161f-776d-4139-bd0a-e4d5c0650305","type":"defendants"}]}}}],"included":[{"id":"2f7fd30b-3bff-4493-bc0f-254e2bd71734","type":"defendants","attributes":{"first_name":"Marion","last_name":"Swift","date_of_birth":"1999-12-30","national_insurance_number":"GX188228C","arrest_summons_number":"N80TNY2CGZGV","is_linked":false},"relationships":{"offences":{"data":[{"id":"f651b45d-5968-4d6b-b615-6f74c1050ca9","type":"offences"}]}}},{"id":"1ed04150-0dd8-45a0-80cf-29f0dcf104b5","type":"defendants","attributes":{"first_name":"Russell","last_name":"Waters","date_of_birth":"1986-12-14","national_insurance_number":"GP592510D","arrest_summons_number":"JRUG82AGN111","is_linked":false},"relationships":{"offences":{"data":[{"id":"15d01c69-e9ee-4243-8398-376b64cff0cb","type":"offences"}]}}},{"id":"e6d2dd73-b95b-4f98-a1ac-795c181791fe","type":"defendants","attributes":{"first_name":"Jolynn","last_name":"Schinner","date_of_birth":"1991-03-01","national_insurance_number":"YE744478B","arrest_summons_number":"A5W1R4OGUX7C","is_linked":false},"relationships":{"offences":{"data":[{"id":"c7726d30-dda1-4b19-8f62-f06529197da3","type":"offences"}]}}},{"id":"a21d8531-5eaf-42df-8dc5-348bbd071f07","type":"defendants","attributes":{"first_name":"Quincy","last_name":"O''Kon","date_of_birth":"1993-09-02","national_insurance_number":"GP181930B","arrest_summons_number":"GFNBCQEY8RBP","is_linked":false},"relationships":{"offences":{"data":[{"id":"d250b0f1-c89c-4715-889e-46045e164753","type":"offences"}]}}},{"id":"9ad9161f-776d-4139-bd0a-e4d5c0650305","type":"defendants","attributes":{"first_name":"Josefa","last_name":"Franecki","date_of_birth":"1961-06-15","national_insurance_number":"HR669639D","arrest_summons_number":"Y1NDQNW9NCN6","is_linked":false},"relationships":{"offences":{"data":[{"id":"28689c87-c6da-4fdf-9b69-ac763fd7fc7a","type":"offences"}]}}},{"id":"f651b45d-5968-4d6b-b615-6f74c1050ca9","type":"offences","attributes":{"code":"Random
         string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"15d01c69-e9ee-4243-8398-376b64cff0cb","type":"offences","attributes":{"code":"Random
-        string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"f651b45d-5968-4d6b-b615-6f74c1050ca9","type":"offences","attributes":{"code":"Random
+        string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"c7726d30-dda1-4b19-8f62-f06529197da3","type":"offences","attributes":{"code":"Random
+        string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"d250b0f1-c89c-4715-889e-46045e164753","type":"offences","attributes":{"code":"Random
+        string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"28689c87-c6da-4fdf-9b69-ac763fd7fc7a","type":"offences","attributes":{"code":"Random
         string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}}]}'
     http_version: null
-  recorded_at: Thu, 12 Mar 2020 08:40:01 GMT
+  recorded_at: Thu, 26 Mar 2020 14:57:37 GMT
 recorded_with: VCR 5.1.0

--- a/spec/fixtures/vcr_cassettes/spec/lib/court_data_adaptor/query/prosecution_case_spec.yml
+++ b/spec/fixtures/vcr_cassettes/spec/lib/court_data_adaptor/query/prosecution_case_spec.yml
@@ -14,7 +14,7 @@ http_interactions:
       Accept:
       - application/vnd.api+json
       Authorization:
-      - Bearer 2DYYX2jqD1YUqXgrvo5H9RSp9wa4OW-WMgiHEXB2nMc
+      - Bearer <BEARER_TOKEN>
       Accept-Encoding:
       - gzip,deflate
   response:
@@ -35,20 +35,20 @@ http_interactions:
       Referrer-Policy:
       - strict-origin-when-cross-origin
       Content-Type:
-      - application/json; charset=utf-8
+      - application/vnd.api+json; charset=utf-8
       Etag:
-      - W/"b2a279c98c1b2e0e4383fa290df0f2e2"
+      - W/"7497a3636a45f300c84f93f31487f802"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - ef189637-2a24-4c75-9a62-d005ad8200ff
+      - a85703b8-fc74-4381-b8f8-eaaab4d84a37
       X-Runtime:
-      - '0.881369'
-      Transfer-Encoding:
-      - chunked
+      - '0.075183'
+      Content-Length:
+      - '1878'
     body:
       encoding: UTF-8
-      string: '{"data":[{"id":"2dc8dd46-d930-4878-a0a6-68ae8642cd9e","type":"prosecution_cases","attributes":{"prosecution_case_reference":"MOGUERBXIZ"},"relationships":{"defendants":{"data":[{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants"},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants"},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants"},{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants"}]},"hearing_summaries":{"data":[]}}}],"included":[{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants","attributes":{"first_name":"Josefa","last_name":"Franecki","date_of_birth":"1961-06-15","national_insurance_number":"HR669639M","gender":null,"address_1":null,"address_2":null,"address_3":null,"address_4":null,"address_5":null,"postcode":null},"relationships":{"offences":{"data":[{"id":"6de5bcf7-c3bd-47cd-9c74-a79d06aaf3dc","type":"offences"}]}}},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants","attributes":{"first_name":"Florene","last_name":"DuBuque","date_of_birth":"1983-10-17","national_insurance_number":"XE675428D","gender":null,"address_1":null,"address_2":null,"address_3":null,"address_4":null,"address_5":null,"postcode":null},"relationships":{"offences":{"data":[{"id":"45d5e934-72d0-4a14-b43c-cad750d4ff3c","type":"offences"}]}}},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants","attributes":{"first_name":"Aracely","last_name":"Zulauf","date_of_birth":"1955-09-27","national_insurance_number":"HH481835D","gender":null,"address_1":null,"address_2":null,"address_3":null,"address_4":null,"address_5":null,"postcode":null},"relationships":{"offences":{"data":[{"id":"0fcb44b6-1ca7-4360-b6ed-1d57ff9423e0","type":"offences"}]}}},{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants","attributes":{"first_name":"Andy","last_name":"Sawayn","date_of_birth":"1987-10-19","national_insurance_number":"EA382617F","gender":null,"address_1":null,"address_2":null,"address_3":null,"address_4":null,"address_5":null,"postcode":null},"relationships":{"offences":{"data":[{"id":"5aff5a05-8f43-40e0-82e6-08c658ffca00","type":"offences"}]}}}]}'
+      string: '{"data":[{"id":"2dc8dd46-d930-4878-a0a6-68ae8642cd9e","type":"prosecution_cases","attributes":{"prosecution_case_reference":"MOGUERBXIZ"},"relationships":{"defendants":{"data":[{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants"},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants"},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants"},{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants"}]}}}],"included":[{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants","attributes":{"first_name":"Andy","last_name":"Sawayn","date_of_birth":"1987-10-19","national_insurance_number":"EA382617F","arrest_summons_number":"KX5SWEFJQ3DL","is_linked":false},"relationships":{"offences":{"data":[{"id":"5aff5a05-8f43-40e0-82e6-08c658ffca00","type":"offences"}]}}},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants","attributes":{"first_name":"Aracely","last_name":"Zulauf","date_of_birth":"1955-09-27","national_insurance_number":"HH481835D","arrest_summons_number":"F79K0TDDZK40","is_linked":false},"relationships":{"offences":{"data":[{"id":"0fcb44b6-1ca7-4360-b6ed-1d57ff9423e0","type":"offences"}]}}},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants","attributes":{"first_name":"Florene","last_name":"DuBuque","date_of_birth":"1983-10-17","national_insurance_number":"XE675428D","arrest_summons_number":"C2ZXXPBNGVR0","is_linked":false},"relationships":{"offences":{"data":[{"id":"45d5e934-72d0-4a14-b43c-cad750d4ff3c","type":"offences"}]}}},{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants","attributes":{"first_name":"Josefa","last_name":"Franecki","date_of_birth":"1961-06-15","national_insurance_number":"HR669639D","arrest_summons_number":"Y1NDQNW9NCN6","is_linked":false},"relationships":{"offences":{"data":[{"id":"6de5bcf7-c3bd-47cd-9c74-a79d06aaf3dc","type":"offences"}]}}}]}'
     http_version: null
-  recorded_at: Mon, 02 Mar 2020 21:00:05 GMT
+  recorded_at: Thu, 26 Mar 2020 14:57:37 GMT
 recorded_with: VCR 5.1.0

--- a/spec/fixtures/vcr_cassettes/spec/lib/court_data_adaptor/resource/prosecution_case_spec.yml
+++ b/spec/fixtures/vcr_cassettes/spec/lib/court_data_adaptor/resource/prosecution_case_spec.yml
@@ -14,7 +14,7 @@ http_interactions:
       Accept:
       - application/vnd.api+json
       Authorization:
-      - Bearer RYc0X-CeP3YX2ZF3jCJYlJDntSW3NWcHhGFQDRORrAA
+      - Bearer <BEARER_TOKEN>
       Accept-Encoding:
       - gzip,deflate
   response:
@@ -35,22 +35,22 @@ http_interactions:
       Referrer-Policy:
       - strict-origin-when-cross-origin
       Content-Type:
-      - application/json; charset=utf-8
+      - application/vnd.api+json; charset=utf-8
       Etag:
       - W/"ba5f3ea40e95f49bce11942f375ebd38"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - fafbc50a-4845-4cee-8fdc-b7ba935fc92c
+      - 3fc02c1a-8a78-4a77-9665-22a2f1cf4a5d
       X-Runtime:
-      - '0.044258'
-      Transfer-Encoding:
-      - chunked
+      - '0.033565'
+      Content-Length:
+      - '13'
     body:
       encoding: UTF-8
       string: '{"data":null}'
     http_version: null
-  recorded_at: Sat, 29 Feb 2020 17:19:39 GMT
+  recorded_at: Thu, 26 Mar 2020 14:57:37 GMT
 - request:
     method: get
     uri: http://localhost:9292/api/internal/v1/prosecution_cases?filter%5Bprosecution_case_reference%5D=MOGUERBXIZ
@@ -65,7 +65,7 @@ http_interactions:
       Accept:
       - application/vnd.api+json
       Authorization:
-      - Bearer RYc0X-CeP3YX2ZF3jCJYlJDntSW3NWcHhGFQDRORrAA
+      - Bearer <BEARER_TOKEN>
       Accept-Encoding:
       - gzip,deflate
   response:
@@ -86,22 +86,22 @@ http_interactions:
       Referrer-Policy:
       - strict-origin-when-cross-origin
       Content-Type:
-      - application/json; charset=utf-8
+      - application/vnd.api+json; charset=utf-8
       Etag:
-      - W/"218320cf0f76fec75e2e5253b03139e5"
+      - W/"d725e0745fec01859c8a2859a605c710"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - a28ee461-3463-49bd-acb6-6096cb4c471e
+      - a370277c-76c9-4345-ab2d-e488b970d309
       X-Runtime:
-      - '0.134274'
-      Transfer-Encoding:
-      - chunked
+      - '0.088029'
+      Content-Length:
+      - '446'
     body:
       encoding: UTF-8
-      string: '{"data":[{"id":"2dc8dd46-d930-4878-a0a6-68ae8642cd9e","type":"prosecution_cases","attributes":{"prosecution_case_reference":"MOGUERBXIZ"},"relationships":{"defendants":{"data":[{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants"},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants"},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants"},{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants"}]},"hearing_summaries":{"data":[]}}}]}'
+      string: '{"data":[{"id":"2dc8dd46-d930-4878-a0a6-68ae8642cd9e","type":"prosecution_cases","attributes":{"prosecution_case_reference":"MOGUERBXIZ"},"relationships":{"defendants":{"data":[{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants"},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants"},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants"},{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants"}]}}}]}'
     http_version: null
-  recorded_at: Sat, 29 Feb 2020 17:19:39 GMT
+  recorded_at: Thu, 26 Mar 2020 14:57:37 GMT
 - request:
     method: get
     uri: http://localhost:9292/api/internal/v1/prosecution_cases?filter%5Bprosecution_case_reference%5D=non-existent-urn&include=defendants
@@ -116,7 +116,7 @@ http_interactions:
       Accept:
       - application/vnd.api+json
       Authorization:
-      - Bearer RYc0X-CeP3YX2ZF3jCJYlJDntSW3NWcHhGFQDRORrAA
+      - Bearer <BEARER_TOKEN>
       Accept-Encoding:
       - gzip,deflate
   response:
@@ -137,22 +137,22 @@ http_interactions:
       Referrer-Policy:
       - strict-origin-when-cross-origin
       Content-Type:
-      - application/json; charset=utf-8
+      - application/vnd.api+json; charset=utf-8
       Etag:
       - W/"ba5f3ea40e95f49bce11942f375ebd38"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 6abc4515-c874-47a1-9d98-b60ee9c09214
+      - 46cad776-6cd3-4588-aea3-b0b6a4bf99d7
       X-Runtime:
-      - '0.036029'
-      Transfer-Encoding:
-      - chunked
+      - '0.032146'
+      Content-Length:
+      - '13'
     body:
       encoding: UTF-8
       string: '{"data":null}'
     http_version: null
-  recorded_at: Sat, 29 Feb 2020 17:19:39 GMT
+  recorded_at: Thu, 26 Mar 2020 14:57:37 GMT
 - request:
     method: get
     uri: http://localhost:9292/api/internal/v1/prosecution_cases?filter%5Bprosecution_case_reference%5D=MOGUERBXIZ&include=defendants
@@ -167,7 +167,7 @@ http_interactions:
       Accept:
       - application/vnd.api+json
       Authorization:
-      - Bearer RYc0X-CeP3YX2ZF3jCJYlJDntSW3NWcHhGFQDRORrAA
+      - Bearer <BEARER_TOKEN>
       Accept-Encoding:
       - gzip,deflate
   response:
@@ -188,20 +188,20 @@ http_interactions:
       Referrer-Policy:
       - strict-origin-when-cross-origin
       Content-Type:
-      - application/json; charset=utf-8
+      - application/vnd.api+json; charset=utf-8
       Etag:
-      - W/"14ec228bcd364bfe53d83c4b03e9a04f"
+      - W/"7497a3636a45f300c84f93f31487f802"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 550f2c42-3ffa-4ec2-8bc7-4b101c785935
+      - 10562c3d-e4b8-48d8-b696-1d4b5c7a32ea
       X-Runtime:
-      - '0.080084'
-      Transfer-Encoding:
-      - chunked
+      - '0.075560'
+      Content-Length:
+      - '1878'
     body:
       encoding: UTF-8
-      string: '{"data":[{"id":"2dc8dd46-d930-4878-a0a6-68ae8642cd9e","type":"prosecution_cases","attributes":{"prosecution_case_reference":"MOGUERBXIZ"},"relationships":{"defendants":{"data":[{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants"},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants"},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants"},{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants"}]},"hearing_summaries":{"data":[]}}}],"included":[{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants","attributes":{"first_name":"Andy","last_name":"Sawayn","date_of_birth":"1987-10-19","national_insurance_number":"EA382617F","gender":null,"address_1":null,"address_2":null,"address_3":null,"address_4":null,"address_5":null,"postcode":null},"relationships":{"offences":{"data":[{"id":"5aff5a05-8f43-40e0-82e6-08c658ffca00","type":"offences"}]}}},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants","attributes":{"first_name":"Aracely","last_name":"Zulauf","date_of_birth":"1955-09-27","national_insurance_number":"HH481835D","gender":null,"address_1":null,"address_2":null,"address_3":null,"address_4":null,"address_5":null,"postcode":null},"relationships":{"offences":{"data":[{"id":"0fcb44b6-1ca7-4360-b6ed-1d57ff9423e0","type":"offences"}]}}},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants","attributes":{"first_name":"Florene","last_name":"DuBuque","date_of_birth":"1983-10-17","national_insurance_number":"XE675428D","gender":null,"address_1":null,"address_2":null,"address_3":null,"address_4":null,"address_5":null,"postcode":null},"relationships":{"offences":{"data":[{"id":"45d5e934-72d0-4a14-b43c-cad750d4ff3c","type":"offences"}]}}},{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants","attributes":{"first_name":"Josefa","last_name":"Franecki","date_of_birth":"1961-06-15","national_insurance_number":"HR669639M","gender":null,"address_1":null,"address_2":null,"address_3":null,"address_4":null,"address_5":null,"postcode":null},"relationships":{"offences":{"data":[{"id":"6de5bcf7-c3bd-47cd-9c74-a79d06aaf3dc","type":"offences"}]}}}]}'
+      string: '{"data":[{"id":"2dc8dd46-d930-4878-a0a6-68ae8642cd9e","type":"prosecution_cases","attributes":{"prosecution_case_reference":"MOGUERBXIZ"},"relationships":{"defendants":{"data":[{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants"},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants"},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants"},{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants"}]}}}],"included":[{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants","attributes":{"first_name":"Andy","last_name":"Sawayn","date_of_birth":"1987-10-19","national_insurance_number":"EA382617F","arrest_summons_number":"KX5SWEFJQ3DL","is_linked":false},"relationships":{"offences":{"data":[{"id":"5aff5a05-8f43-40e0-82e6-08c658ffca00","type":"offences"}]}}},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants","attributes":{"first_name":"Aracely","last_name":"Zulauf","date_of_birth":"1955-09-27","national_insurance_number":"HH481835D","arrest_summons_number":"F79K0TDDZK40","is_linked":false},"relationships":{"offences":{"data":[{"id":"0fcb44b6-1ca7-4360-b6ed-1d57ff9423e0","type":"offences"}]}}},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants","attributes":{"first_name":"Florene","last_name":"DuBuque","date_of_birth":"1983-10-17","national_insurance_number":"XE675428D","arrest_summons_number":"C2ZXXPBNGVR0","is_linked":false},"relationships":{"offences":{"data":[{"id":"45d5e934-72d0-4a14-b43c-cad750d4ff3c","type":"offences"}]}}},{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants","attributes":{"first_name":"Josefa","last_name":"Franecki","date_of_birth":"1961-06-15","national_insurance_number":"HR669639D","arrest_summons_number":"Y1NDQNW9NCN6","is_linked":false},"relationships":{"offences":{"data":[{"id":"6de5bcf7-c3bd-47cd-9c74-a79d06aaf3dc","type":"offences"}]}}}]}'
     http_version: null
-  recorded_at: Sat, 29 Feb 2020 17:19:39 GMT
+  recorded_at: Thu, 26 Mar 2020 14:57:38 GMT
 recorded_with: VCR 5.1.0

--- a/spec/fixtures/vcr_cassettes/spec/requests/defendants_spec.yml
+++ b/spec/fixtures/vcr_cassettes/spec/requests/defendants_spec.yml
@@ -14,7 +14,7 @@ http_interactions:
       Accept:
       - application/vnd.api+json
       Authorization:
-      - Bearer tlB1q3ZGNw4KrV9QOeHWZ0w3iSGRp-KaU-PtJkkVYZc
+      - Bearer <BEARER_TOKEN>
       Accept-Encoding:
       - gzip,deflate
   response:
@@ -37,22 +37,27 @@ http_interactions:
       Content-Type:
       - application/vnd.api+json; charset=utf-8
       Etag:
-      - W/"38fadc840db745dcdfd2eea14fcf520c"
+      - W/"42fc0961f3c0970a0aff2edb0cf75876"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 39fda57a-e92a-4f4e-9ac2-acd006537661
+      - 17445429-d9bf-445a-80e1-eb88c3d0c48c
       X-Runtime:
-      - '0.086128'
-      Transfer-Encoding:
-      - chunked
+      - '0.140090'
+      Content-Length:
+      - '5719'
     body:
       encoding: UTF-8
-      string: '{"data":[{"id":"2dc8dd46-d930-4878-a0a6-68ae8642cd9e","type":"prosecution_cases","attributes":{"prosecution_case_reference":"MOGUERBXIZ"},"relationships":{"defendants":{"data":[{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants"},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants"},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants"},{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants"}]}}}],"included":[{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants","attributes":{"first_name":"Josefa","last_name":"Franecki","date_of_birth":"1961-06-15","national_insurance_number":"HR669639D","arrest_summons_number":"Y1NDQNW9NCN6"},"relationships":{"offences":{"data":[{"id":"6de5bcf7-c3bd-47cd-9c74-a79d06aaf3dc","type":"offences"}]}}},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants","attributes":{"first_name":"Florene","last_name":"DuBuque","date_of_birth":"1983-10-17","national_insurance_number":"XE675428D","arrest_summons_number":"C2ZXXPBNGVR0"},"relationships":{"offences":{"data":[{"id":"45d5e934-72d0-4a14-b43c-cad750d4ff3c","type":"offences"}]}}},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants","attributes":{"first_name":"Aracely","last_name":"Zulauf","date_of_birth":"1955-09-27","national_insurance_number":"HH481835D","arrest_summons_number":"F79K0TDDZK40"},"relationships":{"offences":{"data":[{"id":"0fcb44b6-1ca7-4360-b6ed-1d57ff9423e0","type":"offences"}]}}},{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants","attributes":{"first_name":"Andy","last_name":"Sawayn","date_of_birth":"1987-10-19","national_insurance_number":"EA382617F","arrest_summons_number":"KX5SWEFJQ3DL"},"relationships":{"offences":{"data":[{"id":"5aff5a05-8f43-40e0-82e6-08c658ffca00","type":"offences"}]}}},{"id":"6de5bcf7-c3bd-47cd-9c74-a79d06aaf3dc","type":"offences","attributes":{"code":"Random
-        string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"45d5e934-72d0-4a14-b43c-cad750d4ff3c","type":"offences","attributes":{"code":"Random
+      string: '{"data":[{"id":"2dc8dd46-d930-4878-a0a6-68ae8642cd9e","type":"prosecution_cases","attributes":{"prosecution_case_reference":"MOGUERBXIZ"},"relationships":{"defendants":{"data":[{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants"},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants"},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants"},{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants"}]}}},{"id":"45181ba4-0230-4d76-bd1f-8dd283cc2504","type":"prosecution_cases","attributes":{"prosecution_case_reference":"LJSQNTUNNC"},"relationships":{"defendants":{"data":[{"id":"2f7fd30b-3bff-4493-bc0f-254e2bd71734","type":"defendants"},{"id":"1ed04150-0dd8-45a0-80cf-29f0dcf104b5","type":"defendants"},{"id":"e6d2dd73-b95b-4f98-a1ac-795c181791fe","type":"defendants"},{"id":"a21d8531-5eaf-42df-8dc5-348bbd071f07","type":"defendants"},{"id":"9ad9161f-776d-4139-bd0a-e4d5c0650305","type":"defendants"}]}}}],"included":[{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants","attributes":{"first_name":"Andy","last_name":"Sawayn","date_of_birth":"1987-10-19","national_insurance_number":"EA382617F","arrest_summons_number":"KX5SWEFJQ3DL","is_linked":false},"relationships":{"offences":{"data":[{"id":"5aff5a05-8f43-40e0-82e6-08c658ffca00","type":"offences"}]}}},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants","attributes":{"first_name":"Aracely","last_name":"Zulauf","date_of_birth":"1955-09-27","national_insurance_number":"HH481835D","arrest_summons_number":"F79K0TDDZK40","is_linked":false},"relationships":{"offences":{"data":[{"id":"0fcb44b6-1ca7-4360-b6ed-1d57ff9423e0","type":"offences"}]}}},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants","attributes":{"first_name":"Florene","last_name":"DuBuque","date_of_birth":"1983-10-17","national_insurance_number":"XE675428D","arrest_summons_number":"C2ZXXPBNGVR0","is_linked":false},"relationships":{"offences":{"data":[{"id":"45d5e934-72d0-4a14-b43c-cad750d4ff3c","type":"offences"}]}}},{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants","attributes":{"first_name":"Josefa","last_name":"Franecki","date_of_birth":"1961-06-15","national_insurance_number":"HR669639D","arrest_summons_number":"Y1NDQNW9NCN6","is_linked":false},"relationships":{"offences":{"data":[{"id":"6de5bcf7-c3bd-47cd-9c74-a79d06aaf3dc","type":"offences"}]}}},{"id":"5aff5a05-8f43-40e0-82e6-08c658ffca00","type":"offences","attributes":{"code":"Random
         string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"0fcb44b6-1ca7-4360-b6ed-1d57ff9423e0","type":"offences","attributes":{"code":"Random
-        string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"5aff5a05-8f43-40e0-82e6-08c658ffca00","type":"offences","attributes":{"code":"Random
+        string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"45d5e934-72d0-4a14-b43c-cad750d4ff3c","type":"offences","attributes":{"code":"Random
+        string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"6de5bcf7-c3bd-47cd-9c74-a79d06aaf3dc","type":"offences","attributes":{"code":"Random
+        string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"2f7fd30b-3bff-4493-bc0f-254e2bd71734","type":"defendants","attributes":{"first_name":"Marion","last_name":"Swift","date_of_birth":"1999-12-30","national_insurance_number":"GX188228C","arrest_summons_number":"N80TNY2CGZGV","is_linked":false},"relationships":{"offences":{"data":[{"id":"f651b45d-5968-4d6b-b615-6f74c1050ca9","type":"offences"}]}}},{"id":"1ed04150-0dd8-45a0-80cf-29f0dcf104b5","type":"defendants","attributes":{"first_name":"Russell","last_name":"Waters","date_of_birth":"1986-12-14","national_insurance_number":"GP592510D","arrest_summons_number":"JRUG82AGN111","is_linked":false},"relationships":{"offences":{"data":[{"id":"15d01c69-e9ee-4243-8398-376b64cff0cb","type":"offences"}]}}},{"id":"e6d2dd73-b95b-4f98-a1ac-795c181791fe","type":"defendants","attributes":{"first_name":"Jolynn","last_name":"Schinner","date_of_birth":"1991-03-01","national_insurance_number":"YE744478B","arrest_summons_number":"A5W1R4OGUX7C","is_linked":false},"relationships":{"offences":{"data":[{"id":"c7726d30-dda1-4b19-8f62-f06529197da3","type":"offences"}]}}},{"id":"a21d8531-5eaf-42df-8dc5-348bbd071f07","type":"defendants","attributes":{"first_name":"Quincy","last_name":"O''Kon","date_of_birth":"1993-09-02","national_insurance_number":"GP181930B","arrest_summons_number":"GFNBCQEY8RBP","is_linked":false},"relationships":{"offences":{"data":[{"id":"d250b0f1-c89c-4715-889e-46045e164753","type":"offences"}]}}},{"id":"9ad9161f-776d-4139-bd0a-e4d5c0650305","type":"defendants","attributes":{"first_name":"Josefa","last_name":"Franecki","date_of_birth":"1961-06-15","national_insurance_number":"HR669639D","arrest_summons_number":"Y1NDQNW9NCN6","is_linked":false},"relationships":{"offences":{"data":[{"id":"28689c87-c6da-4fdf-9b69-ac763fd7fc7a","type":"offences"}]}}},{"id":"f651b45d-5968-4d6b-b615-6f74c1050ca9","type":"offences","attributes":{"code":"Random
+        string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"15d01c69-e9ee-4243-8398-376b64cff0cb","type":"offences","attributes":{"code":"Random
+        string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"c7726d30-dda1-4b19-8f62-f06529197da3","type":"offences","attributes":{"code":"Random
+        string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"d250b0f1-c89c-4715-889e-46045e164753","type":"offences","attributes":{"code":"Random
+        string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"28689c87-c6da-4fdf-9b69-ac763fd7fc7a","type":"offences","attributes":{"code":"Random
         string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}}]}'
     http_version: null
-  recorded_at: Thu, 12 Mar 2020 16:24:26 GMT
+  recorded_at: Thu, 26 Mar 2020 14:57:40 GMT
 recorded_with: VCR 5.1.0

--- a/spec/fixtures/vcr_cassettes/spec/requests/prosecution_cases_spec.yml
+++ b/spec/fixtures/vcr_cassettes/spec/requests/prosecution_cases_spec.yml
@@ -14,7 +14,7 @@ http_interactions:
       Accept:
       - application/vnd.api+json
       Authorization:
-      - Bearer ixMrUCwj00skKyDjqo4Npt_cn3MhUE71Ex3Q9qwJh-Y
+      - Bearer <BEARER_TOKEN>
       Accept-Encoding:
       - gzip,deflate
   response:
@@ -37,18 +37,18 @@ http_interactions:
       Content-Type:
       - application/vnd.api+json; charset=utf-8
       Etag:
-      - W/"6f63d14d3c99469f169456298e96ba3d"
+      - W/"7497a3636a45f300c84f93f31487f802"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - aedc1525-badd-4427-b5cc-d9e92df5aafa
+      - d8cf2f0b-6288-4e9c-9c04-bca102879108
       X-Runtime:
-      - '0.093920'
-      Transfer-Encoding:
-      - chunked
+      - '0.090794'
+      Content-Length:
+      - '1878'
     body:
       encoding: UTF-8
-      string: '{"data":[{"id":"2dc8dd46-d930-4878-a0a6-68ae8642cd9e","type":"prosecution_cases","attributes":{"prosecution_case_reference":"MOGUERBXIZ"},"relationships":{"defendants":{"data":[{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants"},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants"},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants"},{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants"}]}}}],"included":[{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants","attributes":{"first_name":"Josefa","last_name":"Franecki","date_of_birth":"1961-06-15","national_insurance_number":"HR669639D","arrest_summons_number":"Y1NDQNW9NCN6"},"relationships":{"offences":{"data":[{"id":"6de5bcf7-c3bd-47cd-9c74-a79d06aaf3dc","type":"offences"}]}}},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants","attributes":{"first_name":"Florene","last_name":"DuBuque","date_of_birth":"1983-10-17","national_insurance_number":"XE675428D","arrest_summons_number":"C2ZXXPBNGVR0"},"relationships":{"offences":{"data":[{"id":"45d5e934-72d0-4a14-b43c-cad750d4ff3c","type":"offences"}]}}},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants","attributes":{"first_name":"Aracely","last_name":"Zulauf","date_of_birth":"1955-09-27","national_insurance_number":"HH481835D","arrest_summons_number":"F79K0TDDZK40"},"relationships":{"offences":{"data":[{"id":"0fcb44b6-1ca7-4360-b6ed-1d57ff9423e0","type":"offences"}]}}},{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants","attributes":{"first_name":"Andy","last_name":"Sawayn","date_of_birth":"1987-10-19","national_insurance_number":"EA382617F","arrest_summons_number":"KX5SWEFJQ3DL"},"relationships":{"offences":{"data":[{"id":"5aff5a05-8f43-40e0-82e6-08c658ffca00","type":"offences"}]}}}]}'
+      string: '{"data":[{"id":"2dc8dd46-d930-4878-a0a6-68ae8642cd9e","type":"prosecution_cases","attributes":{"prosecution_case_reference":"MOGUERBXIZ"},"relationships":{"defendants":{"data":[{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants"},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants"},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants"},{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants"}]}}}],"included":[{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants","attributes":{"first_name":"Andy","last_name":"Sawayn","date_of_birth":"1987-10-19","national_insurance_number":"EA382617F","arrest_summons_number":"KX5SWEFJQ3DL","is_linked":false},"relationships":{"offences":{"data":[{"id":"5aff5a05-8f43-40e0-82e6-08c658ffca00","type":"offences"}]}}},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants","attributes":{"first_name":"Aracely","last_name":"Zulauf","date_of_birth":"1955-09-27","national_insurance_number":"HH481835D","arrest_summons_number":"F79K0TDDZK40","is_linked":false},"relationships":{"offences":{"data":[{"id":"0fcb44b6-1ca7-4360-b6ed-1d57ff9423e0","type":"offences"}]}}},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants","attributes":{"first_name":"Florene","last_name":"DuBuque","date_of_birth":"1983-10-17","national_insurance_number":"XE675428D","arrest_summons_number":"C2ZXXPBNGVR0","is_linked":false},"relationships":{"offences":{"data":[{"id":"45d5e934-72d0-4a14-b43c-cad750d4ff3c","type":"offences"}]}}},{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants","attributes":{"first_name":"Josefa","last_name":"Franecki","date_of_birth":"1961-06-15","national_insurance_number":"HR669639D","arrest_summons_number":"Y1NDQNW9NCN6","is_linked":false},"relationships":{"offences":{"data":[{"id":"6de5bcf7-c3bd-47cd-9c74-a79d06aaf3dc","type":"offences"}]}}}]}'
     http_version: null
-  recorded_at: Thu, 12 Mar 2020 16:42:41 GMT
+  recorded_at: Thu, 26 Mar 2020 14:57:41 GMT
 recorded_with: VCR 5.1.0

--- a/spec/fixtures/vcr_cassettes/spec/requests/search/case_reference_spec.yml
+++ b/spec/fixtures/vcr_cassettes/spec/requests/search/case_reference_spec.yml
@@ -14,7 +14,7 @@ http_interactions:
       Accept:
       - application/vnd.api+json
       Authorization:
-      - Bearer pd6u5q4Z3fD97F5TXkrBalBlTOKFcdOgi4XC2L6zzig
+      - Bearer <BEARER_TOKEN>
       Accept-Encoding:
       - gzip,deflate
   response:
@@ -37,18 +37,18 @@ http_interactions:
       Content-Type:
       - application/vnd.api+json; charset=utf-8
       Etag:
-      - W/"6f63d14d3c99469f169456298e96ba3d"
+      - W/"7497a3636a45f300c84f93f31487f802"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 5c9c0aa1-09d7-4ed3-9593-1484f3d76b13
+      - 1b15a219-7cda-46cd-8240-fa5b5d2f6293
       X-Runtime:
-      - '0.096533'
-      Transfer-Encoding:
-      - chunked
+      - '0.074334'
+      Content-Length:
+      - '1878'
     body:
       encoding: UTF-8
-      string: '{"data":[{"id":"2dc8dd46-d930-4878-a0a6-68ae8642cd9e","type":"prosecution_cases","attributes":{"prosecution_case_reference":"MOGUERBXIZ"},"relationships":{"defendants":{"data":[{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants"},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants"},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants"},{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants"}]}}}],"included":[{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants","attributes":{"first_name":"Josefa","last_name":"Franecki","date_of_birth":"1961-06-15","national_insurance_number":"HR669639D","arrest_summons_number":"Y1NDQNW9NCN6"},"relationships":{"offences":{"data":[{"id":"6de5bcf7-c3bd-47cd-9c74-a79d06aaf3dc","type":"offences"}]}}},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants","attributes":{"first_name":"Florene","last_name":"DuBuque","date_of_birth":"1983-10-17","national_insurance_number":"XE675428D","arrest_summons_number":"C2ZXXPBNGVR0"},"relationships":{"offences":{"data":[{"id":"45d5e934-72d0-4a14-b43c-cad750d4ff3c","type":"offences"}]}}},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants","attributes":{"first_name":"Aracely","last_name":"Zulauf","date_of_birth":"1955-09-27","national_insurance_number":"HH481835D","arrest_summons_number":"F79K0TDDZK40"},"relationships":{"offences":{"data":[{"id":"0fcb44b6-1ca7-4360-b6ed-1d57ff9423e0","type":"offences"}]}}},{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants","attributes":{"first_name":"Andy","last_name":"Sawayn","date_of_birth":"1987-10-19","national_insurance_number":"EA382617F","arrest_summons_number":"KX5SWEFJQ3DL"},"relationships":{"offences":{"data":[{"id":"5aff5a05-8f43-40e0-82e6-08c658ffca00","type":"offences"}]}}}]}'
+      string: '{"data":[{"id":"2dc8dd46-d930-4878-a0a6-68ae8642cd9e","type":"prosecution_cases","attributes":{"prosecution_case_reference":"MOGUERBXIZ"},"relationships":{"defendants":{"data":[{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants"},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants"},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants"},{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants"}]}}}],"included":[{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants","attributes":{"first_name":"Andy","last_name":"Sawayn","date_of_birth":"1987-10-19","national_insurance_number":"EA382617F","arrest_summons_number":"KX5SWEFJQ3DL","is_linked":false},"relationships":{"offences":{"data":[{"id":"5aff5a05-8f43-40e0-82e6-08c658ffca00","type":"offences"}]}}},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants","attributes":{"first_name":"Aracely","last_name":"Zulauf","date_of_birth":"1955-09-27","national_insurance_number":"HH481835D","arrest_summons_number":"F79K0TDDZK40","is_linked":false},"relationships":{"offences":{"data":[{"id":"0fcb44b6-1ca7-4360-b6ed-1d57ff9423e0","type":"offences"}]}}},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants","attributes":{"first_name":"Florene","last_name":"DuBuque","date_of_birth":"1983-10-17","national_insurance_number":"XE675428D","arrest_summons_number":"C2ZXXPBNGVR0","is_linked":false},"relationships":{"offences":{"data":[{"id":"45d5e934-72d0-4a14-b43c-cad750d4ff3c","type":"offences"}]}}},{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants","attributes":{"first_name":"Josefa","last_name":"Franecki","date_of_birth":"1961-06-15","national_insurance_number":"HR669639D","arrest_summons_number":"Y1NDQNW9NCN6","is_linked":false},"relationships":{"offences":{"data":[{"id":"6de5bcf7-c3bd-47cd-9c74-a79d06aaf3dc","type":"offences"}]}}}]}'
     http_version: null
-  recorded_at: Tue, 10 Mar 2020 17:43:26 GMT
+  recorded_at: Thu, 26 Mar 2020 14:57:42 GMT
 recorded_with: VCR 5.1.0

--- a/spec/fixtures/vcr_cassettes/spec/requests/search/defendant_by_name_spec.yml
+++ b/spec/fixtures/vcr_cassettes/spec/requests/search/defendant_by_name_spec.yml
@@ -14,7 +14,7 @@ http_interactions:
       Accept:
       - application/vnd.api+json
       Authorization:
-      - Bearer Tyccu9txytAQ1u2yDjszQqJoTanImPElFOakFKRQKyI
+      - Bearer <BEARER_TOKEN>
       Accept-Encoding:
       - gzip,deflate
   response:
@@ -37,18 +37,18 @@ http_interactions:
       Content-Type:
       - application/vnd.api+json; charset=utf-8
       Etag:
-      - W/"20d4caa56eb85af31b2ccd5901fcd779"
+      - W/"aaa825417c06a05d5b625f1a83a3c925"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 94d7553d-be98-4612-8cd0-e366d97e91a4
+      - 56c693d9-f399-490f-8e74-5023de2c8ee4
       X-Runtime:
-      - '0.090327'
-      Transfer-Encoding:
-      - chunked
+      - '0.142222'
+      Content-Length:
+      - '4153'
     body:
       encoding: UTF-8
-      string: '{"data":[{"id":"2dc8dd46-d930-4878-a0a6-68ae8642cd9e","type":"prosecution_cases","attributes":{"prosecution_case_reference":"MOGUERBXIZ"},"relationships":{"defendants":{"data":[{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants"},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants"},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants"},{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants"}]}}}],"included":[{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants","attributes":{"first_name":"Josefa","last_name":"Franecki","date_of_birth":"1961-06-15","national_insurance_number":"HR669639M","arrest_summons_number":"Y1NDQNW9NCN6"},"relationships":{"offences":{"data":[{"id":"6de5bcf7-c3bd-47cd-9c74-a79d06aaf3dc","type":"offences"}]}}},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants","attributes":{"first_name":"Florene","last_name":"DuBuque","date_of_birth":"1983-10-17","national_insurance_number":"XE675428D","arrest_summons_number":"C2ZXXPBNGVR0"},"relationships":{"offences":{"data":[{"id":"45d5e934-72d0-4a14-b43c-cad750d4ff3c","type":"offences"}]}}},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants","attributes":{"first_name":"Aracely","last_name":"Zulauf","date_of_birth":"1955-09-27","national_insurance_number":"HH481835D","arrest_summons_number":"F79K0TDDZK40"},"relationships":{"offences":{"data":[{"id":"0fcb44b6-1ca7-4360-b6ed-1d57ff9423e0","type":"offences"}]}}},{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants","attributes":{"first_name":"Andy","last_name":"Sawayn","date_of_birth":"1987-10-19","national_insurance_number":"EA382617F","arrest_summons_number":"KX5SWEFJQ3DL"},"relationships":{"offences":{"data":[{"id":"5aff5a05-8f43-40e0-82e6-08c658ffca00","type":"offences"}]}}}]}'
+      string: '{"data":[{"id":"2dc8dd46-d930-4878-a0a6-68ae8642cd9e","type":"prosecution_cases","attributes":{"prosecution_case_reference":"MOGUERBXIZ"},"relationships":{"defendants":{"data":[{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants"},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants"},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants"},{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants"}]}}},{"id":"45181ba4-0230-4d76-bd1f-8dd283cc2504","type":"prosecution_cases","attributes":{"prosecution_case_reference":"LJSQNTUNNC"},"relationships":{"defendants":{"data":[{"id":"2f7fd30b-3bff-4493-bc0f-254e2bd71734","type":"defendants"},{"id":"1ed04150-0dd8-45a0-80cf-29f0dcf104b5","type":"defendants"},{"id":"e6d2dd73-b95b-4f98-a1ac-795c181791fe","type":"defendants"},{"id":"a21d8531-5eaf-42df-8dc5-348bbd071f07","type":"defendants"},{"id":"9ad9161f-776d-4139-bd0a-e4d5c0650305","type":"defendants"}]}}}],"included":[{"id":"9eb614c4-3c3c-42ee-aa2e-80971dfbc4f9","type":"defendants","attributes":{"first_name":"Andy","last_name":"Sawayn","date_of_birth":"1987-10-19","national_insurance_number":"EA382617F","arrest_summons_number":"KX5SWEFJQ3DL","is_linked":false},"relationships":{"offences":{"data":[{"id":"5aff5a05-8f43-40e0-82e6-08c658ffca00","type":"offences"}]}}},{"id":"121cba19-de86-470d-8903-946423684587","type":"defendants","attributes":{"first_name":"Aracely","last_name":"Zulauf","date_of_birth":"1955-09-27","national_insurance_number":"HH481835D","arrest_summons_number":"F79K0TDDZK40","is_linked":false},"relationships":{"offences":{"data":[{"id":"0fcb44b6-1ca7-4360-b6ed-1d57ff9423e0","type":"offences"}]}}},{"id":"e695c7d3-64b4-4acf-a55e-5dac7c91ec13","type":"defendants","attributes":{"first_name":"Florene","last_name":"DuBuque","date_of_birth":"1983-10-17","national_insurance_number":"XE675428D","arrest_summons_number":"C2ZXXPBNGVR0","is_linked":false},"relationships":{"offences":{"data":[{"id":"45d5e934-72d0-4a14-b43c-cad750d4ff3c","type":"offences"}]}}},{"id":"107ba90b-f3ff-4727-ab7d-dea446ad4713","type":"defendants","attributes":{"first_name":"Josefa","last_name":"Franecki","date_of_birth":"1961-06-15","national_insurance_number":"HR669639D","arrest_summons_number":"Y1NDQNW9NCN6","is_linked":false},"relationships":{"offences":{"data":[{"id":"6de5bcf7-c3bd-47cd-9c74-a79d06aaf3dc","type":"offences"}]}}},{"id":"2f7fd30b-3bff-4493-bc0f-254e2bd71734","type":"defendants","attributes":{"first_name":"Marion","last_name":"Swift","date_of_birth":"1999-12-30","national_insurance_number":"GX188228C","arrest_summons_number":"N80TNY2CGZGV","is_linked":false},"relationships":{"offences":{"data":[{"id":"f651b45d-5968-4d6b-b615-6f74c1050ca9","type":"offences"}]}}},{"id":"1ed04150-0dd8-45a0-80cf-29f0dcf104b5","type":"defendants","attributes":{"first_name":"Russell","last_name":"Waters","date_of_birth":"1986-12-14","national_insurance_number":"GP592510D","arrest_summons_number":"JRUG82AGN111","is_linked":false},"relationships":{"offences":{"data":[{"id":"15d01c69-e9ee-4243-8398-376b64cff0cb","type":"offences"}]}}},{"id":"e6d2dd73-b95b-4f98-a1ac-795c181791fe","type":"defendants","attributes":{"first_name":"Jolynn","last_name":"Schinner","date_of_birth":"1991-03-01","national_insurance_number":"YE744478B","arrest_summons_number":"A5W1R4OGUX7C","is_linked":false},"relationships":{"offences":{"data":[{"id":"c7726d30-dda1-4b19-8f62-f06529197da3","type":"offences"}]}}},{"id":"a21d8531-5eaf-42df-8dc5-348bbd071f07","type":"defendants","attributes":{"first_name":"Quincy","last_name":"O''Kon","date_of_birth":"1993-09-02","national_insurance_number":"GP181930B","arrest_summons_number":"GFNBCQEY8RBP","is_linked":false},"relationships":{"offences":{"data":[{"id":"d250b0f1-c89c-4715-889e-46045e164753","type":"offences"}]}}},{"id":"9ad9161f-776d-4139-bd0a-e4d5c0650305","type":"defendants","attributes":{"first_name":"Josefa","last_name":"Franecki","date_of_birth":"1961-06-15","national_insurance_number":"HR669639D","arrest_summons_number":"Y1NDQNW9NCN6","is_linked":false},"relationships":{"offences":{"data":[{"id":"28689c87-c6da-4fdf-9b69-ac763fd7fc7a","type":"offences"}]}}}]}'
     http_version: null
-  recorded_at: Mon, 09 Mar 2020 11:56:40 GMT
+  recorded_at: Thu, 26 Mar 2020 14:57:44 GMT
 recorded_with: VCR 5.1.0

--- a/spec/fixtures/vcr_cassettes/spec/requests/search/defendant_by_reference_spec.yml
+++ b/spec/fixtures/vcr_cassettes/spec/requests/search/defendant_by_reference_spec.yml
@@ -14,7 +14,7 @@ http_interactions:
       Accept:
       - application/vnd.api+json
       Authorization:
-      - Bearer M7zYuvcFnAzfc9OP1oZAuM2z2AAv8LqUmDVrvbBOcwU
+      - Bearer <BEARER_TOKEN>
       Accept-Encoding:
       - gzip,deflate
   response:
@@ -37,22 +37,23 @@ http_interactions:
       Content-Type:
       - application/vnd.api+json; charset=utf-8
       Etag:
-      - W/"6016f43e07dcbd2f4f5aa8a4c974f38d"
+      - W/"65bb9d9f1853b6a4ecb2d3786a645e99"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - df247e84-6780-45df-8bf1-18c98d2d60cd
+      - 4b1e893c-7886-4390-ba2e-fd1484b893a9
       X-Runtime:
-      - '0.072983'
-      Transfer-Encoding:
-      - chunked
+      - '0.085150'
+      Content-Length:
+      - '3168'
     body:
       encoding: UTF-8
-      string: '{"data":[{"id":"45181ba4-0230-4d76-bd1f-8dd283cc2504","type":"prosecution_cases","attributes":{"prosecution_case_reference":"LJSQNTUNNC"},"relationships":{"defendants":{"data":[{"id":"a21d8531-5eaf-42df-8dc5-348bbd071f07","type":"defendants"},{"id":"e6d2dd73-b95b-4f98-a1ac-795c181791fe","type":"defendants"},{"id":"1ed04150-0dd8-45a0-80cf-29f0dcf104b5","type":"defendants"},{"id":"2f7fd30b-3bff-4493-bc0f-254e2bd71734","type":"defendants"}]}}}],"included":[{"id":"a21d8531-5eaf-42df-8dc5-348bbd071f07","type":"defendants","attributes":{"first_name":"Quincy","last_name":"O''Kon","date_of_birth":"1993-09-02","national_insurance_number":"GP181930B","arrest_summons_number":"GFNBCQEY8RBP"},"relationships":{"offences":{"data":[{"id":"d250b0f1-c89c-4715-889e-46045e164753","type":"offences"}]}}},{"id":"e6d2dd73-b95b-4f98-a1ac-795c181791fe","type":"defendants","attributes":{"first_name":"Jolynn","last_name":"Schinner","date_of_birth":"1991-03-01","national_insurance_number":"YE744478B","arrest_summons_number":"A5W1R4OGUX7C"},"relationships":{"offences":{"data":[{"id":"c7726d30-dda1-4b19-8f62-f06529197da3","type":"offences"}]}}},{"id":"1ed04150-0dd8-45a0-80cf-29f0dcf104b5","type":"defendants","attributes":{"first_name":"Russell","last_name":"Waters","date_of_birth":"1986-12-14","national_insurance_number":"GP592510D","arrest_summons_number":"JRUG82AGN111"},"relationships":{"offences":{"data":[{"id":"15d01c69-e9ee-4243-8398-376b64cff0cb","type":"offences"}]}}},{"id":"2f7fd30b-3bff-4493-bc0f-254e2bd71734","type":"defendants","attributes":{"first_name":"Marion","last_name":"Swift","date_of_birth":"1999-12-30","national_insurance_number":"GX188228C","arrest_summons_number":"N80TNY2CGZGV"},"relationships":{"offences":{"data":[{"id":"f651b45d-5968-4d6b-b615-6f74c1050ca9","type":"offences"}]}}},{"id":"d250b0f1-c89c-4715-889e-46045e164753","type":"offences","attributes":{"code":"Random
-        string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"c7726d30-dda1-4b19-8f62-f06529197da3","type":"offences","attributes":{"code":"Random
+      string: '{"data":[{"id":"45181ba4-0230-4d76-bd1f-8dd283cc2504","type":"prosecution_cases","attributes":{"prosecution_case_reference":"LJSQNTUNNC"},"relationships":{"defendants":{"data":[{"id":"2f7fd30b-3bff-4493-bc0f-254e2bd71734","type":"defendants"},{"id":"1ed04150-0dd8-45a0-80cf-29f0dcf104b5","type":"defendants"},{"id":"e6d2dd73-b95b-4f98-a1ac-795c181791fe","type":"defendants"},{"id":"a21d8531-5eaf-42df-8dc5-348bbd071f07","type":"defendants"},{"id":"9ad9161f-776d-4139-bd0a-e4d5c0650305","type":"defendants"}]}}}],"included":[{"id":"2f7fd30b-3bff-4493-bc0f-254e2bd71734","type":"defendants","attributes":{"first_name":"Marion","last_name":"Swift","date_of_birth":"1999-12-30","national_insurance_number":"GX188228C","arrest_summons_number":"N80TNY2CGZGV","is_linked":false},"relationships":{"offences":{"data":[{"id":"f651b45d-5968-4d6b-b615-6f74c1050ca9","type":"offences"}]}}},{"id":"1ed04150-0dd8-45a0-80cf-29f0dcf104b5","type":"defendants","attributes":{"first_name":"Russell","last_name":"Waters","date_of_birth":"1986-12-14","national_insurance_number":"GP592510D","arrest_summons_number":"JRUG82AGN111","is_linked":false},"relationships":{"offences":{"data":[{"id":"15d01c69-e9ee-4243-8398-376b64cff0cb","type":"offences"}]}}},{"id":"e6d2dd73-b95b-4f98-a1ac-795c181791fe","type":"defendants","attributes":{"first_name":"Jolynn","last_name":"Schinner","date_of_birth":"1991-03-01","national_insurance_number":"YE744478B","arrest_summons_number":"A5W1R4OGUX7C","is_linked":false},"relationships":{"offences":{"data":[{"id":"c7726d30-dda1-4b19-8f62-f06529197da3","type":"offences"}]}}},{"id":"a21d8531-5eaf-42df-8dc5-348bbd071f07","type":"defendants","attributes":{"first_name":"Quincy","last_name":"O''Kon","date_of_birth":"1993-09-02","national_insurance_number":"GP181930B","arrest_summons_number":"GFNBCQEY8RBP","is_linked":false},"relationships":{"offences":{"data":[{"id":"d250b0f1-c89c-4715-889e-46045e164753","type":"offences"}]}}},{"id":"9ad9161f-776d-4139-bd0a-e4d5c0650305","type":"defendants","attributes":{"first_name":"Josefa","last_name":"Franecki","date_of_birth":"1961-06-15","national_insurance_number":"HR669639D","arrest_summons_number":"Y1NDQNW9NCN6","is_linked":false},"relationships":{"offences":{"data":[{"id":"28689c87-c6da-4fdf-9b69-ac763fd7fc7a","type":"offences"}]}}},{"id":"f651b45d-5968-4d6b-b615-6f74c1050ca9","type":"offences","attributes":{"code":"Random
         string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"15d01c69-e9ee-4243-8398-376b64cff0cb","type":"offences","attributes":{"code":"Random
-        string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"f651b45d-5968-4d6b-b615-6f74c1050ca9","type":"offences","attributes":{"code":"Random
+        string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"c7726d30-dda1-4b19-8f62-f06529197da3","type":"offences","attributes":{"code":"Random
+        string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"d250b0f1-c89c-4715-889e-46045e164753","type":"offences","attributes":{"code":"Random
+        string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}},{"id":"28689c87-c6da-4fdf-9b69-ac763fd7fc7a","type":"offences","attributes":{"code":"Random
         string","order_index":1,"title":"Random string","mode_of_trial":"Random string"}}]}'
     http_version: null
-  recorded_at: Thu, 12 Mar 2020 09:58:49 GMT
+  recorded_at: Thu, 26 Mar 2020 14:57:45 GMT
 recorded_with: VCR 5.1.0

--- a/spec/lib/court_data_adaptor/resource/defendant_spec.rb
+++ b/spec/lib/court_data_adaptor/resource/defendant_spec.rb
@@ -31,4 +31,32 @@ RSpec.describe CourtDataAdaptor::Resource::Defendant do
       end
     end
   end
+
+  describe '#linked?' do
+    subject { defendant.linked? }
+
+    context 'when is_linked true' do
+      let(:defendant) { described_class.load(is_linked: true) }
+
+      it { is_expected.to be_truthy }
+    end
+
+    context 'when is_linked false' do
+      let(:defendant) { described_class.load(is_linked: false) }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context 'when is_linked nil' do
+      let(:defendant) { described_class.load(is_linked: nil) }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context 'when is_linked not present' do
+      let(:defendant) { described_class.load(first_name: nil, last_name: nil) }
+
+      it { is_expected.to be_falsey }
+    end
+  end
 end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -2,7 +2,31 @@
 
 require 'cancan/matchers'
 
-RSpec.describe Ability, type: :model do
+RSpec.configure do |config|
+  config.alias_it_behaves_like_to :it_is_able_to, 'is able to'
+end
+
+RSpec.shared_examples 'perform search' do
+  it { is_expected.to be_able_to(%i[new create], SearchFilter) }
+  it { is_expected.to be_able_to(%i[new create], Search) }
+end
+
+RSpec.shared_examples 'manage themselves only' do
+  it { is_expected.to be_able_to(%i[show manage_password], themself) }
+  it { is_expected.not_to be_able_to(%i[edit update destroy], themself) }
+end
+
+RSpec.shared_examples 'not manage others' do
+  it {
+    is_expected.not_to \
+      be_able_to(
+        %i[show new create edit update manage_password destroy],
+        other_user
+      )
+  }
+end
+
+RSpec.fdescribe Ability, type: :model do
   subject(:ability) { described_class.new(themself) }
 
   let(:other_user) { create(:user, roles: ['caseworker']) }
@@ -10,49 +34,32 @@ RSpec.describe Ability, type: :model do
   context 'when no user' do
     let(:themself) { nil }
 
+    it { is_expected.not_to be_able_to(:manage, User) }
     it { is_expected.not_to be_able_to(%i[new create], SearchFilter) }
     it { is_expected.not_to be_able_to(%i[new create], Search) }
-    it { is_expected.not_to be_able_to(:manage, User) }
   end
 
-  context 'when is a caseworker' do
+  context 'when a caseworker' do
     let(:themself) { create(:user, roles: ['caseworker']) }
 
-    it { is_expected.to be_able_to(%i[new create], SearchFilter) }
-    it { is_expected.to be_able_to(%i[new create], Search) }
-    it { is_expected.to be_able_to(%i[show manage_password], themself) }
-    it { is_expected.not_to be_able_to(%i[edit update destroy], themself) }
-
-    it {
-      is_expected.not_to \
-        be_able_to(
-          %i[show new create edit update manage_password destroy],
-          other_user
-        )
-    }
+    it_is_able_to 'manage themselves only'
+    it_is_able_to 'not manage others'
+    it_is_able_to 'perform search'
   end
 
-  context 'when is a manager' do
+  context 'when a manager' do
     let(:themself) { create(:user, roles: ['manager']) }
 
     it { is_expected.to be_able_to(:manage, themself) }
     it { is_expected.to be_able_to(:manage, other_user) }
+    it_is_able_to 'perform search'
   end
 
-  context 'when is an admin' do
+  context 'when an admin' do
     let(:themself) { create(:user, roles: ['admin']) }
 
-    it { is_expected.to be_able_to(%i[new create], SearchFilter) }
-    it { is_expected.to be_able_to(%i[new create], Search) }
-    it { is_expected.to be_able_to(%i[show manage_password], themself) }
-    it { is_expected.not_to be_able_to(%i[edit update destroy], themself) }
-
-    it {
-      is_expected.not_to \
-        be_able_to(
-          %i[show new create edit update manage_password destroy],
-          other_user
-        )
-    }
+    it_is_able_to 'manage themselves only'
+    it_is_able_to 'not manage others'
+    it_is_able_to 'perform search'
   end
 end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -3,12 +3,16 @@
 require 'cancan/matchers'
 
 RSpec.configure do |config|
-  config.alias_it_behaves_like_to :it_is_able_to, 'is able to'
+  config.alias_it_behaves_like_to :is_able_to, 'is able to'
 end
 
 RSpec.shared_examples 'perform search' do
   it { is_expected.to be_able_to(%i[new create], SearchFilter) }
   it { is_expected.to be_able_to(%i[new create], Search) }
+end
+
+RSpec.shared_examples 'link maat reference' do
+  it { is_expected.to be_able_to(:create, :link_maat_reference) }
 end
 
 RSpec.shared_examples 'manage themselves only' do
@@ -26,7 +30,8 @@ RSpec.shared_examples 'not manage others' do
   }
 end
 
-RSpec.fdescribe Ability, type: :model do
+# rubocop:disable RSpec/EmptyExampleGroup
+RSpec.describe Ability, type: :model do
   subject(:ability) { described_class.new(themself) }
 
   let(:other_user) { create(:user, roles: ['caseworker']) }
@@ -42,9 +47,10 @@ RSpec.fdescribe Ability, type: :model do
   context 'when a caseworker' do
     let(:themself) { create(:user, roles: ['caseworker']) }
 
-    it_is_able_to 'manage themselves only'
-    it_is_able_to 'not manage others'
-    it_is_able_to 'perform search'
+    is_able_to 'manage themselves only'
+    is_able_to 'not manage others'
+    is_able_to 'perform search'
+    is_able_to 'link maat reference'
   end
 
   context 'when a manager' do
@@ -52,14 +58,18 @@ RSpec.fdescribe Ability, type: :model do
 
     it { is_expected.to be_able_to(:manage, themself) }
     it { is_expected.to be_able_to(:manage, other_user) }
-    it_is_able_to 'perform search'
+
+    is_able_to 'perform search'
+    is_able_to 'link maat reference'
   end
 
   context 'when an admin' do
     let(:themself) { create(:user, roles: ['admin']) }
 
-    it_is_able_to 'manage themselves only'
-    it_is_able_to 'not manage others'
-    it_is_able_to 'perform search'
+    is_able_to 'manage themselves only'
+    is_able_to 'not manage others'
+    is_able_to 'perform search'
+    is_able_to 'link maat reference'
   end
 end
+# rubocop:enable RSpec/EmptyExampleGroup

--- a/spec/support/capybara_extensions.rb
+++ b/spec/support/capybara_extensions.rb
@@ -36,8 +36,15 @@ module CapybaraExtensions
     end
 
     def has_govuk_breadcrumb_link?(text = nil, options = {})
+      href = options.delete(:href)
       text ? options[:text] = text : options
-      has_selector?(breadcrumb_link_selector, options)
+      result = has_selector?(breadcrumb_link_selector, options)
+
+      if href
+        actual_href = find(breadcrumb_link_selector, text: text)['href']
+        result = CGI.unescape(href).eql?(CGI.unescape(actual_href))
+      end
+      result
     end
 
     private

--- a/spec/support/capybara_extensions.rb
+++ b/spec/support/capybara_extensions.rb
@@ -38,16 +38,20 @@ module CapybaraExtensions
     def has_govuk_breadcrumb_link?(text = nil, options = {})
       href = options.delete(:href)
       text ? options[:text] = text : options
-      result = has_selector?(breadcrumb_link_selector, options)
+      selector = options.delete(:aria_current) ? current_breadcrumb_link_selector : breadcrumb_link_selector
+      result = has_selector?(selector, options)
 
       if href
         actual_href = find(breadcrumb_link_selector, text: text)['href']
-        result = CGI.unescape(href).eql?(CGI.unescape(actual_href))
+        result = href_match?(href, actual_href)
       end
       result
     end
 
-    private
+    def href_match?(expected, actual)
+      return actual.match?(expected) if expected.is_a?(Regexp)
+      CGI.unescape(expected).eql?(CGI.unescape(actual))
+    end
 
     def breadcrumb_selector
       'div.govuk-breadcrumbs ol.govuk-breadcrumbs__list li.govuk-breadcrumbs__list-item'
@@ -57,8 +61,16 @@ module CapybaraExtensions
       "#{breadcrumb_selector}[aria-current=\"page\"]"
     end
 
+    def breadcrumb_link
+      'a.govuk-breadcrumbs__link'
+    end
+
     def breadcrumb_link_selector
-      "#{breadcrumb_selector} a.govuk-breadcrumbs__link"
+      "#{breadcrumb_selector} #{breadcrumb_link}"
+    end
+
+    def current_breadcrumb_link_selector
+      "#{breadcrumb_selector}[aria-current=\"page\"] #{breadcrumb_link}"
     end
   end
 end

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -4,12 +4,14 @@ VCR.configure do |config|
   config.cassette_library_dir = 'spec/fixtures/vcr_cassettes'
   config.hook_into :webmock
 
-  # Ignore requests to
-  # ignore/allow oauth requests
   # NOTE: CourtDataAdaptor.configuration.test_mode should be set
   # set to false when recording new stubs, true otherwise
+  #
+  # Ignore requests to:
+  # - ignore/allow oauth requests
   # - webdrivers
   # - chrome browser requests to localhost port on which it runs
+  #
   # Do not ignore requests to:
   # - CourtDataAdaptor API endpoints
 
@@ -27,6 +29,12 @@ VCR.configure do |config|
         (9515..9999).cover?(uri.port)
       ].all?
     ].any?
+  end
+
+  config.filter_sensitive_data('<BEARER_TOKEN>') do |interaction|
+    authorization_header = interaction.request.headers['Authorization'].first
+    a_match = authorization_header.match(/^Bearer\s+([^,\s]+)/)
+    a_match&.captures&.first
   end
 end
 


### PR DESCRIPTION
#### What
Enable users to view case and defendant details with breadcrumb navigation

#### Ticket

[CACP-251](https://dsdmoj.atlassian.net/browse/CACP-251)

#### Why
Inline with designs - to enable users to drill down their search

#### TODO

 - [X] update views inline with designs
 - [X] add GDS breadcrumbs
 - [X] add form (controller/view)
 - [x] retrieve linked status for defendant
