### PR TITLE
Unlink a case from MAAT 

### DIFF
--- a/app/controllers/defendants_controller.rb
+++ b/app/controllers/defendants_controller.rb
@@ -13,6 +13,16 @@ class DefendantsController < ApplicationController
                    defendant_path(defendant.arrest_summons_number || defendant.national_insurance_number)
   end
 
+  def remove_link
+    defendant.update(
+      user_name: 'example',
+      unlink_reason_code: '',
+      unlink_reason_text: 'unknown'
+    )
+
+    redirect_to defendant_path(defendant.arrest_summons_number)
+  end
+
   def defendant
     @defendant ||= @search.execute.first
   end

--- a/app/controllers/defendants_controller.rb
+++ b/app/controllers/defendants_controller.rb
@@ -16,8 +16,8 @@ class DefendantsController < ApplicationController
   def remove_link
     defendant.update(
       user_name: 'example',
-      unlink_reason_code: '',
-      unlink_reason_text: 'unknown'
+      unlink_reason_code: 1,
+      unlink_reason_text: 'Wrong MAAT ID'
     )
 
     redirect_to defendant_path(defendant.arrest_summons_number)

--- a/app/views/laa_references/_unlink.html.haml
+++ b/app/views/laa_references/_unlink.html.haml
@@ -1,4 +1,4 @@
-= link_to t('laa_reference.unlink.label'), '', class: 'govuk-link'
+= link_to t('laa_reference.unlink.label'), remove_link_defendant_path(@defendant.arrest_summons_number), method: :delete, class: 'govuk-link'
 %br
 %br
 .govuk-warning-text

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,8 +22,12 @@ Rails.application.routes.draw do
   end
 
   resources :prosecution_cases, only: %i[show]
-  resources :defendants, only: %i[show]
-  resources :laa_references, only: %i[create destroy]
+
+  resources :defendants, only: %i[show] do
+    delete :remove_link, on: :member
+  end
+
+  resources :laa_references, only: %i[create]
 
   devise_for :users, controllers: {
     confirmations: 'users/confirmations',

--- a/lib/court_data_adaptor/resource/defendant.rb
+++ b/lib/court_data_adaptor/resource/defendant.rb
@@ -3,9 +3,11 @@
 module CourtDataAdaptor
   module Resource
     class Defendant < Base
-      belongs_to :prosecution_case
       property :prosecution_case_reference, type: :string
       property :name, type: :string
+      property :user_name
+      property :unlink_reason_code
+      property :unlink_reason_text
 
       def linked?
         maat_reference&.present?

--- a/spec/features/unlinking_a_case_from_maat_spec.rb
+++ b/spec/features/unlinking_a_case_from_maat_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+describe 'unlinking a case from MAAT', type: :feature do
+  let(:defendant_asn) { '0TSQT1LMI7CR' }
+  let(:api_url) { ENV['COURT_DATA_ADAPTOR_API_URL'] }
+
+  context 'when signed in' do
+    let(:user) { create(:user) }
+
+    before { sign_in user }
+
+    describe 'viewing a case' do
+      before do
+        query = hash_including({ filter: { arrest_summons_number: defendant_asn } })
+        body = load_json_stub(defendant_fixture)
+        json_api_header = { 'Content-Type' => 'application/vnd.api+json' }
+
+        stub_request(:get, "#{api_url}/prosecution_cases")
+          .with(query: query)
+          .to_return(body: body, headers: json_api_header)
+
+        visit "defendants/#{defendant_asn}"
+      end
+
+      context 'with no link' do
+        let(:defendant_fixture) { 'unlinked/defendant_by_reference_body.json' }
+
+        it 'asks the user to link to a MAAT ID' do
+          expect(page).to have_content('Enter the MAAT ID')
+        end
+      end
+
+      context 'with a pre-existing link' do
+        let(:defendant_fixture) { 'linked/defendant_by_reference_body.json' }
+        let(:stub) do
+          json_api_data = {
+            data: [{
+              attributes: {
+                user_name: user.email,
+                unlink_reason_code: '',
+                unlink_reason_text: 'unknown'
+              }
+            }]
+          }
+
+          stub_request(:patch, "#{api_url}/defendants/#{defendant_asn}")
+            .with(body: json_api_data.to_json)
+        end
+
+        it 'does not show the option to link to a MAAT ID' do
+          stub
+          expect(page).not_to have_content('Enter the MAAT ID')
+        end
+
+        it 'sends an unlink request to the adapter when I choose to unlink' do
+          click_on 'Remove link to court data'
+          expect(stub).to have_been_requested
+        end
+      end
+    end
+  end
+end

--- a/spec/features/unlinking_a_case_from_maat_spec.rb
+++ b/spec/features/unlinking_a_case_from_maat_spec.rb
@@ -37,8 +37,8 @@ describe 'unlinking a case from MAAT', type: :feature do
             data: [{
               attributes: {
                 user_name: user.email,
-                unlink_reason_code: '',
-                unlink_reason_text: 'unknown'
+                unlink_reason_code: 1,
+                unlink_reason_text: 'Wrong MAAT ID'
               }
             }]
           }

--- a/spec/features/unlinking_a_case_from_maat_spec.rb
+++ b/spec/features/unlinking_a_case_from_maat_spec.rb
@@ -33,7 +33,7 @@ describe 'unlinking a case from MAAT', type: :feature do
       context 'with a pre-existing link' do
         let(:defendant_fixture) { 'linked/defendant_by_reference_body.json' }
         let(:stub) do
-          json_api_data = {
+          _json_api_data = {
             data: [{
               attributes: {
                 user_name: user.email,
@@ -43,12 +43,15 @@ describe 'unlinking a case from MAAT', type: :feature do
             }]
           }
 
-          stub_request(:patch, "#{api_url}/defendants/#{defendant_asn}")
-            .with(body: json_api_data.to_json)
+          stub_request(:patch, "#{api_url}/defendants/41fcb1cd-516e-438e-887a-5987d92ef90f")
+          # TODO: make it clear why it's this string
+          # stub_request(:patch, "#{api_url}/defendants/41fcb1cd-516e-438e-887a-5987d92ef90f")
+          #   .with(body: json_api_data.to_json)
         end
 
+        before { stub }
+
         it 'does not show the option to link to a MAAT ID' do
-          stub
           expect(page).not_to have_content('Enter the MAAT ID')
         end
 

--- a/spec/features/unlinking_a_case_from_maat_spec.rb
+++ b/spec/features/unlinking_a_case_from_maat_spec.rb
@@ -32,24 +32,10 @@ describe 'unlinking a case from MAAT', type: :feature do
 
       context 'with a pre-existing link' do
         let(:defendant_fixture) { 'linked/defendant_by_reference_body.json' }
-        let(:stub) do
-          _json_api_data = {
-            data: [{
-              attributes: {
-                user_name: user.email,
-                unlink_reason_code: 1,
-                unlink_reason_text: 'Wrong MAAT ID'
-              }
-            }]
-          }
+        let(:defendant_id_from_fixture) { '41fcb1cd-516e-438e-887a-5987d92ef90f' }
+        let(:path) { "#{api_url}/defendants/#{defendant_id_from_fixture}" }
 
-          stub_request(:patch, "#{api_url}/defendants/41fcb1cd-516e-438e-887a-5987d92ef90f")
-          # TODO: make it clear why it's this string
-          # stub_request(:patch, "#{api_url}/defendants/41fcb1cd-516e-438e-887a-5987d92ef90f")
-          #   .with(body: json_api_data.to_json)
-        end
-
-        before { stub }
+        before { stub_request(:patch, path) }
 
         it 'does not show the option to link to a MAAT ID' do
           expect(page).not_to have_content('Enter the MAAT ID')
@@ -57,7 +43,24 @@ describe 'unlinking a case from MAAT', type: :feature do
 
         it 'sends an unlink request to the adapter when I choose to unlink' do
           click_on 'Remove link to court data'
-          expect(stub).to have_been_requested
+
+          expected_data = {
+            data:
+            {
+              id: defendant_id_from_fixture,
+              type: 'defendants',
+              attributes: {
+                prosecution_case_reference: 'TEST12345',
+                user_name: 'example',
+                unlink_reason_code: 1,
+                unlink_reason_text: 'Wrong MAAT ID'
+              }
+            }
+          }
+
+          expect(a_request(:patch, path)
+            .with { |req| req.body == expected_data.to_json })
+            .to have_been_made
         end
       end
     end

--- a/spec/lib/court_data_adaptor/resource/defendant_spec.rb
+++ b/spec/lib/court_data_adaptor/resource/defendant_spec.rb
@@ -5,10 +5,6 @@ require 'court_data_adaptor'
 RSpec.describe CourtDataAdaptor::Resource::Defendant do
   it_behaves_like 'court_data_adaptor resource object', test_class: described_class
 
-  it 'belongs_to prosecution_case' do
-    is_expected.to respond_to(:prosecution_case_id, :prosecution_case_id=)
-  end
-
   it { is_expected.to respond_to(:prosecution_case_reference, :prosecution_case_reference=) }
   it { is_expected.to respond_to(:name) }
 

--- a/spec/requests/linking/link_laa_reference_spec.rb
+++ b/spec/requests/linking/link_laa_reference_spec.rb
@@ -68,16 +68,16 @@ RSpec.describe 'link defendant maat reference', type: :request, vcr_post_request
   end
 
   context 'when not authenticated' do
-    before do
-      post '/laa_references', params: params
-    end
+    context 'when creating a reference' do
+      before { post '/laa_references', params: params }
 
-    it 'redirects to sign in page' do
-      expect(response).to redirect_to new_user_session_path
-    end
+      it 'redirects to sign in page' do
+        expect(response).to redirect_to new_user_session_path
+      end
 
-    it 'flashes alert' do
-      expect(flash.now[:alert]).to match(/sign in before continuing/)
+      it 'flashes alert' do
+        expect(flash.now[:alert]).to match(/sign in before continuing/)
+      end
     end
   end
 end


### PR DESCRIPTION
We can mark a particular case as "linked" to a MAAT ID, so that it'll get more information from HMCTS' Common Platform.

Sometimes, we'll do this accidentally, or get the wrong ID (since it's free-typed) - this change allows users to reverse the process.

The ["Unlink a case"](https://dsdmoj.atlassian.net/browse/CACP-128) ticket on JIRA.

Questions I have:
- Is it good to merge this and worry about getting the right data across in a follow-up?
- Does [removing this relation](https://github.com/ministryofjustice/laa-court-data-ui/pull/163/files#diff-0c312595236dd3d6c044a0a6a5c6a832L6) have any unintended side effects?