### PR TITLE
Use aws cli version 2+ command for docker login

### DIFF
--- a/.k8s/scripts/build.sh
+++ b/.k8s/scripts/build.sh
@@ -25,7 +25,7 @@ function _build() {
   printf "\e[33mRegistry tag: $docker_registry_tag\e[0m\n"
   printf "\e[33m------------------------------------------------------------------------\e[0m\n"
   printf '\e[33mDocker login to registry (ECR)...\e[0m\n'
-  $(aws ecr --profile "$aws_profile" get-login --no-include-email --region "$region")
+  docker login -u AWS -p $(aws ecr get-login-password --profile "$aws_profile" --region "$region") $docker_endpoint
 
   printf '\e[33mBuilding app container image locally...\e[0m\n'
   docker build \


### PR DESCRIPTION
previous method broke for local build and push to ECR.

This may require updating of the circleci build and push too
but seems to be working so far (possibly beicase the cp tools
contains an older verion of th cli)