### PR TITLE
Updates inline with rubocop 0.85 opt-ins

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -25,7 +25,7 @@ plugins:
             - "(call _ expose ___)" # exlude expose methods
   rubocop:
     enabled: true
-    channel: rubocop-0-76
+    channel: rubocop-0-83
     config:
       file: .rubocop.yml
   brakeman:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,10 +29,22 @@ Capybara/FeatureMethods:
 Layout/EmptyLineAfterGuardClause:
   Enabled: false
 
+Layout/EmptyLinesAroundAttributeAccessor:
+    Enabled: true
+
 Layout/LineLength:
   Max: 110
   IgnoredPatterns: ['(\A|\s)#','.*\s+ # .*', "body: '{\".*\":", "%r{http.*"]
   AllowHeredoc: true
+
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: true
+
+Lint/DeprecatedOpenSSLConstant:
+  Enabled: true
+
+Lint/MixedRegexpCaptureTypes:
+  Enabled: true
 
 Lint/RaiseException:
   Enabled: true
@@ -83,6 +95,9 @@ RSpec/NestedGroups:
 Style/Documentation:
   Enabled: false
 
+Style/ExponentialNotation:
+  Enabled: true
+
 Style/FormatStringToken:
   Exclude:
     - app/models/search.rb
@@ -100,5 +115,14 @@ Style/ClassAndModuleChildren:
   Exclude:
     - app/controllers/users/*controller.rb
 
+Style/RedundantRegexpCharacterClass:
+  Enabled: true
+
+Style/RedundantRegexpEscape:
+  Enabled: true
+
 Style/RegexpLiteral:
   EnforcedStyle: slashes
+
+Style/SlicingWithRange:
+  Enabled: true

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -13,5 +13,6 @@ class Feedback
   }.freeze
 
   attr_accessor :comment, :rating, :email
+
   validates :rating, inclusion: { in: RATINGS.keys.map(&:to_s) }
 end

--- a/spec/features/breadcrumbs_spec.rb
+++ b/spec/features/breadcrumbs_spec.rb
@@ -58,7 +58,7 @@ RSpec.feature 'Breadcrumb', type: :feature do
       then_has_case_details_breadcrumbs('MOGUERBXIZ')
 
       click_link('Josefa Franecki')
-      expect(page).to have_current_path(%r{\/defendants\/.+})
+      expect(page).to have_current_path(%r{/defendants/.+})
 
       then_has_defendant_details_breadcrumbs('MOGUERBXIZ', 'Josefa Franecki')
 
@@ -134,7 +134,7 @@ RSpec.feature 'Breadcrumb', type: :feature do
     expect(page).to have_govuk_breadcrumb_link('Home')
     expect(page).to have_govuk_breadcrumb_link(
       'Search',
-      href: %r{\/searches\?search.*#{case_ref}}
+      href: %r{/searches\?search.*#{case_ref}}
     )
     expect(page).not_to have_govuk_breadcrumb_link(/Case/)
     expect(page).to have_govuk_breadcrumb("Case #{case_ref}", aria_current: true)

--- a/spec/features/unlinked_defendant_flow_spec.rb
+++ b/spec/features/unlinked_defendant_flow_spec.rb
@@ -45,7 +45,7 @@ RSpec.feature 'Unlinked defendant page flow', type: :feature, stub_unlinked: tru
   def stub_linked_defendant
     stub_request(
       :get,
-      %r{http.*\/api\/internal\/v1\/prosecution_cases\?filter.*}
+      %r{http.*/api/internal/v1/prosecution_cases\?filter.*}
     ).to_return(
       status: 200,
       body: load_json_stub('linked/defendant_by_reference_body.json'),
@@ -103,8 +103,8 @@ RSpec.feature 'Unlinked defendant page flow', type: :feature, stub_unlinked: tru
       rows = page.all('.govuk-table__row')
       rows.each do |row|
         cells = row.all('.govuk-table__cell')
-        expect(cells[0]).to have_link(nil, href: %r{\/defendants\/.*})
-        expect(cells[1].text).to match(%r{[0-3][0-9]\/[0-1][0-9]\/[1-2][0|9](?:[0-9]{2})?})
+        expect(cells[0]).to have_link(nil, href: %r{/defendants/.*})
+        expect(cells[1].text).to match(%r{[0-3][0-9]/[0-1][0-9]/[1-2][0|9](?:[0-9]{2})?})
         expect(cells[2].text).to eql 'Not linked'
       end
     end
@@ -116,13 +116,13 @@ RSpec.feature 'Unlinked defendant page flow', type: :feature, stub_unlinked: tru
     within defendant_details do
       rows = page.all('.govuk-table__row')
       expect(rows[0]).to have_content('Date of birth')
-      expect(rows[0]).to have_content(%r{[0-3][0-9]\/[0-1][0-9]\/[1-2][0|9](?:[0-9]{2})?})
+      expect(rows[0]).to have_content(%r{[0-3][0-9]/[0-1][0-9]/[1-2][0|9](?:[0-9]{2})?})
       expect(rows[1]).to have_content('Case URN')
       expect(rows[2]).to have_content('NI number')
       expect(rows[3]).to have_content('ASN')
     end
 
-    expect(page).to have_link('View case', href: %r{\/prosecution_cases\/.*})
+    expect(page).to have_link('View case', href: %r{/prosecution_cases/.*})
   end
 
   def then_has_offence_details(table_number: 1)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -51,14 +51,14 @@ RSpec.describe User, type: :model do
         expect do
           user.update!(email: 'john.boy@example.com', email_confirmation: 'jim.bob@example.com')
         end.to \
-          raise_error ActiveRecord::RecordInvalid, /Email confirmation doesn\'t match Email/
+          raise_error ActiveRecord::RecordInvalid, /Email confirmation doesn't match Email/
       end
 
       it 'blank email confirmation raises error' do
         expect do
           user.update!(email: 'john.boy@example.com', email_confirmation: '')
         end.to \
-          raise_error ActiveRecord::RecordInvalid, /Email confirmation can\'t be blank/
+          raise_error ActiveRecord::RecordInvalid, /Email confirmation can't be blank/
       end
     end
 

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -6,7 +6,7 @@ WebMock.disable_net_connect!(allow_localhost: true)
 
 RSpec.configure do |config|
   config.before(:each, stub_oauth_token: true) do
-    stub_request(:post, %r{http.*\/oauth\/token})
+    stub_request(:post, %r{http.*/oauth/token})
       .to_return(
         status: 200,
         body: '{"access_token":"test-bearer-token","token_type":"Bearer","expires_in":7200,"created_at":1582809000}',
@@ -15,7 +15,7 @@ RSpec.configure do |config|
   end
 
   config.before(:each, stub_no_results: true) do
-    stub_request(:get, %r{http.*\/filter.*})
+    stub_request(:get, %r{http.*/filter.*})
       .to_return(
         status: 200,
         body: '{ "data": [] }',
@@ -26,7 +26,7 @@ RSpec.configure do |config|
   config.before(:each, stub_unlinked: true) do
     stub_request(
       :get,
-      %r{http.*\/api\/internal\/v1\/prosecution_cases\?filter\[prosecution_case_reference\]=#{case_urn}\&include=defendants}
+      %r{http.*/api/internal/v1/prosecution_cases\?filter\[prosecution_case_reference\]=#{case_urn}&include=defendants}
     ).to_return(
       status: 200,
       body: load_json_stub('unlinked/prosecution_case_by_reference_body.json'),
@@ -35,7 +35,7 @@ RSpec.configure do |config|
 
     stub_request(
       :get,
-      %r{http.*\/api\/internal\/v1\/prosecution_cases\?filter.*arrest_summons_number.*#{defendant_asn}\&include=defendants,defendants.offences}
+      %r{http.*/api/internal/v1/prosecution_cases\?filter.*arrest_summons_number.*#{defendant_asn}&include=defendants,defendants.offences}
     ).to_return(
       status: 200,
       body: load_json_stub('unlinked/defendant_by_reference_body.json'),
@@ -44,7 +44,7 @@ RSpec.configure do |config|
 
     stub_request(
       :get,
-      %r{http.*\/api\/internal\/v1\/prosecution_cases\?filter.*national_insurance_number.*#{defendant_nino}\&include=defendants,defendants.offences}
+      %r{http.*/api/internal/v1/prosecution_cases\?filter.*national_insurance_number.*#{defendant_nino}&include=defendants,defendants.offences}
     ).to_return(
       status: 200,
       body: load_json_stub('unlinked/defendant_by_reference_body.json'),
@@ -53,13 +53,13 @@ RSpec.configure do |config|
   end
 
   config.before(:each, stub_link_success: true) do
-    stub_request(:post, %r{\/api\/internal\/v1\/laa_references}).to_return(status: 202, body: '')
+    stub_request(:post, %r{/api/internal/v1/laa_references}).to_return(status: 202, body: '')
   end
 
   config.before(:each, stub_linked: true) do
     stub_request(
       :get,
-      %r{http.*\/api\/internal\/v1\/prosecution_cases\?filter.*arrest_summons_number.*#{defendant_asn}\&include=defendants,defendants.offences}
+      %r{http.*/api/internal/v1/prosecution_cases\?filter.*arrest_summons_number.*#{defendant_asn}&include=defendants,defendants.offences}
     ).to_return(
       status: 200,
       body: load_json_stub('linked/defendant_by_reference_body.json'),
@@ -68,7 +68,7 @@ RSpec.configure do |config|
 
     stub_request(
       :get,
-      %r{http.*\/api\/internal\/v1\/prosecution_cases\?filter.*national_insurance_number.*#{defendant_nino}\&include=defendants,defendants.offences}
+      %r{http.*/api/internal/v1/prosecution_cases\?filter.*national_insurance_number.*#{defendant_nino}&include=defendants,defendants.offences}
     ).to_return(
       status: 200,
       body: load_json_stub('linked/defendant_by_reference_body.json'),


### PR DESCRIPTION
#### What
Updates inline with rubocop 0.85 opt-ins

#### Why
To improve code quality: Opt-in to new cops,
fix violations and bump codeclimate inline
with this.

 - Opt-in to cops from 0.83 to 0.85
 - Fix rubocop violations for opt-ins upto version 0.85
 - bump codeclimate rubocop 0.76 to 0.83
		[latest available rubocop channel](https://github.com/codeclimate/codeclimate-rubocop/branches/all?utf8=%E2%9C%93&query=channel%2Frubocop)