### PR TITLE
Cbo 1269 no maat id link

### DIFF
--- a/app/controllers/laa_references_controller.rb
+++ b/app/controllers/laa_references_controller.rb
@@ -14,6 +14,7 @@ class LaaReferencesController < ApplicationController
   private
 
   def link_laa_reference
+    resource_params.delete(:maat_reference) if no_maat_id?
     laa_reference = resource.new(**resource_params)
     laa_reference.save
   rescue CourtDataAdaptor::Errors::BadRequest => e
@@ -35,6 +36,10 @@ class LaaReferencesController < ApplicationController
 
   def resource_params
     @resource_params ||= laa_reference_params.select! { |k, _v| k.in? %w[maat_reference defendant_id] }
+  end
+
+  def no_maat_id?
+    params[:commit] == 'Create link without MAAT ID'
   end
 
   def error_messages

--- a/app/views/laa_references/_form.html.haml
+++ b/app/views/laa_references/_form.html.haml
@@ -8,3 +8,9 @@
     hint_text: t('laa_reference.link.form.maat_reference.hint')
 
   = f.govuk_submit(t('laa_reference.link.form.submit'))
+
+  %details.govuk-details
+    %summary.govuk-details__summary
+      %span.govuk-details__summary-text=t('laa_reference.missing_maat_id.label')
+    %p.govuk-details__details-text=t('laa_reference.missing_maat_id.description')
+    = f.govuk_submit(t('laa_reference.missing_maat_id.submit'), secondary: true)

--- a/config/locales/en/views/laa_references.yml
+++ b/config/locales/en/views/laa_references.yml
@@ -12,3 +12,7 @@ en:
     unlink:
       label: Remove link to court data
       warning: Removing the link will stop hearing updates being received
+    missing_maat_id:
+      label: The MAAT id is missing
+      description: If you are confident that this is the correct defendant, then you can still link
+      submit: Create link without MAAT ID

--- a/config/locales/en/views/laa_references.yml
+++ b/config/locales/en/views/laa_references.yml
@@ -9,10 +9,10 @@ en:
           label: MAAT ID
         submit: Create link to court data
       success: You have successfully linked to the court data source
+    missing_maat_id:
+      description: If you are confident that this is the correct defendant, then you can still link
+      label: The MAAT id is missing
+      submit: Create link without MAAT ID
     unlink:
       label: Remove link to court data
       warning: Removing the link will stop hearing updates being received
-    missing_maat_id:
-      label: The MAAT id is missing
-      description: If you are confident that this is the correct defendant, then you can still link
-      submit: Create link without MAAT ID

--- a/spec/features/linking_defendant_no_maat_id_spec.rb
+++ b/spec/features/linking_defendant_no_maat_id_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Linking a defendant with no MAAT id', type: :feature, stub_unlinked: true do
+  let(:user) { create(:user) }
+  let(:case_urn) { 'TEST12345' }
+  let(:defendant_nino) { 'MR610691B' }
+  let(:defendant_asn) { 'LYDAO0SB7S2P' }
+  let(:defendant_name) { 'Hobert Brown' }
+
+  before do
+    sign_in user
+  end
+
+  scenario 'user links defendant details with no maat id', :stub_link_success do
+    visit "prosecution_cases/#{case_urn}"
+    click_link('Hobert Brown')
+    expect(page).to have_text('The MAAT id is missing')
+    find(:xpath, "//details[@class='govuk-details']", text: 'The MAAT id is missing').click
+    expect(page).to have_button('Create link without MAAT ID')
+    click_button 'Create link without MAAT ID'
+    stub_linked_defendant
+    expect(page).to have_govuk_flash(:notice, text: 'You have successfully linked to the court data source')
+  end
+
+  def stub_linked_defendant
+    stub_request(
+      :get,
+      %r{http.*/api/internal/v1/prosecution_cases\?filter.*}
+    ).to_return(
+      status: 200,
+      body: load_json_stub('linked/defendant_by_reference_body.json'),
+      headers: { 'Content-Type' => 'application/vnd.api+json' }
+    )
+  end
+end

--- a/spec/fixtures/vcr_cassettes/spec/requests/linking/link_defendant_no_maat_id_spec.yml
+++ b/spec/fixtures/vcr_cassettes/spec/requests/linking/link_defendant_no_maat_id_spec.yml
@@ -1,0 +1,103 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://localhost:9292/api/internal/v1/laa_references
+    body:
+      encoding: UTF-8
+      string: '{"data":{"type":"laa_references","attributes":{"defendant_id":"41fcb1cd-516e-438e-887a-5987d92ef90f"}}}'
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Content-Type:
+      - application/vnd.api+json
+      Accept:
+      - application/vnd.api+json
+      Authorization:
+      - Bearer <BEARER_TOKEN>
+      Accept-Encoding:
+      - gzip,deflate
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Laa-Transaction-Id:
+      - 3bf1da23-c49c-4510-bbf2-6f288733dca9
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 3bf1da23-c49c-4510-bbf2-6f288733dca9
+      X-Runtime:
+      - '0.014121'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: " "
+  recorded_at: Tue, 23 Jun 2020 10:18:57 GMT
+- request:
+    method: post
+    uri: http://localhost:9292/api/internal/v1/laa_references
+    body:
+      encoding: UTF-8
+      string: '{"data":{"type":"laa_references","attributes":{"defendant_id":"invalid-defendant-id"}}}'
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Content-Type:
+      - application/vnd.api+json
+      Accept:
+      - application/vnd.api+json
+      Authorization:
+      - Bearer <BEARER_TOKEN>
+      Accept-Encoding:
+      - gzip,deflate
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Laa-Transaction-Id:
+      - 2ded8ea1-2f05-4ea0-b9a3-87df54824e62
+      Content-Type:
+      - application/vnd.api+json; charset=utf-8
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 2ded8ea1-2f05-4ea0-b9a3-87df54824e62
+      X-Runtime:
+      - '0.009379'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"defendant_id":["is not a valid uuid"]}'
+  recorded_at: Tue, 23 Jun 2020 10:18:57 GMT
+recorded_with: VCR 6.0.0

--- a/spec/requests/linking/link_defendant_no_maat_id_spec.rb
+++ b/spec/requests/linking/link_defendant_no_maat_id_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+RSpec.describe 'link defendant with no maat id', type: :request, vcr_cud_request: true do
+  let(:user) { create(:user) }
+
+  let(:nino) { 'JC123456A' }
+  let(:defendant_id) { '41fcb1cd-516e-438e-887a-5987d92ef90f' }
+  let(:params) do
+    {
+      id: nino,
+      defendant_id: defendant_id
+    }
+  end
+
+  context 'when authenticated' do
+    before do
+      sign_in user
+      post '/laa_references', params: params
+    end
+
+    context 'with valid params' do
+      it 'returns status 302' do
+        expect(response).to have_http_status :redirect
+      end
+
+      it 'redirects to defendant path' do
+        expect(response).to redirect_to defendant_path(nino)
+      end
+
+      it 'flashes alert' do
+        expect(flash.now[:notice]).to match(/You have successfully linked to the court data source/)
+      end
+    end
+
+    context 'with invalid defendant_id' do
+      let(:defendant_id) { 'invalid-defendant-id' }
+
+      it 'flashes alert' do
+        expect(flash.now[:alert]).to match(/A link to the court data source could not be created\./)
+      end
+
+      it 'flashes returned error' do
+        expect(flash.now[:alert]).to match(/Defendant is not a valid uuid/i)
+      end
+
+      it 'redirects to defendant path' do
+        expect(response).to redirect_to defendant_path(nino)
+      end
+    end
+  end
+end

--- a/spec/requests/linking/link_defendant_no_maat_id_spec.rb
+++ b/spec/requests/linking/link_defendant_no_maat_id_spec.rb
@@ -48,4 +48,29 @@ RSpec.describe 'link defendant with no maat id', type: :request, vcr_cud_request
       end
     end
   end
+
+  context 'with stubbed requests' do
+    before { sign_in user }
+
+    context 'when no MAAT reference submitted' do
+      before do
+        stub_request(:post, link_request[:path])
+        post '/laa_references', params: params
+      end
+
+      let(:link_request) do
+        {
+          path: "#{ENV['COURT_DATA_ADAPTOR_API_URL']}/laa_references",
+          body: '{"data":{"type":"laa_references","attributes":{"defendant_id":"41fcb1cd-516e-438e-887a-5987d92ef90f"}}}'
+        }
+      end
+
+      it 'sends link request with filtered params' do
+        expect(
+          a_request(:post, link_request[:path])
+            .with(body: link_request[:body])
+        ).to have_been_made.once
+      end
+    end
+  end
 end


### PR DESCRIPTION
#### What
Enable linking of defendants with no MAAT id

#### Ticket
https://dsdmoj.atlassian.net/browse/CBO-1269

#### Why
Sometimes a defendant will not have a MAAT id

#### How
As per design docs, added  "The MAAT id is missing" govuk_details section to the show defendant view form. Added "Create link without MAAT id" button to this section. Updated laa_references so that when a user clicks the "Create link without MAAT id" button it removes maat_reference from the call to the Court Data Adaptor laa_reference api endpoint.
