### PR TITLE
Add rubocop configuration for new cops in 0.81

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,6 +34,12 @@ Layout/LineLength:
   IgnoredPatterns: ['(\A|\s)#','.*\s+ # .*', "body: '{\".*\":"]
   AllowHeredoc: true
 
+Lint/RaiseException:
+  Enabled: true
+
+Lint/StructNewOverride:
+  Enabled: true
+
 Metrics/AbcSize:
   Exclude:
     - app/models/ability.rb


### PR DESCRIPTION
#### What
Enables new 0.81 cops: `Lint/RaiseException`, `Lint/StructNewOverride`

#### Why
Prevents warning below on running rubocop:
```
The following cops were added to RuboCop, but are not configured. Please set Enabled to either `true` or `false` in your `.rubocop.yml` file:
 - Lint/RaiseException (0.81)
 - Lint/StructNewOverride (0.81)
For more information: https://docs.rubocop.org/en/latest/versioning/
```