### PR TITLE
[CBO-1665] Migrate axe-matchers to axe-core-rspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ gem 'sidekiq', '~> 6.1'
 gem 'webpacker', '~> 5.2'
 
 group :test do
-  gem 'axe-matchers'
+  gem 'axe-core-rspec', '~> 4.1'
   gem 'brakeman'
   gem 'capybara'
   gem 'capybara_table'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,9 +60,16 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.1)
     awesome_print (1.8.0)
-    axe-matchers (2.6.1)
-      dumb_delegator (~> 0.8)
-      virtus (~> 1.0)
+    axe-core-api (4.1.0)
+      capybara
+      dumb_delegator
+      selenium-webdriver
+      virtus
+      watir
+    axe-core-rspec (4.1.0)
+      axe-core-api
+      dumb_delegator
+      virtus
     axiom-types (0.1.1)
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
@@ -119,7 +126,7 @@ GEM
     dotenv-rails (2.7.6)
       dotenv (= 2.7.6)
       railties (>= 3.2)
-    dumb_delegator (0.8.1)
+    dumb_delegator (1.0.0)
     equalizer (0.0.11)
     erubi (1.10.0)
     erubis (2.7.0)
@@ -425,6 +432,9 @@ GEM
       equalizer (~> 0.0, >= 0.0.9)
     warden (1.2.9)
       rack (>= 2.0.9)
+    watir (6.17.0)
+      regexp_parser (~> 1.2)
+      selenium-webdriver (~> 3.6)
     web-console (4.1.0)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -462,7 +472,7 @@ PLATFORMS
 
 DEPENDENCIES
   awesome_print
-  axe-matchers
+  axe-core-rspec (~> 4.1)
   bootsnap (>= 1.4.2)
   brakeman
   breadcrumbs_on_rails

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -7,7 +7,7 @@
 #
 require 'capybara_table/rspec'
 require_relative 'capybara_extensions'
-require 'axe/rspec'
+require 'axe-rspec'
 
 module Capybara
   module DSL

--- a/spec/support/matchers/be_accessible.rb
+++ b/spec/support/matchers/be_accessible.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require 'axe-rspec'
+
+RSpec::Matchers.alias_matcher :be_accessible, :be_axe_clean


### PR DESCRIPTION
#### What
The package axe-matchers has been moved to axe-core-gems. We need to migrate to the new package and update our assertions.

#### Ticket
[Migrate axe-matchers to axe-core-rspec](https://dsdmoj.atlassian.net/browse/CBO-1665)

#### Why
Because the package axe-matchers has been deprecated.
