### PR TITLE
Change ECR login mechanism

### DIFF
--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -22,8 +22,8 @@ function _circleci_build() {
   printf "\e[33mBranch: $CIRCLE_BRANCH\e[0m\n"
   printf "\e[33mRegistry tag: $docker_registry_tag\e[0m\n"
   printf "\e[33m------------------------------------------------------------------------\e[0m\n"
-
-  $(aws ecr get-login --region ${AWS_DEFAULT_REGION} --no-include-email)
+  printf '\e[33mDocker login to registry (ECR)...\e[0m\n'
+  aws ecr get-login-password --region ${AWS_DEFAULT_REGION} | docker login --username AWS --password-stdin ${ECR_ENDPOINT}
 
   docker build \
     --build-arg BUILD_DATE=$(date +%Y-%m-%dT%H:%M:%S%z) \

--- a/.k8s/scripts/build.sh
+++ b/.k8s/scripts/build.sh
@@ -25,7 +25,7 @@ function _build() {
   printf "\e[33mRegistry tag: $docker_registry_tag\e[0m\n"
   printf "\e[33m------------------------------------------------------------------------\e[0m\n"
   printf '\e[33mDocker login to registry (ECR)...\e[0m\n'
-  docker login -u AWS -p $(aws ecr get-login-password --profile "$aws_profile" --region "$region") $docker_endpoint
+  aws ecr get-login-password --profile "$aws_profile" --region "$region" | docker login --username AWS --password-stdin ${docker_endpoint}
 
   printf '\e[33mBuilding app container image locally...\e[0m\n'
   docker build \


### PR DESCRIPTION
Update ECR login mechanism for pushing builds

#### What
Use current preferred login mechanism

#### Why
More secure and old get-login mechanism is deprecated
