### PR TITLE
Display multiple pleas on an offence

### DIFF
--- a/app/decorators/base_decorator.rb
+++ b/app/decorators/base_decorator.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class BaseDecorator < SimpleDelegator
+  def initialize(object, context = nil)
+    @object = object
+    @context = context
+    super(@object)
+  end
+
+  attr_reader :object, :context
+
+  alias view context
+  alias h context
+
+  delegate :translate, :t, :tag, :safe_join, to: :context
+end

--- a/app/decorators/offence_decorator.rb
+++ b/app/decorators/offence_decorator.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class OffenceDecorator < BaseDecorator
+  def plea_list
+    return t('generic.not_available') if pleas.blank?
+    return pleas unless pleas.is_a?(Enumerable)
+
+    safe_join(plea_sentences, tag(:br))
+  end
+
+  private
+
+  def plea_sentences
+    sorted_pleas.map { |plea| plea_sentence(plea) }
+  end
+
+  def sorted_pleas
+    pleas.sort_by { |plea| plea&.pleaded_at || Date.new.iso8601 }
+  end
+
+  def plea_sentence(plea)
+    t('offence.plea.sentence',
+      plea: plea.code&.humanize || t('generic.not_available'),
+      pleaded_at: plea.pleaded_at&.to_date&.strftime('%d/%m/%Y') || t('generic.not_available'))
+  end
+end

--- a/app/decorators/offence_decorator.rb
+++ b/app/decorators/offence_decorator.rb
@@ -5,7 +5,7 @@ class OffenceDecorator < BaseDecorator
     return t('generic.not_available') if pleas.blank?
     return pleas unless pleas.is_a?(Enumerable)
 
-    safe_join(plea_sentences, tag(:br))
+    safe_join(plea_sentences, tag.br)
   end
 
   private

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,4 +10,19 @@ module ApplicationHelper
   def l(date, options = {})
     super(date, **options) if date
   end
+
+  # NOTE: implicit decorators assumed to be in app/decorators
+  def decorate(object, decorator_class = nil)
+    decorator_class ||= "#{object.class.to_s.demodulize}Decorator".constantize
+    decorator = decorator_class.new(object, self)
+    yield(decorator) if block_given?
+    decorator
+  end
+
+  def decorate_all(objects, decorator_class = nil, &block)
+    objects.map do |object|
+      decorate(object, decorator_class, &block)
+    end
+  end
+  alias decorate_each decorate_all
 end

--- a/app/views/defendants/_offences.html.haml
+++ b/app/views/defendants/_offences.html.haml
@@ -10,12 +10,12 @@
       %th.govuk-table__header{ scope: 'col' }= t('search.result.offence.plea')
       %th.govuk-table__header{ scope: 'col' }= t('search.result.offence.mode_of_trial')
   %tbody.govuk-table__body
-    - @defendant.offences.each do |offence|
+    - decorate_each(@defendant.offences) do |offence|
       %tr.govuk-table__row
         %td.govuk-table__cell
           = offence.title || t('generic.not_available')
         %td.govuk-table__cell
-          = offence.plea_and_date || t('generic.not_available')
+          = offence.plea_list
         %td.govuk-table__cell
           = "#{offence.mode_of_trial}:"
           %br

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -77,4 +77,7 @@ Rails.application.configure do
 
   # action mailer options for devise
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+
+  # raise i18n missing translations
+  config.action_view.raise_on_missing_translations = true
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -54,6 +54,9 @@ Rails.application.configure do
   #
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
 
+  # raise i18n missing translations
+  config.action_view.raise_on_missing_translations = true
+
   # see https://github.com/shadabahmed/logstasher
   config.logstasher.enabled = false
   if config.logstasher.enabled

--- a/config/initializers/court_data_adaptor.rb
+++ b/config/initializers/court_data_adaptor.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'court_data_adaptor/configuration'
+require 'court_data_adaptor/caster/struct_collection'
 
 CourtDataAdaptor.configure do |config|
   config.api_url = ENV['COURT_DATA_ADAPTOR_API_URL']
@@ -8,3 +9,7 @@ CourtDataAdaptor.configure do |config|
   config.api_secret = ENV['COURT_DATA_ADAPTOR_API_SECRET']
   config.test_mode = ENV.fetch('COURT_DATA_ADAPTOR_API_TEST_MODE', false).eql?('true')
 end
+
+# custom type casters
+# see https://github.com/JsonApiClient/json_api_client#type-casting
+JsonApiClient::Schema.register struct_collection: CourtDataAdaptor::Caster::StructCollection

--- a/config/locales/en/decorators/offence.yml
+++ b/config/locales/en/decorators/offence.yml
@@ -1,0 +1,5 @@
+---
+en:
+  offence:
+    plea:
+      sentence: "%{plea} on %{pleaded_at}"

--- a/config/spring.rb
+++ b/config/spring.rb
@@ -5,5 +5,6 @@ Spring.watch(
   '.rbenv-vars',
   'tmp/restart.txt',
   'tmp/caching-dev.txt',
+  'app/decorators',
   'app/services'
 )

--- a/lib/court_data_adaptor/caster/struct_collection.rb
+++ b/lib/court_data_adaptor/caster/struct_collection.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# see https://github.com/JsonApiClient/json_api_client#type-casting
+#
+module CourtDataAdaptor
+  module Caster
+    class StructCollection
+      def self.cast(value, default = [])
+        value ||= default
+        value.map { |el| OpenStruct.new(el) }
+      end
+    end
+  end
+end

--- a/lib/court_data_adaptor/resource/offence.rb
+++ b/lib/court_data_adaptor/resource/offence.rb
@@ -8,15 +8,9 @@ module CourtDataAdaptor
       belongs_to :defendant
 
       property :title, type: :string
-      property :plea, type: :string
-      property :plea_date, type: :string
+      property :pleas, type: :struct_collection, default: []
       property :mode_of_trial, type: :string
       property :mode_of_trial_reason, type: :string
-
-      def plea_and_date
-        return if plea.nil?
-        "#{plea&.humanize} on #{plea_date&.to_date&.strftime('%d/%m/%Y')}"
-      end
     end
   end
 end

--- a/spec/decorators/base_decorator_spec.rb
+++ b/spec/decorators/base_decorator_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+RSpec.describe BaseDecorator, type: :decorator do
+  subject(:decorator) { test_decorator_class.new(test_object, view_object) }
+
+  let(:test_object) { test_class.new }
+  let(:view_object) { view_class.new }
+
+  let(:view_class) do
+    Class.new do
+      include ActionView::Helpers::TranslationHelper
+    end
+  end
+
+  let(:test_class) do
+    Class.new do
+      def my_string
+        'hi'
+      end
+    end
+  end
+
+  let(:test_decorator_class) do
+    Class.new(BaseDecorator) do
+      def my_upcased_string
+        my_string.upcase
+      end
+    end
+  end
+
+  it_behaves_like 'a base decorator' do
+    let(:object) { test_object }
+  end
+
+  it { is_expected.to respond_to(:my_string) }
+
+  describe '#my_string' do
+    subject { decorator.my_string }
+
+    it { is_expected.to eql 'hi' }
+  end
+
+  describe '#my_upcased_string' do
+    subject { decorator.my_upcased_string }
+
+    it { is_expected.to eql('HI') }
+  end
+end

--- a/spec/decorators/offence_decorator_spec.rb
+++ b/spec/decorators/offence_decorator_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+RSpec.describe OffenceDecorator, type: :decorator do
+  subject(:decorator) { described_class.new(offence, view_object) }
+
+  let(:offence) { instance_double(CourtDataAdaptor::Resource::Offence) }
+  let(:view_object) { view_class.new }
+
+  let(:plea_ostruct_collection) { plea_array.map { |el| OpenStruct.new(el) } }
+
+  let(:view_class) do
+    Class.new do
+      include ActionView::Helpers
+    end
+  end
+
+  it_behaves_like 'a base decorator' do
+    let(:object) { offence }
+  end
+
+  context 'when method is missing' do
+    before do
+      allow(offence)
+        .to receive_messages(title: '',
+                             pleas: [],
+                             mode_of_trial: '',
+                             mode_of_trial_reason: '')
+    end
+
+    it { is_expected.to respond_to(:title, :pleas, :mode_of_trial, :mode_of_trial_reason) }
+  end
+
+  describe '#plea_list' do
+    subject(:call) { decorator.plea_list }
+
+    context 'when 1 or more pleas exist' do
+      let(:plea_array) do
+        [{ code: 'NOT_GUILTY',
+           pleaded_at: '2020-01-01' },
+         { code: 'GUILTY',
+           pleaded_at: '2020-01-20' }]
+      end
+
+      before do
+        allow(offence).to receive(:pleas).and_return(plea_ostruct_collection)
+      end
+
+      it { is_expected.to eql('Not guilty on 01/01/2020<br />Guilty on 20/01/2020') }
+    end
+
+    context 'when pleas are not in pleaded_at order' do
+      let(:plea_array) do
+        [{ code: 'GUILTY',
+           pleaded_at: '2020-02-01' },
+         { code: 'NOT_GUILTY',
+           pleaded_at: '2020-01-01' }]
+      end
+
+      before do
+        allow(offence).to receive(:pleas).and_return(plea_ostruct_collection)
+      end
+
+      it { is_expected.to eql 'Not guilty on 01/01/2020<br />Guilty on 01/02/2020' }
+    end
+
+    context 'when plea does not contain an expected key' do
+      let(:plea_array) do
+        [{ pleaded_at: '2020-01-20' },
+         { pleaded_at: '2020-01-21' },
+         { code: 'NOT_GUILTY' }]
+      end
+
+      let(:html_content) do
+        ['Not guilty on Not available',
+         'Not available on 20/01/2020',
+         'Not available on 21/01/2020'].join('<br />')
+      end
+
+      before do
+        allow(offence).to receive(:pleas).and_return(plea_ostruct_collection)
+      end
+
+      it { is_expected.to eql html_content }
+    end
+
+    context 'when pleas are nil' do
+      before do
+        allow(offence).to receive(:pleas).and_return(nil)
+      end
+
+      it { is_expected.to eql 'Not available' }
+    end
+
+    context 'when pleas are empty' do
+      before do
+        allow(offence).to receive(:pleas).and_return([])
+      end
+
+      it { is_expected.to eql 'Not available' }
+    end
+
+    context 'when pleas are not enumerable' do
+      before do
+        allow(offence).to receive(:pleas).and_return('plea is a string')
+      end
+
+      it { expect { call }.not_to raise_error }
+      it { is_expected.to eql('plea is a string') }
+    end
+  end
+end

--- a/spec/decorators/offence_decorator_spec.rb
+++ b/spec/decorators/offence_decorator_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe OffenceDecorator, type: :decorator do
         allow(offence).to receive(:pleas).and_return(plea_ostruct_collection)
       end
 
-      it { is_expected.to eql('Not guilty on 01/01/2020<br />Guilty on 20/01/2020') }
+      it { is_expected.to eql('Not guilty on 01/01/2020<br>Guilty on 20/01/2020') }
     end
 
     context 'when pleas are not in pleaded_at order' do
@@ -60,7 +60,7 @@ RSpec.describe OffenceDecorator, type: :decorator do
         allow(offence).to receive(:pleas).and_return(plea_ostruct_collection)
       end
 
-      it { is_expected.to eql 'Not guilty on 01/01/2020<br />Guilty on 01/02/2020' }
+      it { is_expected.to eql 'Not guilty on 01/01/2020<br>Guilty on 01/02/2020' }
     end
 
     context 'when plea does not contain an expected key' do
@@ -73,7 +73,7 @@ RSpec.describe OffenceDecorator, type: :decorator do
       let(:html_content) do
         ['Not guilty on Not available',
          'Not available on 20/01/2020',
-         'Not available on 21/01/2020'].join('<br />')
+         'Not available on 21/01/2020'].join('<br>')
       end
 
       before do

--- a/spec/fixtures/i18n/mock.yml
+++ b/spec/fixtures/i18n/mock.yml
@@ -1,0 +1,3 @@
+en:
+  my:
+    translation: my mock translation

--- a/spec/fixtures/stubs/unlinked_defendant.json
+++ b/spec/fixtures/stubs/unlinked_defendant.json
@@ -42,8 +42,12 @@
         "mode_of_trial": "Indictable only",
         "mode_of_trial_reason": "Court directs trial by jury",
         "mode_of_trial_reason_code": "05",
-        "plea": "NOT_GUILTY",
-        "plea_date": "2020-04-12"
+        "pleas": [
+          {
+            "code": "NOT_GUILTY",
+            "pleaded_at": "2020-04-12"
+          }
+        ]
       }
     }
   ]

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -5,4 +5,154 @@ RSpec.describe ApplicationHelper, type: :helper do
 
   it { is_expected.to respond_to :govuk_page_title }
   it { is_expected.to respond_to :govuk_breadcrumb_builder }
+  it { is_expected.to respond_to :service_name }
+  it { is_expected.to respond_to :l }
+  it { is_expected.to respond_to :decorate }
+  it { is_expected.to respond_to :decorate_all }
+
+  shared_context 'with mock objects and decorators' do
+    let(:test_objects) { [test_class.new, test_class.new] }
+    let(:test_object) { test_class.new }
+    let(:view_object) { view_class.new }
+    let(:view_class) { Class.new }
+
+    let(:test_class) do
+      Class.new do
+        def my_string
+          'hi'
+        end
+      end
+    end
+
+    let(:test_class_decorator) do
+      Class.new(BaseDecorator) do
+        def my_upcased_string
+          my_string.upcase
+        end
+      end
+    end
+
+    let(:other_class_decorator) do
+      Class.new(BaseDecorator) do
+        def my_bold_string
+          '<b>my_string</b>'
+        end
+      end
+    end
+  end
+
+  describe '#decorate' do
+    include_context 'with mock objects and decorators'
+
+    shared_examples 'returns or yields decorated object' do
+      subject(:decorated_object) { helper.decorate(test_object) }
+
+      before do
+        stub_const('TestClassDecorator', test_class_decorator)
+      end
+
+      it { is_expected.to be_instance_of(test_class_decorator) }
+      it { is_expected.to respond_to(:my_string, :my_upcased_string) }
+      it { expect { |b| decorate(test_object, &b) }.to yield_with_args(instance_of(test_class_decorator)) }
+
+      it 'sends view context to decorator' do
+        allow(test_class_decorator).to receive(:new)
+        helper.decorate(test_object)
+        expect(test_class_decorator).to have_received(:new).with(test_object, helper)
+      end
+    end
+
+    context 'when called with no decorator class' do
+      context 'with unmodularized class' do
+        before { stub_const('TestClass', test_class) }
+
+        include_examples 'returns or yields decorated object'
+      end
+
+      context 'with modularized class' do
+        before { stub_const('TestModule::TestClass', test_class) }
+
+        include_examples 'returns or yields decorated object'
+      end
+    end
+
+    context 'when called with a decorator class' do
+      subject(:decorated_object) { helper.decorate(test_object, other_class_decorator) }
+
+      before do
+        stub_const('TestClass', test_class)
+        stub_const('OtherClassDecorator', other_class_decorator)
+      end
+
+      it { is_expected.to be_instance_of(other_class_decorator) }
+      it { is_expected.to respond_to(:my_string, :my_bold_string) }
+
+      it {
+        expect { |b| decorate(test_object, other_class_decorator, &b) }
+          .to yield_with_args(instance_of(other_class_decorator))
+      }
+    end
+  end
+
+  describe '#decorate_all' do
+    include_context 'with mock objects and decorators'
+
+    shared_examples 'returns or yields all decorated objects' do
+      subject(:decorated_objects) { helper.decorate_all(test_objects) }
+
+      before do
+        stub_const('TestClassDecorator', test_class_decorator)
+      end
+
+      it { is_expected.to all(be_instance_of(test_class_decorator)) }
+      it { is_expected.to all(respond_to(:my_string, :my_upcased_string)) }
+
+      it {
+        expect { |b| decorate_all(test_objects, &b) }
+          .to yield_successive_args(instance_of(test_class_decorator),
+                                    instance_of(test_class_decorator))
+      }
+
+      it 'sends view context to decorator' do
+        allow(test_class_decorator).to receive(:new)
+        helper.decorate_all(test_objects)
+        expect(test_class_decorator).to have_received(:new).with(instance_of(test_class), helper).twice
+      end
+    end
+
+    it 'aliased as #decorate_each' do
+      expect(helper.method(:decorate_all)).to eql(helper.method(:decorate_each))
+    end
+
+    context 'when called with no decorator class' do
+      context 'with unmodularized class' do
+        before { stub_const('TestClass', test_class) }
+
+        include_examples 'returns or yields all decorated objects'
+      end
+
+      context 'with modularized class' do
+        before { stub_const('TestModule::TestClass', test_class) }
+
+        include_examples 'returns or yields all decorated objects'
+      end
+    end
+
+    context 'when called with a decorator class' do
+      subject(:decorated_object) { helper.decorate_all(test_objects, other_class_decorator) }
+
+      before do
+        stub_const('TestClass', test_class)
+        stub_const('OtherClassDecorator', other_class_decorator)
+      end
+
+      it { is_expected.to all(be_instance_of(other_class_decorator)) }
+      it { is_expected.to all(respond_to(:my_string, :my_bold_string)) }
+
+      it {
+        expect { |b| decorate_all(test_objects, other_class_decorator, &b) }
+          .to yield_successive_args(instance_of(other_class_decorator), instance_of(other_class_decorator))
+      }
+    end
+  end
 end

--- a/spec/lib/court_data_adaptor/caster/struct_collection_spec.rb
+++ b/spec/lib/court_data_adaptor/caster/struct_collection_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+# See https://jsonapi.org/format/#document-resource-object-attributes
+#
+# Complex data structures involving JSON objects and arrays are allowed
+# as attribute values. However, any object that constitutes or is
+# contained in an attribute MUST NOT contain a relationships or links
+# member, as those members are reserved by this specification for future use.
+#
+require 'court_data_adaptor/caster/struct_collection'
+
+RSpec.describe CourtDataAdaptor::Caster::StructCollection do
+  describe '.cast' do
+    subject(:collection) { described_class.cast(value, default) }
+
+    let(:array_of_hashes) do
+      [{ code: 'code1',
+         description: 'description1' },
+       { code: 'code2',
+         description: 'description2' }]
+    end
+
+    context 'with an array of hashes' do
+      let(:value) { array_of_hashes }
+      let(:default) { [] }
+
+      it { is_expected.to all(be_an(OpenStruct)) }
+
+      it 'responds to key names as attributes' do
+        expect(collection).to all(respond_to(:code, :description))
+      end
+    end
+
+    context 'without default' do
+      subject(:collection) { described_class.cast(nil) }
+
+      it { is_expected.to be_an Array }
+      it { is_expected.to be_empty }
+    end
+
+    context 'with empty default' do
+      subject(:collection) { described_class.cast(nil, []) }
+
+      it { is_expected.to be_an Array }
+      it { is_expected.to be_empty }
+    end
+
+    context 'with default' do
+      let(:value) { nil }
+      let(:default) { [{ code: 'default', description: 'default' }] }
+
+      it { is_expected.to be_an Array }
+      it { is_expected.to eql [OpenStruct.new(default.first)] }
+    end
+  end
+end

--- a/spec/lib/court_data_adaptor/resource/offence_spec.rb
+++ b/spec/lib/court_data_adaptor/resource/offence_spec.rb
@@ -3,6 +3,8 @@
 require 'court_data_adaptor'
 
 RSpec.describe CourtDataAdaptor::Resource::Offence do
+  let(:plea_ostruct_collection) { plea_array.map { |el| OpenStruct.new(el) } }
+
   it_behaves_like 'court_data_adaptor acts_as_resource object', resource: described_class do
     let(:klass) { described_class }
     let(:instance) { described_class.new }
@@ -14,29 +16,28 @@ RSpec.describe CourtDataAdaptor::Resource::Offence do
     let(:instance) { described_class.new(defendant_id: nil) }
   end
 
-  it { is_expected.to respond_to(:title, :plea, :plea_date, :mode_of_trial, :mode_of_trial_reason) }
+  it { is_expected.to respond_to(:title, :pleas, :mode_of_trial, :mode_of_trial_reason) }
 
-  describe '#plea_and_date' do
-    subject { instance.plea_and_date }
+  describe '#pleas' do
+    subject(:pleas) { instance.pleas }
 
     let(:instance) { described_class.new(defendant_id: nil) }
+    let(:plea_array) { [{ code: 'NOT_GUILTY', pleaded_at: '2020-01-01' }] }
 
-    context 'when plea exists on offence' do
-      before do
-        allow(instance).to receive(:plea).and_return('NOT_GUILTY')
-        allow(instance).to receive(:plea_date).and_return('2020-01-01')
-      end
+    it { is_expected.to be_an Array }
 
-      it { is_expected.to eql 'Not guilty on 01/01/2020' }
+    context 'when empty' do
+      before { allow(instance).to receive(:pleas).and_call_original }
+
+      it { is_expected.to be_empty }
     end
 
-    context 'when plea does not exist on offence' do
-      before do
-        allow(instance).to receive(:plea).and_return(nil)
-        allow(instance).to receive(:plea_date).and_return(nil)
-      end
+    context 'when 1 or more pleas exist' do
+      before { allow(instance).to receive(:pleas).and_return(plea_ostruct_collection) }
 
-      it { is_expected.to be_nil }
+      it { is_expected.to be_present }
+      it { is_expected.to all(be_an(OpenStruct)) }
+      it { is_expected.to all(respond_to(:code, :pleaded_at)) }
     end
   end
 end

--- a/spec/lib/court_data_adaptor/resource/provider_spec.rb
+++ b/spec/lib/court_data_adaptor/resource/provider_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe CourtDataAdaptor::Resource::Provider do
     it { is_expected.to respond_to :name }
     it { is_expected.to respond_to :role }
 
-    describe '#name_nad_role' do
+    describe '#name_and_role' do
       subject { instance.name_and_role }
 
       before do

--- a/spec/support/shared_examples_for_decorators.rb
+++ b/spec/support/shared_examples_for_decorators.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'a base decorator' do
+  it { is_expected.to respond_to(:object) }
+
+  describe '#object' do
+    subject { decorator.object }
+
+    it { is_expected.to be(object) }
+  end
+
+  it { expect(decorator).to delegate_method(:translate).to(:context) }
+  it { expect(decorator).to delegate_method(:t).to(:context) }
+  it { expect(decorator).to delegate_method(:tag).to(:context) }
+
+  describe '#translate' do
+    subject(:call) { decorator.translate('my.translation') }
+
+    context 'when translation exists' do
+      around do |example|
+        original_backend = I18n.backend
+        mock_backend = I18n::Backend::Simple.new
+        mock_backend.load_translations(Rails.root.join('spec', 'fixtures', 'i18n', 'mock.yml'))
+
+        I18n.backend = mock_backend
+        example.run
+        I18n.backend = original_backend
+      end
+
+      it { is_expected.to eql 'my mock translation' }
+    end
+
+    # NOTE: error raising optional, see config/environments/test.rb
+    # config.action_view.raise_on_missing_translations = true
+    context 'when translation does not exist' do
+      it { expect { call }.to raise_error(I18n::MissingTranslationData) }
+    end
+  end
+
+  describe '#context' do
+    subject { decorator.context }
+
+    it 'aliased to #view' do
+      expect(decorator.method(:view)).to eql(decorator.method(:context))
+    end
+
+    it 'aliased to #h' do
+      expect(decorator.method(:h)).to eql(decorator.method(:context))
+    end
+  end
+end

--- a/spec/views/defendants/_offences.html.haml_spec.rb
+++ b/spec/views/defendants/_offences.html.haml_spec.rb
@@ -52,24 +52,33 @@ RSpec.describe 'defendants/_offences.html.haml', type: :view do
       end
     end
 
-    context 'when the offence has plea details' do
-      before do
-        allow(offence).to receive(:plea).and_return('NOT_GUILTY')
-        allow(offence).to receive(:plea_date).and_return('2020-04-12')
-        allow(offence).to receive(:plea_and_date).and_call_original
+    context 'when the offence has pleas' do
+      let(:plea_ostruct_collection) { plea_array.map { |el| OpenStruct.new(el) } }
+
+      let(:plea_array) do
+        [{ code: 'NOT_GUILTY',
+           pleaded_at: '2020-04-12' },
+         { code: 'GUILTY',
+           pleaded_at: '2020-05-12' },
+         { code: 'NO_PLEA',
+           pleaded_at: '2020-03-12' }]
       end
 
-      it 'displays plea and plea date' do
+      before do
+        allow(offence).to receive(:pleas).and_return(plea_ostruct_collection)
+      end
+
+      it 'displays list of pleas with plea dates' do
         render
-        expect(rendered).to have_css('.govuk-table__cell', text: 'Not guilty on 12/04/2020')
+        expect(rendered)
+          .to have_css('.govuk-table__cell',
+                       text: %r{No plea on 12/03/2020.*Not guilty on 12/04/2020.*Guilty on 12/05/2020})
       end
     end
 
-    context 'when the offence has no plea details' do
+    context 'when the offence has no pleas' do
       before do
-        allow(offence).to receive(:plea).and_return(nil)
-        allow(offence).to receive(:plea_date).and_return(nil)
-        allow(offence).to receive(:plea_and_date).and_call_original
+        allow(offence).to receive(:pleas).and_return([])
       end
 
       it 'displays Not available for plea and plea date' do


### PR DESCRIPTION
#### What
Display multiple pleas per offence on defendant details page

#### Ticket

[CBO-1599](https://dsdmoj.atlassian.net/browse/CBO-1599)

depends on:

[CBO-1597](https://dsdmoj.atlassian.net/browse/CBO-1597)

#### Why
Changes of plea are possible and the adaptor is
to be amended to return an array of hashes, where
each hash represents a plea.

#### How
Stub agreed JSON response for offence pleas from the adaptor.

The response is an array of hashes, which is converted
to an array of OpenStruct objects for convenience.
A convenience method plea_list returns an array
of "plea sentences" (e.g. "Guilty on 01/01/2020")
which can then be displayed in the view.

#### Decorator pattern introduced

I have added a decorator/presenter pattern to keep  the presentation logic
out of models/resource-objects while keeping views clean. This pattern is simlar
to CCCDs and can be applied to other classes relatively easily by defining a decorator
(classnameDecorator) and using the new `decorate` or `decorate_all` methods