### PR TITLE
Resolve webpacker warnings

### DIFF
--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -11,7 +11,7 @@ default: &default
 
   # Additional paths webpack should lookup modules
   # ['app/assets', 'engine/foo/app/assets']
-  resolved_paths: ['node_modules/govuk-frontend/govuk']
+  additional_paths: ['node_modules/govuk-frontend/govuk']
 
   # Reload manifest.json on all requests so we reload latest compiled packs
   cache_manifest: false

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "dependencies": {
     "@rails/ujs": "^6.0.3",
     "@rails/webpacker": "5.2.1",
-    "govuk-frontend": "^3.8.1"
+    "govuk-frontend": "^3.8.1",
+    "webpack": "^4.44.1"
   },
   "devDependencies": {
     "sass-lint": "^1.13.1",


### PR DESCRIPTION
#### What
Resolve webpacker warnings

#### Why
Application warnings relating to webpacker (1) Unmet peer dependency, (2) The resolved_paths option has been deprecated

