### PR TITLE
Add ingress class annotations to k8s config

### DIFF
--- a/.k8s/dev/ingress.yaml
+++ b/.k8s/dev/ingress.yaml
@@ -3,6 +3,8 @@ kind: Ingress
 metadata:
   name: laa-court-data-ui-app-ingress
   namespace: laa-court-data-ui-dev
+  annotations:
+    kubernetes.io/ingress.class: laa-court-data-ui-dev
 spec:
   rules:
     - host: dev.view-court-data.service.justice.gov.uk

--- a/.k8s/production/ingress.yaml
+++ b/.k8s/production/ingress.yaml
@@ -3,6 +3,8 @@ kind: Ingress
 metadata:
   name: laa-court-data-ui-app-ingress
   namespace: laa-court-data-ui-production
+  annotations:
+    kubernetes.io/ingress.class: laa-court-data-ui-production
 spec:
   rules:
     - host: view-court-data.service.justice.gov.uk

--- a/.k8s/staging/ingress.yaml
+++ b/.k8s/staging/ingress.yaml
@@ -3,6 +3,8 @@ kind: Ingress
 metadata:
   name: laa-court-data-ui-app-ingress
   namespace: laa-court-data-ui-staging
+  annotations:
+    kubernetes.io/ingress.class: laa-court-data-ui-staging
 spec:
   rules:
     - host: staging.view-court-data.service.justice.gov.uk

--- a/.k8s/uat/ingress.yaml
+++ b/.k8s/uat/ingress.yaml
@@ -3,6 +3,8 @@ kind: Ingress
 metadata:
   name: laa-court-data-ui-app-ingress
   namespace: laa-court-data-ui-uat
+  annotations:
+    kubernetes.io/ingress.class: laa-court-data-ui-uat
 spec:
   rules:
     - host: uat.view-court-data.service.justice.gov.uk


### PR DESCRIPTION
WARNING: resources/ingress.tf required for namespace first

#### What
Add ingress class annotations to k8s config #257

#### Ticket

[CBO-1455](https://dsdmoj.atlassian.net/browse/CBO-1455)

#### Why
required by cloud platforms

> We're switching from one big nginx ingress to
having separate ingress controllers for each namespace.
You will need to add a one-line annotation to your ingress
definitions, but not until we ask you to do so. All traffic
to services on the cloud platform goes through ingress
controllers. Over-simplified, this is an AWS load-balancer
plus an nginx webserver, configured to route web traffic to
your service (generally based on the hostname of the web request).

> We originally decided to use a single* ingress controller for all
namespaces. i.e. one AWS load-balancer, and one nginx with a config
block for each ingress. This is partly for ease of management, and
partly to save money (because every AWS load-balancer costs around
$25/month, which adds up when you have several hundred of them).

>This architecture is not scaling well as we add more and more
ingresses, and we're starting to run into problems including nginx
pods running out of memory and crashing (possibly losing some web
requests when they do so), and ingress definitions taking a long
time to create/update. The underlying cause of both of these problems
is that the monolithic nginx configuration is unmanageably large.

> So, we have decided to change the architecture to have separate ingress
controllers for each namespace. i.e. every namespace will have its own
AWS load-balancer and nginx instance, which only handles web traffic for
the service(s) in that namespace.