### PR TITLE
Display plea detail and mode of trial reason for defendant

### DIFF
--- a/app/views/defendants/_offences.html.haml
+++ b/app/views/defendants/_offences.html.haml
@@ -15,7 +15,7 @@
         %td.govuk-table__cell
           = offence.title
         %td.govuk-table__cell
-          = offence.plea || t('generic.not_available')
+          = offence.plea_and_date || t('generic.not_available')
         %td.govuk-table__cell
           = "#{offence.mode_of_trial}:"
           %br

--- a/app/views/defendants/_offences.html.haml
+++ b/app/views/defendants/_offences.html.haml
@@ -15,6 +15,8 @@
         %td.govuk-table__cell
           = offence.title
         %td.govuk-table__cell
-          Not yet available
+          = offence.plea || t('generic.not_available')
         %td.govuk-table__cell
-          = offence.mode_of_trial
+          = "#{offence.mode_of_trial}:"
+          %br
+          = offence.mode_of_trial_reason || t('generic.not_available')

--- a/app/views/defendants/_offences.html.haml
+++ b/app/views/defendants/_offences.html.haml
@@ -13,7 +13,7 @@
     - @defendant.offences.each do |offence|
       %tr.govuk-table__row
         %td.govuk-table__cell
-          = offence.title
+          = offence.title || t('generic.not_available')
         %td.govuk-table__cell
           = offence.plea_and_date || t('generic.not_available')
         %td.govuk-table__cell

--- a/lib/court_data_adaptor/resource/defendant.rb
+++ b/lib/court_data_adaptor/resource/defendant.rb
@@ -5,6 +5,8 @@ module CourtDataAdaptor
     class Defendant < Base
       acts_as_resource self
 
+      has_many :offences
+
       property :prosecution_case_reference, type: :string
       property :name, type: :string
       property :user_name

--- a/lib/court_data_adaptor/resource/offence.rb
+++ b/lib/court_data_adaptor/resource/offence.rb
@@ -12,6 +12,11 @@ module CourtDataAdaptor
       property :plea_date, type: :string
       property :mode_of_trial, type: :string
       property :mode_of_trial_reason, type: :string
+
+      def plea_and_date
+        return if plea.nil?
+        "#{plea&.humanize} on #{plea_date&.to_date&.strftime('%d/%m/%Y')}"
+      end
     end
   end
 end

--- a/lib/court_data_adaptor/resource/offence.rb
+++ b/lib/court_data_adaptor/resource/offence.rb
@@ -6,6 +6,12 @@ module CourtDataAdaptor
       acts_as_resource self
 
       belongs_to :defendant
+
+      property :title, type: :string
+      property :plea, type: :string
+      property :plea_date, type: :string
+      property :mode_of_trial, type: :string
+      property :mode_of_trial_reason, type: :string
     end
   end
 end

--- a/spec/features/unlinked_defendant_flow_spec.rb
+++ b/spec/features/unlinked_defendant_flow_spec.rb
@@ -252,6 +252,9 @@ RSpec.feature 'Unlinked defendant page flow', type: :feature, stub_unlinked: tru
       expect(page).to have_css('.govuk-table__header', text: 'Offence')
       expect(page).to have_css('.govuk-table__header', text: 'Plea')
       expect(page).to have_css('.govuk-table__header', text: 'Mode of trial')
+
+      expect(page).to have_css('.govuk-table__cell', text: 'Not guilty on 12/04/2020')
+      expect(page).to have_css('.govuk-table__cell', text: /Indictable only:.*Court directs trial by jury/)
     end
   end
 

--- a/spec/fixtures/stubs/unlinked_defendant.json
+++ b/spec/fixtures/stubs/unlinked_defendant.json
@@ -1,30 +1,49 @@
 {
-  "data": [
-    {
-      "id": "41fcb1cd-516e-438e-887a-5987d92ef90f",
-      "type": "defendants",
-      "attributes": {
-        "name": "Jammy Dodger",
-        "date_of_birth": "1961-06-15",
-        "national_insurance_number":"JC123456A",
-        "arrest_summons_number":"0TSQT1LMI7CR",
-        "gender": null,
-        "address_1": null,
-        "address_2": null,
-        "address_3": null,
-        "address_4": null,
-        "address_5": null,
-        "postcode": null
+  "data": {
+    "id": "41fcb1cd-516e-438e-887a-5987d92ef90f",
+    "type": "defendants",
+    "attributes": {
+      "name": "Jammy Dodger",
+      "date_of_birth": "1961-06-15",
+      "national_insurance_number":"JC123456A",
+      "arrest_summons_number":"0TSQT1LMI7CR",
+      "maat_reference": null,
+      "representation_order_date": null,
+      "prosecution_case_id": "c37c2ca9-d5f9-4758-a224-52ba918a3d64"
+    },
+    "relationships": {
+      "offences": {
+        "data": [
+          {
+            "id": "6de5bcf7-c3bd-47cd-9c74-a79d06aaf3dc",
+            "type": "offences"
+          }
+        ]
       },
-      "relationships": {
-        "offences": {
-          "data": [
-            {
-              "id": "6de5bcf7-c3bd-47cd-9c74-a79d06aaf3dc",
-              "type": "offences"
-            }
-          ]
+      "defence_organisation": {
+        "data": null
+      },
+      "prosecution_case": {
+        "data": {
+          "id": "c37c2ca9-d5f9-4758-a224-52ba918a3d64",
+          "type": "prosecution_case"
         }
+      }
+    }
+  },
+  "included": [
+    {
+      "id": "6de5bcf7-c3bd-47cd-9c74-a79d06aaf3dc",
+      "type": "offences",
+      "attributes": {
+        "code": "PT00011",
+        "order_index": 1,
+        "title": "Copying false instrument with intent",
+        "mode_of_trial": "Indictable only",
+        "mode_of_trial_reason": "Court directs trial by jury",
+        "mode_of_trial_reason_code": "05",
+        "plea": "NOT_GUILTY",
+        "plea_date": "2020-04-12"
       }
     }
   ]

--- a/spec/lib/court_data_adaptor/resource/offence_spec.rb
+++ b/spec/lib/court_data_adaptor/resource/offence_spec.rb
@@ -13,4 +13,6 @@ RSpec.describe CourtDataAdaptor::Resource::Offence do
   include_examples 'court_data_adaptor resource callbacks' do
     let(:instance) { described_class.new(defendant_id: nil) }
   end
+
+  it { is_expected.to respond_to(:title, :plea, :plea_date, :mode_of_trial, :mode_of_trial_reason) }
 end

--- a/spec/lib/court_data_adaptor/resource/offence_spec.rb
+++ b/spec/lib/court_data_adaptor/resource/offence_spec.rb
@@ -15,4 +15,28 @@ RSpec.describe CourtDataAdaptor::Resource::Offence do
   end
 
   it { is_expected.to respond_to(:title, :plea, :plea_date, :mode_of_trial, :mode_of_trial_reason) }
+
+  describe '#plea_and_date' do
+    subject { instance.plea_and_date }
+
+    let(:instance) { described_class.new(defendant_id: nil) }
+
+    context 'when plea exists on offence' do
+      before do
+        allow(instance).to receive(:plea).and_return('NOT_GUILTY')
+        allow(instance).to receive(:plea_date).and_return('2020-01-01')
+      end
+
+      it { is_expected.to eql 'Not guilty on 01/01/2020' }
+    end
+
+    context 'when plea does not exist on offence' do
+      before do
+        allow(instance).to receive(:plea).and_return(nil)
+        allow(instance).to receive(:plea_date).and_return(nil)
+      end
+
+      it { is_expected.to be_nil }
+    end
+  end
 end

--- a/spec/views/defendants/_offences.html.haml_spec.rb
+++ b/spec/views/defendants/_offences.html.haml_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+RSpec.describe 'defendants/_offences.html.haml', type: :view do
+  let(:defendant) { object_double(CourtDataAdaptor::Resource::Defendant.new, offences: [offence]) }
+  let(:offence) { CourtDataAdaptor::Resource::Offence.new }
+
+  before do
+    assign(:defendant, defendant)
+  end
+
+  context 'when the defendant has an offence' do
+    context 'when the offence has a mode of trial' do
+      before { allow(offence).to receive(:mode_of_trial).and_return('Indictable only') }
+
+      context 'with reason' do
+        before do
+          allow(offence).to receive(:mode_of_trial_reason).and_return('Court directs trial by jury')
+        end
+
+        it 'displays mode of trial with reason' do
+          render
+          expect(rendered).to have_css('.govuk-table__cell',
+                                       text: /Indictable only:\n*Court directs trial by jury/)
+        end
+      end
+
+      context 'without reason' do
+        before { allow(offence).to receive(:mode_of_trial_reason).and_return(nil) }
+
+        it 'displays mode of trial without reason' do
+          render
+          expect(rendered).to have_css('.govuk-table__cell', text: /Indictable only:\n*Not available/)
+        end
+      end
+    end
+
+    context 'when the offence has a title' do
+      before { allow(offence).to receive(:title).and_return('Murder') }
+
+      it 'displays offence title' do
+        render
+        expect(rendered).to have_css('.govuk-table__cell', text: 'Murder')
+      end
+    end
+
+    context 'when the offence has no title' do
+      before { allow(offence).to receive(:title).and_return(nil) }
+
+      it 'displays not available' do
+        render
+        expect(rendered).to have_css('.govuk-table__cell:nth-of-type(1)', text: 'Not available')
+      end
+    end
+
+    context 'when the offence has plea details' do
+      before do
+        allow(offence).to receive(:plea).and_return('NOT_GUILTY')
+        allow(offence).to receive(:plea_date).and_return('2020-04-12')
+        allow(offence).to receive(:plea_and_date).and_call_original
+      end
+
+      it 'displays plea and plea date' do
+        render
+        expect(rendered).to have_css('.govuk-table__cell', text: 'Not guilty on 12/04/2020')
+      end
+    end
+
+    context 'when the offence has no plea details' do
+      before do
+        allow(offence).to receive(:plea).and_return(nil)
+        allow(offence).to receive(:plea_date).and_return(nil)
+        allow(offence).to receive(:plea_and_date).and_call_original
+      end
+
+      it 'displays Not available for plea and plea date' do
+        render
+        expect(rendered).to have_css('.govuk-table__cell:nth-of-type(2)', text: 'Not available')
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What
Display plea, plea date, and offence mode of trial to defendant view

#### Ticket

[mode of trial reason CBO-1575](https://dsdmoj.atlassian.net/browse/CBO-1575)
[plea details CBO-1588](https://dsdmoj.atlassian.net/browse/CBO-1588)

#### Why
The mode of trial reason and plea details are required information
for caseworkers as it impacts claimable fee values.

#### How

Use amended defedendant endpoint to retrieve these details

see [related PR](https://github.com/ministryofjustice/laa-court-data-adaptor/pull/325)
upon which this functionality depends. However, this could be merged prior
to the adaptor changes without breaking current functionality.