### PR TITLE
Remove duplicated defendant_asn_or_nino_parameter

### DIFF
--- a/app/controllers/laa_references_controller.rb
+++ b/app/controllers/laa_references_controller.rb
@@ -48,7 +48,7 @@ class LaaReferencesController < ApplicationController
 
   def laa_reference_params
     params.permit(:id,
-                  link_attempt: %i[defendant_asn_or_nino defendant_id maat_reference defendant_asn_or_nino])
+                  link_attempt: %i[defendant_id maat_reference defendant_asn_or_nino])
   end
 
   def link_attempt_params


### PR DESCRIPTION
#### What
Remove duplicated defendant_asn_or_nino parameter from link_attempt permitted parameters

#### Ticket
n/a

#### Why
Added in error

#### How
Remove duplicated parameter

