### PR TITLE
Unlink with unique username

### DIFF
--- a/app/controllers/defendants_controller.rb
+++ b/app/controllers/defendants_controller.rb
@@ -15,7 +15,7 @@ class DefendantsController < ApplicationController
 
   def remove_link
     defendant.update(
-      user_name: 'example',
+      user_name: current_user.unique_user_reference,
       unlink_reason_code: 1,
       unlink_reason_text: 'Wrong MAAT ID'
     )

--- a/db/migrate/20200611102258_add_unique_reference_to_user.rb
+++ b/db/migrate/20200611102258_add_unique_reference_to_user.rb
@@ -1,0 +1,6 @@
+class AddUniqueReferenceToUser < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :unique_user_reference, :string, null: false
+    add_index :users, :unique_user_reference, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_21_130904) do
+ActiveRecord::Schema.define(version: 2020_06_11_102258) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,8 +34,10 @@ ActiveRecord::Schema.define(version: 2020_01_21_130904) do
     t.string "first_name", null: false
     t.string "last_name", null: false
     t.string "roles", default: ["caseworker"], array: true
+    t.string "unique_user_reference", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["unique_user_reference"], name: "index_users_on_unique_user_reference", unique: true
     t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true
   end
 

--- a/spec/features/unlinking_a_case_from_maat_spec.rb
+++ b/spec/features/unlinking_a_case_from_maat_spec.rb
@@ -51,7 +51,7 @@ describe 'unlinking a case from MAAT', type: :feature do
               type: 'defendants',
               attributes: {
                 prosecution_case_reference: 'TEST12345',
-                user_name: 'example',
+                user_name: user.unique_user_reference,
                 unlink_reason_code: 1,
                 unlink_reason_text: 'Wrong MAAT ID'
               }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -9,7 +9,10 @@ RSpec.describe User, type: :model do
   end
 
   # only attributes/methods that are additional to devise user
-  it { is_expected.to respond_to(:first_name, :last_name, :name, :roles, :email_confirmation) }
+  it {
+    is_expected.to respond_to(:first_name, :last_name, :name, :roles, :email_confirmation,
+                              :unique_user_reference)
+  }
 
   describe '#name' do
     subject { user.name }
@@ -69,6 +72,22 @@ RSpec.describe User, type: :model do
         end.not_to \
           raise_error
       end
+    end
+  end
+
+  describe '#unique_user_reference' do
+    let(:unique_user_reference) { SecureRandom.hex(5) }
+
+    it 'generates a random hex string when creating a user' do
+      user = create(:user)
+      expect(user.unique_user_reference).not_to eq(nil)
+    end
+
+    it 'raises an error when creating a user with the same unique user reference' do
+      expect do
+        create(:user, unique_user_reference: unique_user_reference)
+        create(:user, unique_user_reference: unique_user_reference)
+      end.to raise_error ActiveRecord::RecordInvalid
     end
   end
 end


### PR DESCRIPTION
Previously a generic username was sent as part of the unlinking. However this is not sufficient as it doesn't allow identification of the user who unlinked the case. There is a 10 char limit enforced by MLRA for the username which does not allow for using the user email as the username. Therefore,  a uniquely user reference will be used instead and VCD will be the source of truth for identifying the user. 

A primary key cannot be used to do this as there are potential security implications with using auto incrementing ids in this context. There are also concerns regarding the fact that primary ids are susceptible to change (so when an external service only has awareness of this id when communing about the user, then once this primary id changes in the db it can no longer identify the user ). Therefore, a unique user reference is used (which is not susceptible to change as primary id may be) to serve this need
