### PR TITLE
Add metrics container to worker pods

### DIFF
--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -62,7 +62,7 @@ function _circleci_deploy() {
 
   # apply deployment with specfied image
   kubectl set image -f .k8s/${environment}/deployment.yaml laa-court-data-ui-app=${docker_image_tag} laa-court-data-ui-metrics=${docker_image_tag} --local -o yaml | kubectl apply -f -
-  kubectl set image -f .k8s/${environment}/deployment-worker.yaml laa-court-data-ui-worker=${docker_image_tag} --local --output yaml | kubectl apply -f -
+  kubectl set image -f .k8s/${environment}/deployment-worker.yaml laa-court-data-ui-worker=${docker_image_tag} laa-court-data-ui-metrics=${docker_image_tag} --local --output yaml | kubectl apply -f -
 
   # apply non-image specific config
   kubectl apply \

--- a/.k8s/dev/deployment-worker.yaml
+++ b/.k8s/dev/deployment-worker.yaml
@@ -80,3 +80,21 @@ spec:
                 secretKeyRef:
                   name: lcdui-secrets
                   key: GOVUK_NOTIFY_API_KEY
+        - name: laa-court-data-ui-metrics
+          image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/laa-get-paid/laa-court-data-ui:set-me
+          imagePullPolicy: Always
+          command: ['sh', '-c', "bundle exec prometheus_exporter --bind 0.0.0.0"]
+          ports:
+          - containerPort: 9394
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: 9394
+            initialDelaySeconds: 10
+            periodSeconds: 60
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: 9394
+            initialDelaySeconds: 10
+            periodSeconds: 60

--- a/.k8s/production/deployment-worker.yaml
+++ b/.k8s/production/deployment-worker.yaml
@@ -85,3 +85,22 @@ spec:
                 secretKeyRef:
                   name: lcdui-secrets
                   key: SENTRY_DSN
+        - name: laa-court-data-ui-metrics
+          image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/laa-get-paid/laa-court-data-ui:set-me
+          imagePullPolicy: Always
+          command: ['sh', '-c', "bundle exec prometheus_exporter --bind 0.0.0.0"]
+          ports:
+          - containerPort: 9394
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: 9394
+            initialDelaySeconds: 10
+            periodSeconds: 60
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: 9394
+            initialDelaySeconds: 10
+            periodSeconds: 60
+

--- a/.k8s/scripts/deploy.sh
+++ b/.k8s/scripts/deploy.sh
@@ -73,7 +73,7 @@ function _deploy() {
 
   # apply deployment with specfied image
   kubectl set image -f .k8s/${environment}/deployment.yaml ${repo_name}-app=${docker_image_tag} ${repo_name}-metrics=${docker_image_tag} --local --output yaml | kubectl apply -f -
-  kubectl set image -f .k8s/${environment}/deployment-worker.yaml ${repo_name}-worker=${docker_image_tag} --local --output yaml | kubectl apply -f -
+  kubectl set image -f .k8s/${environment}/deployment-worker.yaml ${repo_name}-worker=${docker_image_tag} ${repo_name}-metrics=${docker_image_tag} --local --output yaml | kubectl apply -f -
 
   # apply non-image specific config
   kubectl apply \

--- a/.k8s/staging/deployment-worker.yaml
+++ b/.k8s/staging/deployment-worker.yaml
@@ -85,3 +85,22 @@ spec:
                 secretKeyRef:
                   name: lcdui-secrets
                   key: SENTRY_DSN
+        - name: laa-court-data-ui-metrics
+          image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/laa-get-paid/laa-court-data-ui:set-me
+          imagePullPolicy: Always
+          command: ['sh', '-c', "bundle exec prometheus_exporter --bind 0.0.0.0"]
+          ports:
+          - containerPort: 9394
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: 9394
+            initialDelaySeconds: 10
+            periodSeconds: 60
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: 9394
+            initialDelaySeconds: 10
+            periodSeconds: 60
+

--- a/.k8s/uat/deployment-worker.yaml
+++ b/.k8s/uat/deployment-worker.yaml
@@ -85,3 +85,21 @@ spec:
                 secretKeyRef:
                   name: lcdui-secrets
                   key: SENTRY_DSN
+        - name: laa-court-data-ui-metrics
+          image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/laa-get-paid/laa-court-data-ui:set-me
+          imagePullPolicy: Always
+          command: ['sh', '-c', "bundle exec prometheus_exporter --bind 0.0.0.0"]
+          ports:
+          - containerPort: 9394
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: 9394
+            initialDelaySeconds: 10
+            periodSeconds: 60
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: 9394
+            initialDelaySeconds: 10
+            periodSeconds: 60


### PR DESCRIPTION
#### What
Fix `Prometheus Exporter, failed to send message Address not available - connect(2) for "localhost" port 9394` error in worker pods

#### Ticket
N/A

#### Why
Currently the worker pods are logging the error above, as they are not able to connect to a prometheus_exporter

#### How
This pr creates a metrics container on worker pods (in the same way as the pods running the application have a metrics container) and runs bundle exec prometheus_exporter in this container. This means that the error above isn't raised and also potentially that we can gather metrics on the worker pods.


