### PR TITLE
Specify version of docker to use

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,7 +189,8 @@ commands:
         type: string
     steps:
       - checkout
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 19.03.13
       - run:
           name: deploying to << parameters.environment >>
           command: |
@@ -238,7 +239,8 @@ jobs:
     executor: cloud-platform-executor
     steps:
       - checkout
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 19.03.13
       - *script-build-app-container
 
   deploy-dev:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,9 +29,9 @@ references:
   _restore-assets: &restore-assets
     restore_cache:
       keys:
-        - v1-yarn-{{ checksum "yarn.lock" }}
+        - v3-yarn-{{ checksum "yarn.lock" }}
         # fallback to using the latest asset cache if no exact match is found
-        - v1-yarn-
+        - v3-yarn-
 
   _install-assets: &install-assets
     run:
@@ -42,7 +42,7 @@ references:
 
   _save-assets: &save-assets
     save_cache:
-      key: v2-yarn-{{ checksum "yarn.lock" }}
+      key: v3-yarn-{{ checksum "yarn.lock" }}
       paths:
         - node_modules
         - public/packs-test


### PR DESCRIPTION
#### What
Specify version of docker to use

#### Why
Started receiving this during app container build:
```
[3/4] Linking dependencies...
error An unexpected error occurred: "EPERM: operation not permitted, copyfile '/usr/local/share/.cache/yarn/v6/...blahblahblah".
info If you think this is a bug, please open a bug report with the information provided in "/usr/src/app/yarn-error.log".
```

See this [related discussion](https://discuss.circleci.com/t/docker-build-fails-with-nonsensical-eperm-operation-not-permitted-copyfile/37364)

#### How
specify version of remote docker as described here

https://circleci.com/docs/2.0/building-docker-images/#docker-version