### PR TITLE
Cbo 1600 display mode of trial reasons

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -3,4 +3,4 @@ MANAGER_PASSWORD: manager-password
 ADMIN_PASSWORD: admin-password
 # COURT_DATA_ADAPTOR_API_URL: http://localhost:9292/api/internal/v1
 GA_TRACKING_ID: UA-XXXXXXXXX-XX
-DISPLAY_RAW_RESPONSES: true
+DISPLAY_RAW_RESPONSES: enabled

--- a/.k8s/staging/deployment.yaml
+++ b/.k8s/staging/deployment.yaml
@@ -63,6 +63,8 @@ spec:
               value: 'UA-131160087-16'
             - name: RAILS_LOG_TO_STDOUT
               value: enabled
+            - name: DISPLAY_RAW_RESPONSES
+              value: enabled
             - name: COURT_DATA_ADAPTOR_API_UID
               valueFrom:
                 secretKeyRef:

--- a/app/decorators/offence_decorator.rb
+++ b/app/decorators/offence_decorator.rb
@@ -8,6 +8,13 @@ class OffenceDecorator < BaseDecorator
     safe_join(plea_sentences, tag.br)
   end
 
+  def mode_of_trial_reason_list
+    return t('generic.not_available') if mode_of_trial_reasons.blank?
+    return mode_of_trial_reason unless mode_of_trial_reasons.is_a?(Enumerable)
+
+    safe_join(mode_of_trial_reason_descriptions, tag.br)
+  end
+
   private
 
   def plea_sentences
@@ -22,5 +29,13 @@ class OffenceDecorator < BaseDecorator
     t('offence.plea.sentence',
       plea: plea.code&.humanize || t('generic.not_available'),
       pleaded_at: plea.pleaded_at&.to_date&.strftime('%d/%m/%Y') || t('generic.not_available'))
+  end
+
+  def mode_of_trial_reason_descriptions
+    mode_of_trial_reasons.map{|mode_of_trial| mode_of_trial_reason_description(mode_of_trial)}
+  end
+
+  def mode_of_trial_reason_description(mode_of_trial)
+    mode_of_trial.description&.humanize || t('generic.not_available')
   end
 end

--- a/app/decorators/offence_decorator.rb
+++ b/app/decorators/offence_decorator.rb
@@ -32,7 +32,7 @@ class OffenceDecorator < BaseDecorator
   end
 
   def mode_of_trial_reason_descriptions
-    mode_of_trial_reasons.map{|mode_of_trial| mode_of_trial_reason_description(mode_of_trial)}
+    mode_of_trial_reasons.map { |mode_of_trial| mode_of_trial_reason_description(mode_of_trial) }
   end
 
   def mode_of_trial_reason_description(mode_of_trial)

--- a/app/decorators/offence_decorator.rb
+++ b/app/decorators/offence_decorator.rb
@@ -32,10 +32,6 @@ class OffenceDecorator < BaseDecorator
   end
 
   def mode_of_trial_reason_descriptions
-    mode_of_trial_reasons.map { |mode_of_trial| mode_of_trial_reason_description(mode_of_trial) }
-  end
-
-  def mode_of_trial_reason_description(mode_of_trial)
-    mode_of_trial.description || t('generic.not_available')
+    mode_of_trial_reasons.map { |reason| reason.description || t('generic.not_available') }
   end
 end

--- a/app/decorators/offence_decorator.rb
+++ b/app/decorators/offence_decorator.rb
@@ -10,7 +10,7 @@ class OffenceDecorator < BaseDecorator
 
   def mode_of_trial_reason_list
     return t('generic.not_available') if mode_of_trial_reasons.blank?
-    return mode_of_trial_reason unless mode_of_trial_reasons.is_a?(Enumerable)
+    return mode_of_trial_reasons unless mode_of_trial_reasons.is_a?(Enumerable)
 
     safe_join(mode_of_trial_reason_descriptions, tag.br)
   end
@@ -36,6 +36,6 @@ class OffenceDecorator < BaseDecorator
   end
 
   def mode_of_trial_reason_description(mode_of_trial)
-    mode_of_trial.description&.humanize || t('generic.not_available')
+    mode_of_trial.description || t('generic.not_available')
   end
 end

--- a/app/views/defendants/_offences.html.haml
+++ b/app/views/defendants/_offences.html.haml
@@ -19,4 +19,4 @@
         %td.govuk-table__cell
           = "#{offence.mode_of_trial}:"
           %br
-          = offence.mode_of_trial_reason || t('generic.not_available')
+          = offence.mode_of_trial_reasons

--- a/app/views/defendants/_offences.html.haml
+++ b/app/views/defendants/_offences.html.haml
@@ -19,4 +19,4 @@
         %td.govuk-table__cell
           = "#{offence.mode_of_trial}:"
           %br
-          = offence.mode_of_trial_reasons
+          = offence.mode_of_trial_reason_list

--- a/lib/court_data_adaptor/resource/offence.rb
+++ b/lib/court_data_adaptor/resource/offence.rb
@@ -9,6 +9,7 @@ module CourtDataAdaptor
 
       property :title, type: :string
       property :pleas, type: :struct_collection, default: []
+      property :mode_of_trial, type: :string
       property :mode_of_trial_reasons, type: :struct_collection, default: []
 
       def plea_and_date

--- a/lib/court_data_adaptor/resource/offence.rb
+++ b/lib/court_data_adaptor/resource/offence.rb
@@ -11,11 +11,6 @@ module CourtDataAdaptor
       property :pleas, type: :struct_collection, default: []
       property :mode_of_trial, type: :string
       property :mode_of_trial_reasons, type: :struct_collection, default: []
-
-      def plea_and_date
-        return if plea.nil?
-        "#{plea&.humanize} on #{plea_date&.to_date&.strftime('%d/%m/%Y')}"
-      end
     end
   end
 end

--- a/lib/court_data_adaptor/resource/offence.rb
+++ b/lib/court_data_adaptor/resource/offence.rb
@@ -9,8 +9,12 @@ module CourtDataAdaptor
 
       property :title, type: :string
       property :pleas, type: :struct_collection, default: []
-      property :mode_of_trial, type: :string
-      property :mode_of_trial_reason, type: :string
+      property :mode_of_trial_reasons, type: :struct_collection, default: []
+
+      def plea_and_date
+        return if plea.nil?
+        "#{plea&.humanize} on #{plea_date&.to_date&.strftime('%d/%m/%Y')}"
+      end
     end
   end
 end

--- a/spec/decorators/offence_decorator_spec.rb
+++ b/spec/decorators/offence_decorator_spec.rb
@@ -113,19 +113,52 @@ RSpec.describe OffenceDecorator, type: :decorator do
   describe '#mode_of_trial_reason_list' do
     subject(:call) { decorator.mode_of_trial_reason_list }
 
-    context 'when 1 or more mode of trial reasons exist' do
-      let(:mode_of_trial_reason_array) do
-        [{ code: '4',
-           description: 'Defendant elects trial by jury' },
-         { code: '2',
-           description: 'Indictable-only offence' }]
-      end
-
+    context 'when reasons exist' do
       before do
         allow(offence).to receive(:mode_of_trial_reasons).and_return(mot_reason_ostruct_collection)
       end
 
-      it { is_expected.to eql('Defendant elects trial by jury<br>Indictable-only offence') }
+      context 'when exactly one reason exists' do
+        let(:mode_of_trial_reason_array) do
+          [{ code: '4',
+             description: 'Defendant elects trial by jury' }]
+        end
+
+        it { is_expected.to eql('Defendant elects trial by jury') }
+      end
+
+      context 'when more than one reason exists' do
+        let(:mode_of_trial_reason_array) do
+          [{ code: '4',
+             description: 'Defendant elects trial by jury' },
+           { code: '2',
+             description: 'Indictable-only offence' }]
+        end
+
+        it { is_expected.to eql('Defendant elects trial by jury<br>Indictable-only offence') }
+      end
+    end
+
+    context 'when mode_of_trial_reasons does not contain an expected key' do
+      before do
+        allow(offence).to receive(:mode_of_trial_reasons).and_return(mot_reason_ostruct_collection)
+      end
+
+      context 'when it does not contain a code' do
+        let(:mode_of_trial_reason_array) do
+          [{ description: 'Defendant elects trial by jury' }]
+        end
+
+        it { is_expected.to eql('Defendant elects trial by jury') }
+      end
+
+      context 'when it does not contain a description' do
+        let(:mode_of_trial_reason_array) do
+          [{ code: '4' }]
+        end
+
+        it { is_expected.to eql('Not available') }
+      end
     end
 
     context 'when mode of trial reasons are nil' do

--- a/spec/decorators/offence_decorator_spec.rb
+++ b/spec/decorators/offence_decorator_spec.rb
@@ -24,10 +24,10 @@ RSpec.describe OffenceDecorator, type: :decorator do
         .to receive_messages(title: '',
                              pleas: [],
                              mode_of_trial: '',
-                             mode_of_trial_reason: '')
+                             mode_of_trial_reasons: [])
     end
 
-    it { is_expected.to respond_to(:title, :pleas, :mode_of_trial, :mode_of_trial_reason) }
+    it { is_expected.to respond_to(:title, :pleas, :mode_of_trial, :mode_of_trial_reasons) }
   end
 
   describe '#plea_list' do

--- a/spec/decorators/offence_decorator_spec.rb
+++ b/spec/decorators/offence_decorator_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe OffenceDecorator, type: :decorator do
   let(:view_object) { view_class.new }
 
   let(:plea_ostruct_collection) { plea_array.map { |el| OpenStruct.new(el) } }
+  let(:mot_reason_ostruct_collection) { mode_of_trial_reason_array.map { |el| OpenStruct.new(el) } }
 
   let(:view_class) do
     Class.new do
@@ -106,6 +107,50 @@ RSpec.describe OffenceDecorator, type: :decorator do
 
       it { expect { call }.not_to raise_error }
       it { is_expected.to eql('plea is a string') }
+    end
+  end
+
+  describe '#mode_of_trial_reason_list' do
+    subject(:call) { decorator.mode_of_trial_reason_list }
+
+    context 'when 1 or more mode of trial reasons exist' do
+      let(:mode_of_trial_reason_array) do
+        [{ code: '4',
+           description: 'Defendant elects trial by jury' },
+         { code: '2',
+           description: 'Indictable-only offence' }]
+      end
+
+      before do
+        allow(offence).to receive(:mode_of_trial_reasons).and_return(mot_reason_ostruct_collection)
+      end
+
+      it { is_expected.to eql('Defendant elects trial by jury<br>Indictable-only offence') }
+    end
+
+    context 'when mode of trial reasons are nil' do
+      before do
+        allow(offence).to receive(:mode_of_trial_reasons).and_return(nil)
+      end
+
+      it { is_expected.to eql 'Not available' }
+    end
+
+    context 'when mode of trial reasons are empty' do
+      before do
+        allow(offence).to receive(:mode_of_trial_reasons).and_return([])
+      end
+
+      it { is_expected.to eql 'Not available' }
+    end
+
+    context 'when mode of trial reasons are not enumerable' do
+      before do
+        allow(offence).to receive(:mode_of_trial_reasons).and_return('mode of trial reason is a string')
+      end
+
+      it { expect { call }.not_to raise_error }
+      it { is_expected.to eql('mode of trial reason is a string') }
     end
   end
 end

--- a/spec/features/unlinked_defendant_flow_spec.rb
+++ b/spec/features/unlinked_defendant_flow_spec.rb
@@ -254,7 +254,7 @@ RSpec.feature 'Unlinked defendant page flow', type: :feature, stub_unlinked: tru
       expect(page).to have_css('.govuk-table__header', text: 'Mode of trial')
 
       expect(page).to have_css('.govuk-table__cell', text: 'Not guilty on 12/04/2020')
-      expect(page).to have_css('.govuk-table__cell', text: /Indictable only: Court directs trial by jury/)
+      expect(page).to have_css('.govuk-table__cell', text: /Indictable only:.*Defendant elects trial by jury/)
     end
   end
 

--- a/spec/features/unlinked_defendant_flow_spec.rb
+++ b/spec/features/unlinked_defendant_flow_spec.rb
@@ -254,7 +254,7 @@ RSpec.feature 'Unlinked defendant page flow', type: :feature, stub_unlinked: tru
       expect(page).to have_css('.govuk-table__header', text: 'Mode of trial')
 
       expect(page).to have_css('.govuk-table__cell', text: 'Not guilty on 12/04/2020')
-      expect(page).to have_css('.govuk-table__cell', text: /Indictable only:.*Court directs trial by jury/)
+      expect(page).to have_css('.govuk-table__cell', text: /Indictable only: Court directs trial by jury/)
     end
   end
 

--- a/spec/fixtures/stubs/unlinked_defendant.json
+++ b/spec/fixtures/stubs/unlinked_defendant.json
@@ -40,8 +40,11 @@
         "order_index": 1,
         "title": "Copying false instrument with intent",
         "mode_of_trial": "Indictable only",
-        "mode_of_trial_reason": "Court directs trial by jury",
-        "mode_of_trial_reason_code": "05",
+        "mode_of_trial_reasons": [
+          {
+            "description": "Court directs trial by jury"
+          }
+        ],
         "pleas": [
           {
             "code": "NOT_GUILTY",

--- a/spec/fixtures/stubs/unlinked_defendant.json
+++ b/spec/fixtures/stubs/unlinked_defendant.json
@@ -42,8 +42,8 @@
         "mode_of_trial": "Indictable only",
         "mode_of_trial_reasons": [
           {
-            "code": "gfc0",
-            "description": "Court directs trial by jury"
+            "code": "4",
+            "description": "Defendant elects trial by jury"
           }
         ],
         "pleas": [

--- a/spec/fixtures/stubs/unlinked_defendant.json
+++ b/spec/fixtures/stubs/unlinked_defendant.json
@@ -42,6 +42,7 @@
         "mode_of_trial": "Indictable only",
         "mode_of_trial_reasons": [
           {
+            "code": "gfc0",
             "description": "Court directs trial by jury"
           }
         ],

--- a/spec/lib/court_data_adaptor/resource/offence_spec.rb
+++ b/spec/lib/court_data_adaptor/resource/offence_spec.rb
@@ -4,6 +4,7 @@ require 'court_data_adaptor'
 
 RSpec.describe CourtDataAdaptor::Resource::Offence do
   let(:plea_ostruct_collection) { plea_array.map { |el| OpenStruct.new(el) } }
+  let(:mot_reason_ostruct_collection) { mode_of_trial_array.map { |el| OpenStruct.new(el) } }
 
   it_behaves_like 'court_data_adaptor acts_as_resource object', resource: described_class do
     let(:klass) { described_class }
@@ -38,6 +39,29 @@ RSpec.describe CourtDataAdaptor::Resource::Offence do
       it { is_expected.to be_present }
       it { is_expected.to all(be_an(OpenStruct)) }
       it { is_expected.to all(respond_to(:code, :pleaded_at)) }
+    end
+  end
+
+  describe '#mode_of_trial_reasons' do
+    subject(:mode_of_trial_reasons) { instance.mode_of_trial_reasons }
+
+    let(:instance) { described_class.new(defendant_id: nil) }
+    let(:mode_of_trial_array) { [{ code: '4', description: 'Defendant elects trial by jury' }] }
+
+    it { is_expected.to be_an Array }
+
+    context 'when empty' do
+      before { allow(instance).to receive(:mode_of_trial_reasons).and_call_original }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'when 1 or more mode of trial reasons exist' do
+      before { allow(instance).to receive(:mode_of_trial_reasons).and_return(mot_reason_ostruct_collection) }
+
+      it { is_expected.to be_present }
+      it { is_expected.to all(be_an(OpenStruct)) }
+      it { is_expected.to all(respond_to(:code, :description)) }
     end
   end
 end

--- a/spec/lib/court_data_adaptor/resource/offence_spec.rb
+++ b/spec/lib/court_data_adaptor/resource/offence_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe CourtDataAdaptor::Resource::Offence do
     let(:instance) { described_class.new(defendant_id: nil) }
   end
 
-  it { is_expected.to respond_to(:title, :pleas, :mode_of_trial, :mode_of_trial_reason) }
+  it { is_expected.to respond_to(:title, :pleas, :mode_of_trial, :mode_of_trial_reasons) }
 
   describe '#pleas' do
     subject(:pleas) { instance.pleas }

--- a/spec/views/defendants/_offences.html.haml_spec.rb
+++ b/spec/views/defendants/_offences.html.haml_spec.rb
@@ -13,8 +13,14 @@ RSpec.describe 'defendants/_offences.html.haml', type: :view do
       before { allow(offence).to receive(:mode_of_trial).and_return('Indictable only') }
 
       context 'with reason' do
+        let(:mot_reason_ostruct_collection) { mot_reasons_array.map { |el| OpenStruct.new(el) } }
+
+        let(:mot_reasons_array) do
+          [{ description: 'Court directs trial by jury' }]
+        end
+
         before do
-          allow(offence).to receive(:mode_of_trial_reason).and_return('Court directs trial by jury')
+          allow(offence).to receive(:mode_of_trial_reasons).and_return(mot_reason_ostruct_collection)
         end
 
         it 'displays mode of trial with reason' do
@@ -25,7 +31,7 @@ RSpec.describe 'defendants/_offences.html.haml', type: :view do
       end
 
       context 'without reason' do
-        before { allow(offence).to receive(:mode_of_trial_reason).and_return(nil) }
+        before { allow(offence).to receive(:mode_of_trial_reasons).and_return(nil) }
 
         it 'displays mode of trial without reason' do
           render

--- a/spec/views/defendants/_offences.html.haml_spec.rb
+++ b/spec/views/defendants/_offences.html.haml_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'defendants/_offences.html.haml', type: :view do
         let(:mot_reason_ostruct_collection) { mot_reasons_array.map { |el| OpenStruct.new(el) } }
 
         let(:mot_reasons_array) do
-          [{ description: 'Court directs trial by jury' }]
+          [{ code: '4', description: 'Defendant elects trial by jury' }]
         end
 
         before do
@@ -26,7 +26,7 @@ RSpec.describe 'defendants/_offences.html.haml', type: :view do
         it 'displays mode of trial with reason' do
           render
           expect(rendered).to have_css('.govuk-table__cell',
-                                       text: /Indictable only:\n*Court directs trial by jury/)
+                                       text: /Indictable only:\n*Defendant elects trial by jury/)
         end
       end
 


### PR DESCRIPTION
#### What
Display mode of trial reasons

#### Ticket
https://dsdmoj.atlassian.net/browse/CBO-1600
(See https://dsdmoj.atlassian.net/browse/LASB-443 for the related CDA changes)

#### Why
CDA is returning a new collection, mode_of_trial_reasons. Although in reality we only expect there to be one one mode of trial reason per offence, the structure of hmcts data allows for multiple mode of trial reasons per offence, potentially spread across multiple hearings. This pr allows for a single or multiple mode of trial reasons to be displayed by VCD dependant on what is returned by CDA.

#### How
Added a new property mode_of_trial_reasons to lib/court_data_adaptor/resource/offence.rb with type struct_collection  (and deleted old mode_of_trial_reason property). Followed the pattern introduced by pleas to display this collection by adding it to offence_decorator.rb
