### PR TITLE
Fix yaml error in staging worker deployment

### DIFF
--- a/.k8s/staging/deployment-worker.yaml
+++ b/.k8s/staging/deployment-worker.yaml
@@ -36,7 +36,7 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 30
           env:
-           - name: ENV
+            - name: ENV
               value: 'staging'
             - name: RACK_ENV
               value: 'production'


### PR DESCRIPTION
fixes:
```
error: error parsing .k8s/staging/deployment-worker.yaml: error converting YAML to JSON: yaml: line 40: mapping values are not allowed in this context
error: no objects passed to apply
```