### PR TITLE
Fix testfile var reference for circle test splitting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,13 +144,13 @@ commands:
           command: |
                 mkdir /tmp/test-results
                 tmp/cc-test-reporter before-build
-                TESTS=$(circleci tests glob "spec/**/*_spec.rb" | circleci tests split)
+                TESTFILES=$(circleci tests glob "spec/**/*_spec.rb" | circleci tests split)
                 RUBYOPT=-W:no-deprecated \
                 bundle exec rspec \
                   --format progress \
                   --format RspecJunitFormatter \
                   --out /tmp/test-results/rspec.xml \
-                  $TEST_FILES
+                  $TESTFILES
                 tmp/cc-test-reporter format-coverage -t simplecov -o "tmp/coverage/codeclimate.$CIRCLE_NODE_INDEX.json"
       - store_test_results:
           path: /tmp/test-results


### PR DESCRIPTION
#### What
amend env var used to split tests

#### Why
This was setting and using a different var but
did not matter since it fallsback to all tests,
and we are only running with parrellism of 1
at the moment in any event