### PR TITLE
Extend hearing_events tests to cover properties

### DIFF
--- a/spec/lib/court_data_adaptor/resource/hearing_event_spec.rb
+++ b/spec/lib/court_data_adaptor/resource/hearing_event_spec.rb
@@ -13,4 +13,11 @@ RSpec.describe CourtDataAdaptor::Resource::HearingEvent do
   include_examples 'court_data_adaptor resource callbacks' do
     let(:instance) { described_class.new(hearing_id: nil) }
   end
+
+  context 'with properties' do
+    subject(:instance) { described_class.new(hearing_id: nil) }
+
+    it { is_expected.to respond_to :description }
+    it { is_expected.to respond_to :occurred_at }
+  end
 end


### PR DESCRIPTION
#### What
Add hearing event tests to cover properties
as other PR is for providers.

#### Why
Increase test coverage of this object