### PR TITLE
Revert "Bump sidekiq from 5.2.8 to 6.0.7"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'puma', '~> 4.3'
 gem 'rails', '~> 6.0.3'
 gem 'redis', '~> 4.1.4'
 gem 'sentry-raven'
-gem 'sidekiq', '~> 6.0.7'
+gem 'sidekiq', '~> 5.2.7'
 gem 'webpacker', '~> 5.1'
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -253,7 +253,7 @@ GEM
       nio4r (~> 2.0)
     puma (4.3.5-java)
       nio4r (~> 2.0)
-    rack (2.2.2)
+    rack (2.0.9)
     rack-contrib (2.1.0)
       rack (~> 2.0)
     rack-protection (2.0.8.1)
@@ -356,11 +356,11 @@ GEM
     sentry-raven (2.13.0)
       faraday (>= 0.7.6, < 1.0)
     sexp_processor (4.14.1)
-    sidekiq (6.0.7)
-      connection_pool (>= 2.2.2)
-      rack (~> 2.0)
-      rack-protection (>= 2.0.0)
-      redis (>= 4.1.0)
+    sidekiq (5.2.8)
+      connection_pool (~> 2.2, >= 2.2.2)
+      rack (< 2.1.0)
+      rack-protection (>= 1.5.0)
+      redis (>= 3.3.5, < 5)
     simplecov (0.17.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -475,7 +475,7 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rspec
   sentry-raven
-  sidekiq (~> 6.0.7)
+  sidekiq (~> 5.2.7)
   simplecov (~> 0.17.1)
   spring
   spring-watcher-listen (~> 2.0.0)


### PR DESCRIPTION
This reverts commit 0d8c68299e3391dc39043dd88fe1177705bb44bd.

#### What
fix broken deploy and possible cause of errors in app

#### Ticket

[CBO-1277](https://dsdmoj.atlassian.net/browse/CBO-1277)

#### Why
The dependabot upgrade of sidekiq from 5 to 6 broke
the deployment and other problems have arisen probably due
to the environment not having been refreshed since then

sidekiq 6 requires sidekiq to be started in non-daemonized
mode using a supervisor. this is a separate task and a ticket
has been [written to do this - CBO-1299](https://dsdmoj.atlassian.net/browse/CBO-1299). revert for now.

#### How
revert the sidekiq major version bump