### PR TITLE
Hide mode_of_trial_reasons with certain codes

### DIFF
--- a/app/decorators/offence_decorator.rb
+++ b/app/decorators/offence_decorator.rb
@@ -1,6 +1,13 @@
 # frozen_string_literal: true
 
 class OffenceDecorator < BaseDecorator
+  # Allow for future mot reason mappings; e.g. to 'Elected' and 'Directed'
+  MODE_OF_TRIAL_REASON_MAPPINGS = {
+    1 => '',
+    2 => '',
+    6 => ''
+  }.freeze
+
   def plea_list
     return t('generic.not_available') if pleas.blank?
     return pleas unless pleas.is_a?(Enumerable)
@@ -12,7 +19,7 @@ class OffenceDecorator < BaseDecorator
     return t('generic.not_available') if mode_of_trial_reasons.blank?
     return mode_of_trial_reasons unless mode_of_trial_reasons.is_a?(Enumerable)
 
-    safe_join(mode_of_trial_reason_descriptions, tag.br)
+    safe_join(mode_of_trial_reason_descriptions.reject(&:empty?), tag.br)
   end
 
   private
@@ -32,6 +39,14 @@ class OffenceDecorator < BaseDecorator
   end
 
   def mode_of_trial_reason_descriptions
-    mode_of_trial_reasons.map { |reason| reason.description || t('generic.not_available') }
+    mode_of_trial_reasons.map { |reason| mode_of_trial_reason_description(reason) }
+  end
+
+  def mode_of_trial_reason_description(reason)
+    if MODE_OF_TRIAL_REASON_MAPPINGS.key?(reason.code.to_i)
+      MODE_OF_TRIAL_REASON_MAPPINGS[reason.code.to_i]
+    else
+      reason.description || t('generic.not_available')
+    end
   end
 end

--- a/app/decorators/offence_decorator.rb
+++ b/app/decorators/offence_decorator.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class OffenceDecorator < BaseDecorator
-  # Allow for future mot reason mappings; e.g. to 'Elected' and 'Directed'
+  # TODO: mot reason text mappings for 'Elected' and 'Directed'
   MODE_OF_TRIAL_REASON_MAPPINGS = {
     1 => nil,
     2 => nil,

--- a/app/decorators/offence_decorator.rb
+++ b/app/decorators/offence_decorator.rb
@@ -3,9 +3,9 @@
 class OffenceDecorator < BaseDecorator
   # Allow for future mot reason mappings; e.g. to 'Elected' and 'Directed'
   MODE_OF_TRIAL_REASON_MAPPINGS = {
-    1 => '',
-    2 => '',
-    6 => ''
+    1 => nil,
+    2 => nil,
+    6 => nil
   }.freeze
 
   def plea_list
@@ -19,7 +19,7 @@ class OffenceDecorator < BaseDecorator
     return t('generic.not_available') if mode_of_trial_reasons.blank?
     return mode_of_trial_reasons unless mode_of_trial_reasons.is_a?(Enumerable)
 
-    safe_join(mode_of_trial_reason_descriptions.reject(&:empty?), tag.br)
+    safe_join(mode_of_trial_reason_descriptions.compact, tag.br)
   end
 
   private
@@ -43,10 +43,6 @@ class OffenceDecorator < BaseDecorator
   end
 
   def mode_of_trial_reason_description(reason)
-    if MODE_OF_TRIAL_REASON_MAPPINGS.key?(reason.code.to_i)
-      MODE_OF_TRIAL_REASON_MAPPINGS[reason.code.to_i]
-    else
-      reason.description || t('generic.not_available')
-    end
+    MODE_OF_TRIAL_REASON_MAPPINGS.fetch(reason.code.to_i, reason.description || t('generic.not_available'))
   end
 end

--- a/spec/decorators/offence_decorator_spec.rb
+++ b/spec/decorators/offence_decorator_spec.rb
@@ -197,17 +197,17 @@ RSpec.describe OffenceDecorator, type: :decorator do
         context "when exactly one reason exists, with code #{code}" do
           let(:mode_of_trial_reason_array) do
             [{ code: code,
-               description: 'Defendant elects trial by jury' }]
+               description: 'description to be hidden' }]
           end
 
           it { is_expected.to eql('') }
         end
       end
 
-      context 'when more than one reason exists, one of which should be hidden' do
+      context 'when more than one reason exists, all of which should be hidden' do
         let(:mode_of_trial_reason_array) do
           [{ code: '2',
-             description: 'Defendant elects trial by jury' },
+             description: 'Indictable-only offence' },
            { code: '6',
              description: 'Low value offence triable summarily only' }]
         end
@@ -215,10 +215,10 @@ RSpec.describe OffenceDecorator, type: :decorator do
         it { is_expected.to eql('') }
       end
 
-      context 'when more than one reason exists, all of which should be hidden' do
+      context 'when more than one reason exists, one of which should be hidden' do
         let(:mode_of_trial_reason_array) do
           [{ code: '2',
-             description: 'Defendant elects trial by jury' },
+             description: 'Indictable-only offence' },
            { code: '5',
              description: 'Court directs trial by jury' }]
         end

--- a/spec/decorators/offence_decorator_spec.rb
+++ b/spec/decorators/offence_decorator_spec.rb
@@ -131,11 +131,13 @@ RSpec.describe OffenceDecorator, type: :decorator do
         let(:mode_of_trial_reason_array) do
           [{ code: '4',
              description: 'Defendant elects trial by jury' },
-           { code: '2',
-             description: 'Indictable-only offence' }]
+           { code: '5',
+             description: 'Court directs trial by jury' }]
         end
 
-        it { is_expected.to eql('Defendant elects trial by jury<br>Indictable-only offence') }
+        it {
+          is_expected.to eql('Defendant elects trial by jury<br>Court directs trial by jury')
+        }
       end
     end
 
@@ -184,6 +186,45 @@ RSpec.describe OffenceDecorator, type: :decorator do
 
       it { expect { call }.not_to raise_error }
       it { is_expected.to eql('mode of trial reason is a string') }
+    end
+
+    context 'when the mode of trial reason code means the description should be hidden' do
+      before do
+        allow(offence).to receive(:mode_of_trial_reasons).and_return(mot_reason_ostruct_collection)
+      end
+
+      [1, 2, 6].each do |code|
+        context "when exactly one reason exists, with code #{code}" do
+          let(:mode_of_trial_reason_array) do
+            [{ code: code,
+               description: 'Defendant elects trial by jury' }]
+          end
+
+          it { is_expected.to eql('') }
+        end
+      end
+
+      context 'when more than one reason exists, one of which should be hidden' do
+        let(:mode_of_trial_reason_array) do
+          [{ code: '2',
+             description: 'Defendant elects trial by jury' },
+           { code: '6',
+             description: 'Low value offence triable summarily only' }]
+        end
+
+        it { is_expected.to eql('') }
+      end
+
+      context 'when more than one reason exists, all of which should be hidden' do
+        let(:mode_of_trial_reason_array) do
+          [{ code: '2',
+             description: 'Defendant elects trial by jury' },
+           { code: '5',
+             description: 'Court directs trial by jury' }]
+        end
+
+        it { is_expected.to eql('Court directs trial by jury') }
+      end
     end
   end
 end


### PR DESCRIPTION
#### What
Apply mappings for common platform mode of trial reasons

#### Ticket
https://dsdmoj.atlassian.net/browse/CBO-1633

#### Why
So that mode_of_trial_reason is hidden for certain associated codes (see https://docs.google.com/spreadsheets/d/1-gkLXxS7DqEPDf5tdMkc3c6_Rtrq2G5xIH6OMSvNyYY/edit#gid=1021818802) and to allow for possible future mode_of_trial_reason mappings to be defined.

#### How
Added MODE_OF_TRIAL_REASON_MAPPINGS, currently this allows for mode_of_trial_reason to be hidden for certain associated codes, however, it can be extended in future to allow mode_of_trial_reasons.description to be mapped to different values as required (e.g. 'Directed' and 'Elected' etc.)
