### PR TITLE
[security] bump sidekiq 5.2.7 --> 6.10

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'puma', '~> 4.3'
 gem 'rails', '~> 6.0.3'
 gem 'redis', '~> 4.2.1'
 gem 'sentry-raven'
-gem 'sidekiq', '~> 5.2.7'
+gem 'sidekiq', '~> 6.0'
 gem 'webpacker', '~> 5.1'
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,7 +97,7 @@ GEM
       descendants_tracker (~> 0.0.1)
     colorize (0.8.1)
     concurrent-ruby (1.1.6)
-    connection_pool (2.2.2)
+    connection_pool (2.2.3)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.6)
@@ -253,11 +253,9 @@ GEM
       nio4r (~> 2.0)
     puma (4.3.5-java)
       nio4r (~> 2.0)
-    rack (2.0.9)
+    rack (2.2.3)
     rack-contrib (2.1.0)
       rack (~> 2.0)
-    rack-protection (2.0.8.1)
-      rack
     rack-proxy (0.6.5)
       rack
     rack-test (1.1.0)
@@ -365,11 +363,10 @@ GEM
     sexp_processor (4.14.1)
     shoulda-matchers (4.3.0)
       activesupport (>= 4.2.0)
-    sidekiq (5.2.8)
-      connection_pool (~> 2.2, >= 2.2.2)
-      rack (< 2.1.0)
-      rack-protection (>= 1.5.0)
-      redis (>= 3.3.5, < 5)
+    sidekiq (6.1.0)
+      connection_pool (>= 2.2.2)
+      rack (~> 2.0)
+      redis (>= 4.2.0)
     simplecov (0.17.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -486,7 +483,7 @@ DEPENDENCIES
   rubocop-rspec
   sentry-raven
   shoulda-matchers
-  sidekiq (~> 5.2.7)
+  sidekiq (~> 6.0)
   simplecov (~> 0.17.1)
   spring
   spring-watcher-listen (~> 2.0.0)


### PR DESCRIPTION
#### What

Bump sidekiq to version 6+

#### Why
Although not directly related to security,
using sidekiq 5 means we cannot bump rack
to (< 2.1) and rack has a vulnerability
that needs handling:

https://github.com/ministryofjustice/laa-court-data-ui/network/alert/Gemfile.lock/rack/open

#### Note 
Since we recently offloaded sidekiq server to worker
pods the previous issue with sidekiq upgrade (proper
daemonization) should no longer be an issue