### PR TITLE
Add dependency to controller

### DIFF
--- a/app/controllers/laa_references_controller.rb
+++ b/app/controllers/laa_references_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_dependency 'court_data_adaptor'
+
 class LaaReferencesController < ApplicationController
   before_action :load_and_authorize_defendant_search,
                 :set_defendant_uuid_if_required,


### PR DESCRIPTION
#### What
Add dependency to controller

#### Why

Not having this is causing on pod start up

```
Unable to load application: NameError: uninitialized constant CourtDataAdaptor::Errors
Did you mean?  Errno
bundler: failed to load command: puma (/usr/local/bundle/bin/puma)
NameError: uninitialized constant CourtDataAdaptor::Errors
Did you mean?  Errno
```