### PR TITLE
Cbo 1310 fix kubernetes api deprecations

### DIFF
--- a/.k8s/dev/deployment-worker.yaml
+++ b/.k8s/dev/deployment-worker.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: laa-court-data-ui-worker

--- a/.k8s/dev/deployment.yaml
+++ b/.k8s/dev/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: laa-court-data-ui

--- a/.k8s/dev/deployment.yaml
+++ b/.k8s/dev/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: extensions/v1
 kind: Deployment
 metadata:
   name: laa-court-data-ui

--- a/.k8s/dev/ingress.yaml
+++ b/.k8s/dev/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: laa-court-data-ui-app-ingress

--- a/.k8s/production/deployment-worker.yaml
+++ b/.k8s/production/deployment-worker.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: laa-court-data-ui-worker

--- a/.k8s/production/deployment.yaml
+++ b/.k8s/production/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: laa-court-data-ui

--- a/.k8s/production/ingress.yaml
+++ b/.k8s/production/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: laa-court-data-ui-app-ingress

--- a/.k8s/staging/deployment-worker.yaml
+++ b/.k8s/staging/deployment-worker.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: laa-court-data-ui-worker

--- a/.k8s/staging/deployment.yaml
+++ b/.k8s/staging/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: laa-court-data-ui

--- a/.k8s/staging/ingress.yaml
+++ b/.k8s/staging/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: laa-court-data-ui-app-ingress


### PR DESCRIPTION
#### What
Remove Deprecated APIs for Kubernetes version 1.16. See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/apiversion-changes-k8s-1-16.html#removing-deprecated-apis-for-kubernetes-version-1-16

#### Ticket
https://dsdmoj.atlassian.net/browse/CBO-1345

#### Why
To allow for upgrade to Kubernetes v1.16

#### How
Amended apiVersion to apps/v1 in deployment.yaml and deployment-worker.yaml
Amended apiVersion to networking.k8s.io/v1beta1 in ingress.yaml