### PR TITLE
Enable new performance rubocop cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -66,6 +66,30 @@ Metrics/BlockLength:
 Metrics/MethodLength:
   Max: 15
 
+Performance/AncestorsInclude:
+  Enabled: true
+
+Performance/BigDecimalWithNumericArgument:
+  Enabled: true
+
+Performance/RedundantSortBlock:
+  Enabled: true
+
+Performance/RedundantStringChars:
+  Enabled: true
+
+Performance/ReverseFirst:
+  Enabled: true
+
+Performance/SortReverse:
+  Enabled: true
+
+Performance/Squeeze:
+  Enabled: true
+
+Performance/StringInclude:
+  Enabled: true
+
 # => Rails
 Rails/FilePath:
   Enabled: false


### PR DESCRIPTION
remove warnings for new performance cops in latest version by enabling - rubocop passes