### PR TITLE
Add caption to page title helper

### DIFF
--- a/app/helpers/govuk_design_system_helper.rb
+++ b/app/helpers/govuk_design_system_helper.rb
@@ -7,12 +7,12 @@
 require 'gds_design_system_breadcrumb_builder'
 
 module GovukDesignSystemHelper
-  def govuk_page_title(title = nil)
-    content_for :page_title, (title || contextual_title) + " - #{service_name} - GOV.UK"
+  def govuk_page_title(title = nil, caption = nil)
+    content_for :page_title, page_title(title, caption)
 
     content_for :page_heading do
       tag.h1(class: 'govuk-heading-xl') do
-        title || contextual_title
+        page_heading(title, caption)
       end
     end
   end
@@ -25,5 +25,17 @@ module GovukDesignSystemHelper
 
   def contextual_title
     [action_name.titleize, controller_name.downcase.singularize].join(' ')
+  end
+
+  def page_heading(title, caption)
+    page_title_var = title || contextual_title
+    return page_title_var if caption.nil?
+    tag.span(caption, class: 'govuk-caption-xl').concat(page_title_var)
+  end
+
+  def page_title(title, caption)
+    page_title_var = title || contextual_title
+    caption_var = caption.strip.concat if caption.present?
+    "#{caption_var} #{page_title_var} - #{service_name} - GOV.UK".strip
   end
 end

--- a/spec/helpers/govuk_design_system_helper_spec.rb
+++ b/spec/helpers/govuk_design_system_helper_spec.rb
@@ -25,6 +25,33 @@ RSpec.describe GovukDesignSystemHelper, type: :helper do
       end
     end
 
+    context 'when caption provided' do
+      before do
+        helper.govuk_page_title('My page title', 'My page caption')
+      end
+
+      it 'stores :page_title' do
+        expect(helper.content_for(:page_title)).to include 'My page caption'
+      end
+
+      it 'stores :page_heading' do
+        expect(helper.content_for(:page_heading)).to include 'My page caption'
+      end
+
+      it ':page_title contains caption in plain text' do
+        expected_markup = 'My page caption My page title - View court data - GOV.UK'
+        expect(helper.content_for(:page_title)).to eql expected_markup
+      end
+
+      it ':page_heading contains GDS styled heading caption' do
+        markup = helper.content_for(:page_heading)
+        expected_markup = '<h1 class="govuk-heading-xl">'\
+                          '<span class="govuk-caption-xl">My page caption</span>'\
+                          'My page title</h1>'
+        expect(markup).to eql expected_markup
+      end
+    end
+
     context 'when no page title provided' do
       before do
         allow(controller).to receive(:controller_name).and_return 'Widgets'


### PR DESCRIPTION
#### What
Extend govuk_page_title to accept a caption

#### Ticket
[CACP-309](https://dsdmoj.atlassian.net/browse/CACP-309)

#### Why
Provide context to heading to make them clearer.

#### How
Extend the exiting method to accept a new arg.
