### PR TITLE
Prevent 500s due to lack of hearing details

### DIFF
--- a/app/controllers/hearings_controller.rb
+++ b/app/controllers/hearings_controller.rb
@@ -14,9 +14,11 @@ class HearingsController < ApplicationController
   def show
     add_breadcrumb "Hearing #{@hearing_day&.strftime('%d/%m/%Y')}", ''
 
-    unless @hearing
-      redirect_back(fallback_location: prosecution_case_path(prosecution_case_reference), allow_other_host: false, notice: 'No hearing details available')
-    end
+    return if @hearing
+
+    redirect_back(fallback_location: prosecution_case_path(prosecution_case_reference),
+                  allow_other_host: false,
+                  notice: 'No hearing details available')
   end
 
   def prosecution_case_reference

--- a/app/controllers/hearings_controller.rb
+++ b/app/controllers/hearings_controller.rb
@@ -13,6 +13,10 @@ class HearingsController < ApplicationController
 
   def show
     add_breadcrumb "Hearing #{@hearing_day&.strftime('%d/%m/%Y')}", ''
+
+    unless @hearing
+      redirect_back(fallback_location: prosecution_case_path(prosecution_case_reference), allow_other_host: false, notice: 'No hearing details available')
+    end
   end
 
   def prosecution_case_reference

--- a/app/controllers/hearings_controller.rb
+++ b/app/controllers/hearings_controller.rb
@@ -18,7 +18,7 @@ class HearingsController < ApplicationController
 
     redirect_back(fallback_location: prosecution_case_path(prosecution_case_reference),
                   allow_other_host: false,
-                  notice: 'No hearing details available')
+                  notice: I18n.t('hearings.show.flash.notice.no_hearing_details'))
   end
 
   def prosecution_case_reference

--- a/app/views/hearings/show.html.haml
+++ b/app/views/hearings/show.html.haml
@@ -8,17 +8,17 @@
       %th.govuk-table__header{ scope: 'row' }
         = t('hearings.show.hearing_type')
       %td.govuk-table__cell
-        = @hearing.hearing_type
+        = @hearing&.hearing_type || 'not set'
     %tr.govuk-table__row
       %th.govuk-table__header{ scope: 'row' }
         = t('hearings.show.court')
       %td.govuk-table__cell
-        = @hearing.court_name || 'not set'
+        = @hearing&.court_name || 'not set'
     %tr.govuk-table__row
       %th.govuk-table__header{ scope: 'row' }
         = t('hearings.show.time_listed')
       %td.govuk-table__cell
-        = @hearing_day&.strftime('%H:%M')
+        = @hearing_day&.strftime('%H:%M') || 'not set'
 
 %h2.govuk-heading-m
   = t('hearings.show.attendees.heading')
@@ -31,22 +31,22 @@
       %th.govuk-table__header{ scope: 'row' }
         = t('hearings.show.attendees.defendants')
       %td.govuk-table__cell
-        = @hearing.defendant_names.join(', ')
+        = @hearing&.defendant_names&.join(', ') || 'not set'
     %tr.govuk-table__row
       %th.govuk-table__header{ scope: 'row' }
         = t('hearings.show.attendees.defence')
       %td.govuk-table__cell
-        = @hearing.defence_advocate_names&.join(', ') || 'not set'
+        = @hearing&.defence_advocate_names&.join(', ') || 'not set'
     %tr.govuk-table__row
       %th.govuk-table__header{ scope: 'row' }
         = t('hearings.show.attendees.prosecution')
       %td.govuk-table__cell
-        = @hearing.prosecution_advocate_names&.join(', ') || 'not set'
+        = @hearing&.prosecution_advocate_names&.join(', ') || 'not set'
     %tr.govuk-table__row
       %th.govuk-table__header{ scope: 'row' }
         = t('hearings.show.attendees.judges')
       %td.govuk-table__cell
-        = @hearing.judge_names.join(', ')
+        = @hearing&.judge_names&.join(', ') || 'not set'
 
 %table.govuk-table
   %caption.govuk-table__caption.govuk-visually-hidden
@@ -56,7 +56,7 @@
       %th.govuk-table__header{ scope: 'col' }= t('hearings.show.events.time')
       %th.govuk-table__header{ scope: 'col' }= t('hearings.show.events.event')
   %tbody.govuk-table__body
-    - @hearing.hearing_events.sort {|a,b| a.occurred_at <=> b.occurred_at }.each do |event|
+    - @hearing&.hearing_events&.sort {|a,b| a.occurred_at <=> b.occurred_at }&.each do |event|
       %tr.govuk-table__row
         %td.govuk-table__cell
           = event.occurred_at.to_datetime.strftime('%H:%M')
@@ -69,7 +69,7 @@
   = govuk_detail('View raw data') do
     %h3='Hearings'
     %pre
-      = JSON.pretty_generate(@hearing.attributes)
+      = JSON.pretty_generate(@hearing&.attributes)
     %h3='Hearing events'
     %pre
-      = JSON.pretty_generate(@hearing.hearing_events.map(&:attributes))
+      = JSON.pretty_generate(@hearing&.hearing_events&.map(&:attributes))

--- a/app/views/hearings/show.html.haml
+++ b/app/views/hearings/show.html.haml
@@ -8,17 +8,17 @@
       %th.govuk-table__header{ scope: 'row' }
         = t('hearings.show.hearing_type')
       %td.govuk-table__cell
-        = @hearing&.hearing_type || 'not set'
+        = @hearing&.hearing_type || t('generic.not_available')
     %tr.govuk-table__row
       %th.govuk-table__header{ scope: 'row' }
         = t('hearings.show.court')
       %td.govuk-table__cell
-        = @hearing&.court_name || 'not set'
+        = @hearing&.court_name || t('generic.not_available')
     %tr.govuk-table__row
       %th.govuk-table__header{ scope: 'row' }
         = t('hearings.show.time_listed')
       %td.govuk-table__cell
-        = @hearing_day&.strftime('%H:%M') || 'not set'
+        = @hearing_day&.strftime('%H:%M') || t('generic.not_available')
 
 %h2.govuk-heading-m
   = t('hearings.show.attendees.heading')
@@ -31,22 +31,22 @@
       %th.govuk-table__header{ scope: 'row' }
         = t('hearings.show.attendees.defendants')
       %td.govuk-table__cell
-        = @hearing&.defendant_names&.join(', ') || 'not set'
+        = @hearing&.defendant_names&.join(', ') || t('generic.not_available')
     %tr.govuk-table__row
       %th.govuk-table__header{ scope: 'row' }
         = t('hearings.show.attendees.defence')
       %td.govuk-table__cell
-        = @hearing&.defence_advocate_names&.join(', ') || 'not set'
+        = @hearing&.defence_advocate_names&.join(', ') || t('generic.not_available')
     %tr.govuk-table__row
       %th.govuk-table__header{ scope: 'row' }
         = t('hearings.show.attendees.prosecution')
       %td.govuk-table__cell
-        = @hearing&.prosecution_advocate_names&.join(', ') || 'not set'
+        = @hearing&.prosecution_advocate_names&.join(', ') || t('generic.not_available')
     %tr.govuk-table__row
       %th.govuk-table__header{ scope: 'row' }
         = t('hearings.show.attendees.judges')
       %td.govuk-table__cell
-        = @hearing&.judge_names&.join(', ') || 'not set'
+        = @hearing&.judge_names&.join(', ') || t('generic.not_available')
 
 %table.govuk-table
   %caption.govuk-table__caption.govuk-visually-hidden

--- a/app/views/prosecution_cases/show.html.haml
+++ b/app/views/prosecution_cases/show.html.haml
@@ -42,7 +42,7 @@
               = hearing_summary.hearing_type
             %td.govuk-table__cell
               - hearing = prosecution_case.hearings.find { |h| h.id == hearing_summary.id}
-              = hearing&.defence_advocate_names&.join(', ') || 'not set'
+              = hearing&.defence_advocate_names&.join(', ') || t('generic.not_available')
 
 - if Rails.configuration.x.display_raw_responses
   %br

--- a/config/locales/en/generic.yml
+++ b/config/locales/en/generic.yml
@@ -10,5 +10,6 @@ en:
         blank_option: Please select
     hearing: Hearing
     new_window: opens in a new window
+    not_available: Not available
     search: Search
     warning: Warning

--- a/config/locales/en/views/hearings.yml
+++ b/config/locales/en/views/hearings.yml
@@ -14,5 +14,8 @@ en:
         caption: Hearing events
         event: Event
         time: Time
+      flash:
+        notice:
+          no_hearing_details: No hearing details available
       hearing_type: Hearing type
       time_listed: Time listed

--- a/spec/requests/hearings_spec.rb
+++ b/spec/requests/hearings_spec.rb
@@ -34,4 +34,24 @@ RSpec.describe 'hearings', type: :request do
       expect(response).to redirect_to new_user_session_path
     end
   end
+
+  context 'when no hearing data available' do
+    before do
+      stub_request(:get, %r{#{ENV['COURT_DATA_ADAPTOR_API_URL']}/hearings/.*})
+        .to_return(
+          body: '',
+          headers: { 'Content-Type' => 'application/text' }
+        )
+      sign_in user
+      get "/hearings/#{hearing_id_from_fixture}?urn=#{case_reference}"
+    end
+
+    it 'redirects back to prosecution case page' do
+      expect(response).to redirect_to prosecution_case_path(case_reference)
+    end
+
+    it 'flashes notice' do
+      expect(flash.now[:notice]).to match(/No hearing details available/)
+    end
+  end
 end


### PR DESCRIPTION
#### What
Provide more informative/useful response to users when
hearing details are absent or partially missing.

#### Why
Currently lack of hearing details will raise
500s which is not very useful or resilient.