### PR TITLE
Move sidekiq to worker pods

### DIFF
--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -55,9 +55,12 @@ function _circleci_deploy() {
 
   docker_image_tag=${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPO_NAME}:app-${CIRCLE_SHA1}
 
-  # apply image specific config
+  # apply secrets first so changes can be picked up by deployment
   kubectl apply -f .k8s/${environment}/secrets.yaml 2> /dev/null
+
+  # apply deployment with specfied image
   kubectl set image -f .k8s/${environment}/deployment.yaml laa-court-data-ui-app=${docker_image_tag} --local -o yaml | kubectl apply -f -
+  kubectl set image -f .k8s/${environment}/deployment-worker.yaml laa-court-data-ui-worker=${docker_image_tag} --local --output yaml | kubectl apply -f -
 
   # apply non-image specific config
   kubectl apply \

--- a/.k8s/dev/deployment-worker.yaml
+++ b/.k8s/dev/deployment-worker.yaml
@@ -1,0 +1,82 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: laa-court-data-ui-worker
+  namespace: laa-court-data-ui-dev
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 100%
+  selector:
+    matchLabels:
+      app: laa-court-data-ui
+      tier: worker
+  template:
+    metadata:
+      labels:
+        app: laa-court-data-ui
+        tier: worker
+    spec:
+      containers:
+        - name: laa-court-data-ui-worker
+          imagePullPolicy: Always
+          image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/laa-get-paid/laa-court-data-ui:set-me
+          command: ['bundle', 'exec', 'sidekiq']
+          readinessProbe:
+            exec:
+              command: ['bundle', 'exec', 'rake', 'worker:healthcheck']
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          livenessProbe:
+            exec:
+              command: ['bundle', 'exec', 'rake', 'worker:healthcheck']
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          env:
+            - name: ENV
+              value: 'dev'
+            - name: RACK_ENV
+              value: 'production'
+            - name: RAILS_ENV
+              value: 'production'
+            - name: DOMAIN_URL
+              value: 'https://dev.view-court-data.service.justice.gov.uk'
+            - name: COURT_DATA_ADAPTOR_API_URL
+              value: https://laa-court-data-adaptor-dev.apps.live-1.cloud-platform.service.justice.gov.uk/api/internal/v1
+            - name: RAILS_SERVE_STATIC_FILES
+              value: enabled
+            - name: RAILS_LOG_TO_STDOUT
+              value: enabled
+            - name: COURT_DATA_ADAPTOR_API_UID
+              valueFrom:
+                secretKeyRef:
+                  name: lcdui-secrets
+                  key: COURT_DATA_ADAPTOR_API_UID
+            - name: COURT_DATA_ADAPTOR_API_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: lcdui-secrets
+                  key: COURT_DATA_ADAPTOR_API_SECRET
+            - name: SECRET_KEY_BASE
+              valueFrom:
+                secretKeyRef:
+                  name: lcdui-secrets
+                  key: SECRET_KEY_BASE
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: lcdui-rds
+                  key: url
+            - name: REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  name: lcdui-elasticache
+                  key: url
+            - name: GOVUK_NOTIFY_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: lcdui-secrets
+                  key: GOVUK_NOTIFY_API_KEY

--- a/.k8s/production/deployment-worker.yaml
+++ b/.k8s/production/deployment-worker.yaml
@@ -1,0 +1,87 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: laa-court-data-ui-worker
+  namespace: laa-court-data-ui-dev
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 100%
+  selector:
+    matchLabels:
+      app: laa-court-data-ui
+      tier: worker
+  template:
+    metadata:
+      labels:
+        app: laa-court-data-ui
+        tier: worker
+    spec:
+      containers:
+        - name: laa-court-data-ui-worker
+          imagePullPolicy: Always
+          image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/laa-get-paid/laa-court-data-ui:set-me
+          command: ['bundle', 'exec', 'sidekiq']
+          readinessProbe:
+            exec:
+              command: ['bundle', 'exec', 'rake', 'worker:healthcheck']
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          livenessProbe:
+            exec:
+              command: ['bundle', 'exec', 'rake', 'worker:healthcheck']
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          env:
+            - name: ENV
+              value: 'production'
+            - name: RACK_ENV
+              value: 'production'
+            - name: RAILS_ENV
+              value: 'production'
+            - name: DOMAIN_URL
+              value: 'https://view-court-data.service.justice.gov.uk'
+            - name: COURT_DATA_ADAPTOR_API_URL
+              value: https://laa-court-data-adaptor.apps.live-1.cloud-platform.service.justice.gov.uk/api/internal/v1
+            - name: RAILS_SERVE_STATIC_FILES
+              value: enabled
+            - name: RAILS_LOG_TO_STDOUT
+              value: enabled
+            - name: COURT_DATA_ADAPTOR_API_UID
+              valueFrom:
+                secretKeyRef:
+                  name: lcdui-secrets
+                  key: COURT_DATA_ADAPTOR_API_UID
+            - name: COURT_DATA_ADAPTOR_API_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: lcdui-secrets
+                  key: COURT_DATA_ADAPTOR_API_SECRET
+            - name: SECRET_KEY_BASE
+              valueFrom:
+                secretKeyRef:
+                  name: lcdui-secrets
+                  key: SECRET_KEY_BASE
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: lcdui-rds
+                  key: url
+            - name: REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  name: lcdui-elasticache
+                  key: url
+            - name: GOVUK_NOTIFY_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: lcdui-secrets
+                  key: GOVUK_NOTIFY_API_KEY
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: lcdui-secrets
+                  key: SENTRY_DSN

--- a/.k8s/scripts/deploy.sh
+++ b/.k8s/scripts/deploy.sh
@@ -65,8 +65,9 @@ function _deploy() {
   # apply secrets first so changes can be picked up by deployment
   kubectl apply -f .k8s/${environment}/secrets.yaml
 
-  # apply image specific config
+  # apply deployment with specfied image
   kubectl set image -f .k8s/${environment}/deployment.yaml ${repo_name}-app=${docker_image_tag} --local --output yaml | kubectl apply -f -
+  kubectl set image -f .k8s/${environment}/deployment-worker.yaml ${repo_name}-worker=${docker_image_tag} --local --output yaml | kubectl apply -f -
 
   # apply non-image specific config
   kubectl apply \

--- a/.k8s/staging/deployment-worker.yaml
+++ b/.k8s/staging/deployment-worker.yaml
@@ -1,0 +1,87 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: laa-court-data-ui-worker
+  namespace: laa-court-data-ui-dev
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 100%
+  selector:
+    matchLabels:
+      app: laa-court-data-ui
+      tier: worker
+  template:
+    metadata:
+      labels:
+        app: laa-court-data-ui
+        tier: worker
+    spec:
+      containers:
+        - name: laa-court-data-ui-worker
+          imagePullPolicy: Always
+          image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/laa-get-paid/laa-court-data-ui:set-me
+          command: ['bundle', 'exec', 'sidekiq']
+          readinessProbe:
+            exec:
+              command: ['bundle', 'exec', 'rake', 'worker:healthcheck']
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          livenessProbe:
+            exec:
+              command: ['bundle', 'exec', 'rake', 'worker:healthcheck']
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          env:
+           - name: ENV
+              value: 'staging'
+            - name: RACK_ENV
+              value: 'production'
+            - name: RAILS_ENV
+              value: 'production'
+            - name: DOMAIN_URL
+              value: 'https://staging.view-court-data.service.justice.gov.uk'
+            - name: COURT_DATA_ADAPTOR_API_URL
+              value: https://laa-court-data-adaptor-stage.apps.live-1.cloud-platform.service.justice.gov.uk/api/internal/v1
+            - name: RAILS_SERVE_STATIC_FILES
+              value: enabled
+            - name: RAILS_LOG_TO_STDOUT
+              value: enabled
+            - name: COURT_DATA_ADAPTOR_API_UID
+              valueFrom:
+                secretKeyRef:
+                  name: lcdui-secrets
+                  key: COURT_DATA_ADAPTOR_API_UID
+            - name: COURT_DATA_ADAPTOR_API_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: lcdui-secrets
+                  key: COURT_DATA_ADAPTOR_API_SECRET
+            - name: SECRET_KEY_BASE
+              valueFrom:
+                secretKeyRef:
+                  name: lcdui-secrets
+                  key: SECRET_KEY_BASE
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: lcdui-rds
+                  key: url
+            - name: REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  name: lcdui-elasticache
+                  key: url
+            - name: GOVUK_NOTIFY_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: lcdui-secrets
+                  key: GOVUK_NOTIFY_API_KEY
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: lcdui-secrets
+                  key: SENTRY_DSN

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -7,14 +7,11 @@ RUBYOPT=-W:no-deprecated bundle exec rails db:create db:migrate
 
 # if REDIS_URL is not set then we start redis-server locally
 if [ -z ${REDIS_URL+x} ]; then
-  printf '\e[33mINFO: Starting redis-server daemon\e[0m\n'
+  printf '\e[33mINFO: Fallback to using local redis-server daemon\e[0m\n'
   redis-server --daemonize yes
 else
   printf '\e[33mINFO: Using remote redis-server specified in REDIS_URL\e[0m\n'
 fi
-
-printf '\e[33mINFO: Starting sidekiq daemon\e[0m\n'
-bundle exec sidekiq -d
 
 # NOTE: "RUBYOPT=-W:no-deprecated" removes verbose
 # warnings raised by rails using ruby 2.7

--- a/lib/tasks/worker.rake
+++ b/lib/tasks/worker.rake
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+namespace :worker do
+  desc 'Test if sidekiq process is running. raises error if not.'
+  task healthcheck: :environment do
+    raise StandardError if `pgrep -f sidekiq`.blank?
+  end
+end


### PR DESCRIPTION
#### What
create separate pods for workers

#### Ticket

N/A

#### Why

Offloads work to dedicated instances/pods
and works around the sidekiq 6 need for
a supervisor for running sidekiq daemonized,
as we currently do, which will enabled us
to upgrade sidekiq.

Also means we have dedicated sidekiq logs
to look at.