### PR TITLE
Handle unexpected formats for not_found responses

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -11,7 +11,10 @@ class ErrorsController < ApplicationController
   end
 
   def not_found
-    render status: :not_found
+    respond_to do |format|
+      format.html { render status: :not_found }
+      format.all { render plain: 'Not found', status: :not_found }
+    end
   end
 
   def unacceptable

--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -14,14 +14,32 @@ RSpec.describe 'error routes', type: :request do
   end
 
   describe 'GET #not_found', type: :request do
-    before { get '/not-exists' }
+    context 'with non-existent route' do
+      before { get '/not-exists' }
 
-    it 'has a status of 404' do
-      expect(response.status).to eq(404)
+      it 'has a status of 404' do
+        expect(response.status).to eq(404)
+      end
+
+      it 'renders the 404/not_found template' do
+        expect(response).to render_template('errors/not_found')
+      end
     end
 
-    it 'renders the 404/not_found template' do
-      expect(response).to render_template('errors/not_found')
+    context 'with non-existent route and format' do
+      before { get '/.well-known/security.txt' }
+
+      it 'has a status of 404' do
+        expect(response.status).to eq(404)
+      end
+
+      it 'renders plain text' do
+        expect(response.content_type).to include('text/plain')
+      end
+
+      it 'renders not found message' do
+        expect(response.body).to include('Not found')
+      end
     end
   end
 


### PR DESCRIPTION
#### What
Handle unexpected formats for not_found responses

#### Why
Prevent sentry error clutter from requests to non-existent paths/pages
with unhandled formats as well.

Example error:

```
ActionView::MissingTemplate
  Missing template errors/not_found, application/not_found with {:locale=>[:en], :formats=>[:text], :variants=>[], :handlers=>[:raw, :erb, :html, :builder, :ruby, :haml]}
```

The missing template error results from the format (e.g. `:formats=>[:text]`)
itself. Such requests appear to be be vulnerability scans. As such they are not
something we need cluttering up sentry - they are recorded
by our prometheus monitoring and alerting setup in any event.

#### How
Keep responding to `html` requests with the errors#not_found template
as usual, but all other formats can respond with plain text.