### PR TITLE
Update env vars in README

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -54,10 +54,7 @@ rails console
 ```
 # in .env.development.local
 COMMON_PLATFORM_URL=http://localhost:9293
-SHARED_SECRET_KEY_LAA_REFERENCE=super-secret-search-laa-reference-key
-SHARED_SECRET_KEY_REPRESENTATION_ORDER=super-secret-search-representation-order-key
-SHARED_SECRET_KEY_SEARCH_PROSECUTION_CASE=super-secret-search-prosecution-case-key
-SHARED_SECRET_KEY_HEARING=super-secret-hearing-key
+SHARED_SECRET_KEY=super-secret-key
 ```
 
 - start server


### PR DESCRIPTION
#### What
The README doesn't reflect the change made in [this](https://github.com/ministryofjustice/hmcts-common-platform-mock-api/commit/a44cf0b51af847b643ac7a03e22ea44f4c0d255c#diff-f579cccc964135c7d644c7b2d3b0d3ec) commit. This commit ensures the env vars in the README are updated.

#### Why
So that the application can be run locally.
