### PR TITLE
Add contact_us view

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class PagesController < ApplicationController
+  skip_before_action :authenticate_user!
+  skip_authorization_check
+
+  def contact_us; end
+end

--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -7,19 +7,10 @@
 
         %ul.govuk-footer__inline-list
           %li.govuk-footer__inline-list-item
-            %a.govuk-footer__link{href: "#1"}
-              = t('layouts.application.footer.help')
-
-          %li.govuk-footer__inline-list-item
             = link_to t('layouts.application.footer.cookies'), cookies_path, class: 'govuk-footer__link'
 
           %li.govuk-footer__inline-list-item
-            %a.govuk-footer__link{href: "#3"}
-              = t('layouts.application.footer.contact')
-
-          %li.govuk-footer__inline-list-item
-            %a.govuk-footer__link{href: "#4"}
-              = t('layouts.application.footer.terms')
+            = link_to t('layouts.application.footer.contact'), contact_us_path, class: 'govuk-footer__link'
 
           %li.govuk-footer__inline-list-item
             = t('layouts.application.footer.built_by_html')

--- a/app/views/pages/contact_us.html.haml
+++ b/app/views/pages/contact_us.html.haml
@@ -1,0 +1,11 @@
+= govuk_page_title(t('pages.contact_us.page_title'))
+
+%p.govuk-body
+  =t('pages.contact_us.paragraph')
+
+%dl.govuk-summary-list
+  .govuk-summary-list__row
+    %dt.govuk-summary-list__key
+      = t('pages.contact_us.contact_details_email')
+    %dd.govuk-summary-list__value
+      = mail_to Rails.configuration.x.support_email_address, Rails.configuration.x.support_email_address, class: 'govuk-link'

--- a/config/locales/en/views/contact_us.yml
+++ b/config/locales/en/views/contact_us.yml
@@ -1,0 +1,7 @@
+---
+en:
+  pages:
+    contact_us:
+      contact_details_email: Email
+      page_title: Contact us
+      paragraph: 'For general queries, contact:'

--- a/config/locales/en/views/layouts.yml
+++ b/config/locales/en/views/layouts.yml
@@ -11,10 +11,8 @@ en:
         contact: Contact
         cookies: Cookies
         copyright: "© Crown copyright"
-        help: Help
         licence_html: All content is available under the <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>
         support: Support links
-        terms: Terms and conditions
       header:
         navigation:
           manage_users: Manage users

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,7 @@ Rails.application.routes.draw do
   resources :feedback, only: %i[new create]
 
   get 'cookies', to: 'help#cookies'
+  get '/contact_us', to: 'pages#contact_us'
 
   get 'ping', to: 'status#ping', format: :json
 

--- a/spec/features/page/contact_us_spec.rb
+++ b/spec/features/page/contact_us_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+RSpec.feature 'Comntact_us', type: :feature, js: true do
+  context 'when on the contact_us page' do
+    scenario 'content should be available' do
+      visit '/'
+      click_link('Contact')
+
+      within '.govuk-main-wrapper' do
+        expect(page).to have_css('.govuk-heading-xl', text: 'Contact us')
+        expect(page).to have_css('.govuk-link', text: Rails.configuration.x.support_email_address)
+      end
+
+      expect(page).to be_accessible.within '#main-content'
+    end
+  end
+end


### PR DESCRIPTION
#### What
Add a 'Contact us' page.
Removal of unused footer links.

#### Why
Display information on how users can submit general queries pertaining to the web application.