### PR TITLE
Prevent nilclass errors

### DIFF
--- a/app/views/prosecution_cases/_cracked_ineffective_trial.html.haml
+++ b/app/views/prosecution_cases/_cracked_ineffective_trial.html.haml
@@ -1,6 +1,6 @@
 - results.each do |prosecution_case|
   - prosecution_case = decorate(prosecution_case)
-  - if prosecution_case.cracked?
+  - if prosecution_case&.cracked?
     %table.govuk-table
       %caption.govuk-table__caption.govuk-visually-hidden
         = t('prosecution_case.show.cracked_ineffective_trial.caption')


### PR DESCRIPTION
#### What
Fix nil class error. will spec after the fact
but this is a prod issue

#### Why
sentry errors show this against UAT
```
ActionView::Template::Error ProsecutionCasesController#show
error
undefined method `cracked?' for nil:NilClass
```

