### PR TITLE
Revert ingress annotations

### DIFF
--- a/.k8s/dev/ingress.yaml
+++ b/.k8s/dev/ingress.yaml
@@ -3,8 +3,6 @@ kind: Ingress
 metadata:
   name: laa-court-data-ui-app-ingress
   namespace: laa-court-data-ui-dev
-  annotations:
-    kubernetes.io/ingress.class: laa-court-data-ui-dev
 spec:
   rules:
     - host: dev.view-court-data.service.justice.gov.uk

--- a/.k8s/production/ingress.yaml
+++ b/.k8s/production/ingress.yaml
@@ -3,8 +3,6 @@ kind: Ingress
 metadata:
   name: laa-court-data-ui-app-ingress
   namespace: laa-court-data-ui-production
-  annotations:
-    kubernetes.io/ingress.class: laa-court-data-ui-production
 spec:
   rules:
     - host: view-court-data.service.justice.gov.uk

--- a/.k8s/staging/ingress.yaml
+++ b/.k8s/staging/ingress.yaml
@@ -3,8 +3,6 @@ kind: Ingress
 metadata:
   name: laa-court-data-ui-app-ingress
   namespace: laa-court-data-ui-staging
-  annotations:
-    kubernetes.io/ingress.class: laa-court-data-ui-staging
 spec:
   rules:
     - host: staging.view-court-data.service.justice.gov.uk

--- a/.k8s/uat/ingress.yaml
+++ b/.k8s/uat/ingress.yaml
@@ -3,8 +3,6 @@ kind: Ingress
 metadata:
   name: laa-court-data-ui-app-ingress
   namespace: laa-court-data-ui-uat
-  annotations:
-    kubernetes.io/ingress.class: laa-court-data-ui-uat
 spec:
   rules:
     - host: uat.view-court-data.service.justice.gov.uk


### PR DESCRIPTION
#### What
Revert ingress annotations

#### Why
> In response to this morning's incident, we are moving
services' ingresses back to the default ingress controller
(we'll publish full details of why this is necessary in our
post-incident report).

> If you have a dedicated ingress controller (i.e. you have a
custom kubernetes.io/ingress.class annotation), please remove this
annotation from your ingress definitions before redeploying your service.

> If you redeploy your service and change back to your dedicated ingress
controller, after we have moved your ingress to the default ingress
controller, your service will be unavailable.