### PR TITLE
Attempt to quiten nginex-500-error alert

### DIFF
--- a/.k8s/dev/prometheus-custom-rules.yaml
+++ b/.k8s/dev/prometheus-custom-rules.yaml
@@ -32,7 +32,7 @@ spec:
         message: laa-court-data-ui-dev More than a hundred 404 errors in one day
         runbook_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-24h,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,key:kubernetes.namespace_name,negate:!f,params:(query:laa-court-data-ui-dev,type:phrase),type:phrase,value:laa-court-data-ui-dev),query:(match:(kubernetes.namespace_name:(query:laa-court-data-ui-dev,type:phrase))))),index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,interval:auto,query:(language:lucene,query:'log:%22RoutingError%22'),sort:!('@timestamp',desc))
     - alert: nginx-5xx-error
-      expr: sum(rate(nginx_ingress_controller_requests{exported_namespace="laa-court-data-ui-dev", status=~"5.."}[5m]))*270 > 0
+      expr: sum(rate(nginx_ingress_controller_requests{exported_namespace="laa-court-data-ui-dev", status=~"5.."}[5m])) * 300 > 5
       for: 1m
       labels:
         severity: laa-court-get-paid

--- a/.k8s/production/prometheus-custom-rules.yaml
+++ b/.k8s/production/prometheus-custom-rules.yaml
@@ -32,7 +32,7 @@ spec:
         message: laa-court-data-ui-production More than a hundred 404 errors in one day
         runbook_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-24h,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,key:kubernetes.namespace_name,negate:!f,params:(query:laa-court-data-ui-production,type:phrase),type:phrase,value:laa-court-data-ui-production),query:(match:(kubernetes.namespace_name:(query:laa-court-data-ui-production,type:phrase))))),index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,interval:auto,query:(language:lucene,query:'log:%22RoutingError%22'),sort:!('@timestamp',desc))
     - alert: nginx-5xx-error
-      expr: sum(rate(nginx_ingress_controller_requests{exported_namespace="laa-court-data-ui-production", status=~"5.."}[5m]))*270 > 0
+      expr: sum(rate(nginx_ingress_controller_requests{exported_namespace="laa-court-data-ui-production", status=~"5.."}[5m])) * 300 > 5
       for: 1m
       labels:
         severity: laa-court-get-paid

--- a/.k8s/staging/prometheus-custom-rules.yaml
+++ b/.k8s/staging/prometheus-custom-rules.yaml
@@ -32,7 +32,7 @@ spec:
         message: laa-court-data-ui-staging More than a hundred 404 errors in one day
         runbook_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-24h,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,key:kubernetes.namespace_name,negate:!f,params:(query:laa-court-data-ui-staging,type:phrase),type:phrase,value:laa-court-data-ui-staging),query:(match:(kubernetes.namespace_name:(query:laa-court-data-ui-staging,type:phrase))))),index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,interval:auto,query:(language:lucene,query:'log:%22RoutingError%22'),sort:!('@timestamp',desc))
     - alert: nginx-5xx-error
-      expr: sum(rate(nginx_ingress_controller_requests{exported_namespace="laa-court-data-ui-staging", status=~"5.."}[5m]))*270 > 0
+      expr: sum(rate(nginx_ingress_controller_requests{exported_namespace="laa-court-data-ui-staging", status=~"5.."}[5m])) * 300 > 5
       for: 1m
       labels:
         severity: laa-court-get-paid

--- a/.k8s/uat/prometheus-custom-rules.yaml
+++ b/.k8s/uat/prometheus-custom-rules.yaml
@@ -32,7 +32,7 @@ spec:
         message: laa-court-data-ui-uat More than a hundred 404 errors in one day
         runbook_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-24h,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,key:kubernetes.namespace_name,negate:!f,params:(query:laa-court-data-ui-uat,type:phrase),type:phrase,value:laa-court-data-ui-uat),query:(match:(kubernetes.namespace_name:(query:laa-court-data-ui-uat,type:phrase))))),index:ec9109a0-2b35-11e9-ac82-95e56bd45b02,interval:auto,query:(language:lucene,query:'log:%22RoutingError%22'),sort:!('@timestamp',desc))
     - alert: nginx-5xx-error
-      expr: sum(rate(nginx_ingress_controller_requests{exported_namespace="laa-court-data-ui-uat", status=~"5.."}[5m]))*270 > 0
+      expr: sum(rate(nginx_ingress_controller_requests{exported_namespace="laa-court-data-ui-uat", status=~"5.."}[5m])) * 300 > 5
       for: 1m
       labels:
         severity: laa-court-get-paid


### PR DESCRIPTION

#### What
The nginex-500-error alert is noisy on all environments (especially production). This is an attempt to make it quieter.

#### Ticket
N/A

#### Why
We want the alert to alert us to genuine application issues.

#### How
Change the number of 500 statuses required in a 5 minute period to raise the error from >1 to >5. (I have also  tweaked  * 270 in the expression to * 300 as I am assuming this was a typo for 300 seconds/5 minutes?)
