### PR TITLE
[Security] Bump node-forge from 0.9.0 to 0.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "http-proxy": "^1.18.1",
     "kind-of": "^6.0.3",
     "minimist": "^1.2.2",
+    "node-forge": "^0.10.0",
     "serialize-javascript": "^3.1.0"
   },
   "standard": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5601,10 +5601,10 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-node-forge@0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.9.0.tgz#d624050edbb44874adca12bb9a52ec63cb782579"
-  integrity sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ==
+node-forge@0.9.0, node-forge@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"
+  integrity sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==
 
 node-gyp@^3.8.0:
   version "3.8.0"


### PR DESCRIPTION
#### What
Bump node-forge from 0.9.0 to 0.10.0

#### Why
High severity security issue with dependency lower than version 0.10.0
