### PR TITLE
Add team devs as default dependabot reviewers

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -10,6 +10,8 @@ update_configs:
     # pull requests
     default_reviewers:
       - "jsugarman"
+      - "kmahern"
+      - "jrmhaig"
 
   # Keep package.json (& lockfiles) up to date as soon as
   # new versions are published to the npm registry


### PR DESCRIPTION
#### What
Add team devs as default dependabot reviewers

#### Ticket

n/a

#### Why
Any team dev can review and approve dependabot
PR.s this automates the assignment of devs.

Note: we should move to version 2 of the
dependabot githubnative config. see
cccd for example.