### PR TITLE
Bump bootsnap 1.6.0 --> 1.7.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby '2.7.0'
 
 # Reduces boot times through caching; required in config/boot.rb
-gem 'bootsnap', '>= 1.4.2', require: false
+gem 'bootsnap', '>= 1.7.0', require: false
 
 gem 'breadcrumbs_on_rails'
 gem 'cancancan'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,7 +81,7 @@ GEM
     bcrypt (3.1.16)
     bcrypt (3.1.16-java)
     bindex (0.8.1)
-    bootsnap (1.6.0)
+    bootsnap (1.7.0)
       msgpack (~> 1.0)
     brakeman (5.0.0)
     breadcrumbs_on_rails (4.0.0)
@@ -221,8 +221,8 @@ GEM
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.3)
-    msgpack (1.4.1)
-    msgpack (1.4.1-java)
+    msgpack (1.4.2)
+    msgpack (1.4.2-java)
     multi_json (1.14.1)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
@@ -474,7 +474,7 @@ PLATFORMS
 DEPENDENCIES
   awesome_print
   axe-core-rspec (~> 4.1)
-  bootsnap (>= 1.4.2)
+  bootsnap (>= 1.7.0)
   brakeman
   breadcrumbs_on_rails
   cancancan


### PR DESCRIPTION
Getting build errors as below. bootsnap is
the dependency that use msgpack and it has released
a fix today thankfully.

```
Your bundle is locked to msgpack (1.4.1-java), but that version could not be
found in any of the sources listed in your Gemfile. If you haven't changed
sources, that means the author of msgpack (1.4.1-java) has removed it. You'll
need to update your bundle to a version other than msgpack (1.4.1-java) that
hasn't been removed in order to install.
```

Bootsnap [changelog](https://github.com/Shopify/bootsnap/blob/master/CHANGELOG.md)