### PR TITLE
Refactor the prosecution case "show" flow

### DIFF
--- a/app/controllers/prosecution_cases_controller.rb
+++ b/app/controllers/prosecution_cases_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ProsecutionCasesController < ApplicationController
-  before_action :load_and_authorize_search, :set_prosecution_case_and_results
+  before_action :load_and_authorize_search, :set_prosecution_case
 
   add_breadcrumb :search_filter_breadcrumb_name, :new_search_filter_path
   add_breadcrumb :search_breadcrumb_name, :search_breadcrumb_path
@@ -18,8 +18,11 @@ class ProsecutionCasesController < ApplicationController
     authorize! :create, @search
   end
 
-  def set_prosecution_case_and_results
-    @results = @search.execute
-    @prosecution_case = @results.first
+  def set_prosecution_case
+    @prosecution_case = helpers.decorate(search_results.first)
+  end
+
+  def search_results
+    @search_results ||= @search.execute
   end
 end

--- a/app/views/prosecution_cases/_cracked_ineffective_trial.html.haml
+++ b/app/views/prosecution_cases/_cracked_ineffective_trial.html.haml
@@ -1,16 +1,14 @@
-- results.each do |prosecution_case|
-  - prosecution_case = decorate(prosecution_case)
-  - if prosecution_case&.cracked?
-    %table.govuk-table
-      %caption.govuk-table__caption.govuk-visually-hidden
-        = t('prosecution_case.show.cracked_ineffective_trial.caption')
-      %tbody.govuk-table__body
-        %tr.govuk-table__row
-          %th.govuk-table__header{ scope: 'row' }
-            = t('prosecution_case.show.cracked_ineffective_trial.heading')
-          %td.govuk-table__cell
-            - prosecution_case.hearings.each do |hearing|
-              - if hearing.cracked_ineffective_trial&.cracked?
-                = hearing.cracked_ineffective_trial.cracked_on_sentence(hearing, prosecution_case)
-                %br
-                = hearing.cracked_ineffective_trial.description
+- if prosecution_case&.cracked?
+  %table.govuk-table
+    %caption.govuk-table__caption.govuk-visually-hidden
+      = t('prosecution_case.show.cracked_ineffective_trial.caption')
+    %tbody.govuk-table__body
+      %tr.govuk-table__row
+        %th.govuk-table__header{ scope: 'row' }
+          = t('prosecution_case.show.cracked_ineffective_trial.heading')
+        %td.govuk-table__cell
+          - prosecution_case.hearings.each do |hearing|
+            - if hearing.cracked_ineffective_trial&.cracked?
+              = hearing.cracked_ineffective_trial.cracked_on_sentence(hearing, prosecution_case)
+              %br
+              = hearing.cracked_ineffective_trial.description

--- a/app/views/prosecution_cases/_defendants.html.haml
+++ b/app/views/prosecution_cases/_defendants.html.haml
@@ -9,12 +9,11 @@
       %th.govuk-table__header{ scope: 'col' }= t('search.result.defendant.date_of_birth')
       %th.govuk-table__header{ scope: 'col' }= t('search.result.defendant.maat_number')
   %tbody.govuk-table__body
-    - @results.each do |prosecution_case|
-      - prosecution_case.defendants.each do |defendant|
-        %tr.govuk-table__row
-          %td.govuk-table__cell
-            = link_to defendant.name, defendant_link_path(defendant, prosecution_case.prosecution_case_reference)
-          %td.govuk-table__cell
-            = l(defendant.date_of_birth&.to_date)
-          %td.govuk-table__cell
-            = defendant.maat_reference || t('search.result.defendant.unlinked')
+    - prosecution_case.defendants.each do |defendant|
+      %tr.govuk-table__row
+        %td.govuk-table__cell
+          = link_to defendant.name, defendant_link_path(defendant, prosecution_case.prosecution_case_reference), class: 'govuk-link'
+        %td.govuk-table__cell
+          = l(defendant.date_of_birth&.to_date)
+        %td.govuk-table__cell
+          = defendant.maat_reference || t('search.result.defendant.unlinked')

--- a/app/views/prosecution_cases/_hearing_summaries.html.haml
+++ b/app/views/prosecution_cases/_hearing_summaries.html.haml
@@ -9,14 +9,12 @@
       %th.govuk-table__header{ scope: 'col' }= t('search.result.hearing.hearing_type')
       %th.govuk-table__header{ scope: 'col' }= t('search.result.hearing.providers')
   %tbody.govuk-table__body
-    - results.each do |prosecution_case|
-      - decorate(prosecution_case) do |pc|
-        - pc.hearings_by_datetime.each do |hearing|
-          - hearing.hearing_days.map(&:to_date).sort.each do |hearing_day|
-            %tr.govuk-table__row
-              %td.govuk-table__cell
-                = link_to hearing_day.to_date.strftime('%d/%m/%Y'), hearing_path(id: hearing.id, urn: prosecution_case.prosecution_case_reference, hearing_day: hearing_day.to_date.strftime('%d/%m/%Y'))
-              %td.govuk-table__cell
-                = hearing.hearing_type
-              %td.govuk-table__cell
-                = hearing ? decorate(hearing).provider_list : t('generic.not_available')
+    - prosecution_case.hearings_by_datetime.each do |hearing|
+      - hearing.hearing_days.map(&:to_date).sort.each do |hearing_day|
+        %tr.govuk-table__row
+          %td.govuk-table__cell
+            = link_to hearing_day.to_date.strftime('%d/%m/%Y'), hearing_path(id: hearing.id, urn: prosecution_case.prosecution_case_reference, hearing_day: hearing_day.to_date.strftime('%d/%m/%Y')), class: 'govuk-link'
+          %td.govuk-table__cell
+            = hearing.hearing_type
+          %td.govuk-table__cell
+            = hearing ? decorate(hearing).provider_list : t('generic.not_available')

--- a/app/views/prosecution_cases/_raw_response.html.haml
+++ b/app/views/prosecution_cases/_raw_response.html.haml
@@ -1,45 +1,44 @@
 %div{ class: 'govuk-!-padding-bottom-4' }
 = govuk_detail(t('generic.view_raw_data')) do
-  - @results.each do |prosecution_case|
-    %h3='Prosecution case'
+  %h3=t('generic.prosecution_case')
+  %pre
+    = JSON.pretty_generate(prosecution_case.as_json)
+
+  %h3='Defendants'
+  %pre
+    - prosecution_case.defendants.each.with_index do |defendant, idx|
+      %h4="defendant #{idx}"
+      = JSON.pretty_generate(defendant.attributes)
+      %h4="Offences for defendant #{idx}"
+      - defendant.offences.each do |offence|
+        = JSON.pretty_generate(offence.attributes)
+
+  %h3='Hearing summaries'
+  - prosecution_case.hearing_summaries.each do |hearing_summary|
     %pre
-      = JSON.pretty_generate(prosecution_case.as_json)
+      = JSON.pretty_generate(hearing_summary.attributes)
 
-    %h3='Defendants'
+  %h3='Hearings'
+  - prosecution_case.hearings.each.with_index do |hearing, hidx|
+    %h4="hearing #{hidx}"
     %pre
-      - prosecution_case.defendants.each.with_index do |defendant, idx|
-        %h4="defendant #{idx}"
-        = JSON.pretty_generate(defendant.attributes)
-        %h4="Offences for defendant #{idx}"
-        - defendant.offences.each do |offence|
-          = JSON.pretty_generate(offence.attributes)
+      = JSON.pretty_generate(hearing.attributes)
 
-    %h3='Hearing summaries'
-    - prosecution_case.hearing_summaries.each do |hearing_summary|
+    %h4="Hearing events for hearing #{hidx}"
+    = 'none' if hearing.hearing_events.empty?
+    - hearing.hearing_events.each.with_index do |event, eidx|
       %pre
-        = JSON.pretty_generate(hearing_summary.attributes)
+        = JSON.pretty_generate(event.attributes)
 
-    %h3='Hearings'
-    - prosecution_case.hearings.each.with_index do |hearing, hidx|
-      %h4="hearing #{hidx}"
+    %h4="Providers for hearing #{hidx}"
+    = 'none' if hearing.providers.empty?
+    - hearing.providers.each.with_index do |event, pidx|
       %pre
-        = JSON.pretty_generate(hearing.attributes)
+        = JSON.pretty_generate(event.attributes)
 
-      %h4="Hearing events for hearing #{hidx}"
-      = 'none' if hearing.hearing_events.empty?
-      - hearing.hearing_events.each.with_index do |event, eidx|
-        %pre
-          = JSON.pretty_generate(event.attributes)
-
-      %h4="Providers for hearing #{hidx}"
-      = 'none' if hearing.providers.empty?
-      - hearing.providers.each.with_index do |event, pidx|
-        %pre
-          = JSON.pretty_generate(event.attributes)
-
-      %h4="Cracked ineffective details for hearing #{hidx}"
-      - if hearing.cracked_ineffective_trial.nil?
-        = 'none'
-      - else
-        %pre
-          = JSON.pretty_generate(hearing.cracked_ineffective_trial.attributes)
+    %h4="Cracked ineffective details for hearing #{hidx}"
+    - if hearing.cracked_ineffective_trial.nil?
+      = 'none'
+    - else
+      %pre
+        = JSON.pretty_generate(hearing.cracked_ineffective_trial.attributes)

--- a/app/views/prosecution_cases/show.html.haml
+++ b/app/views/prosecution_cases/show.html.haml
@@ -1,10 +1,10 @@
 = govuk_page_title(@prosecution_case.prosecution_case_reference, t('generic.case'))
 
-= render partial: 'cracked_ineffective_trial', locals: { results: @results }
+= render partial: 'cracked_ineffective_trial', locals: { prosecution_case: @prosecution_case }
 
-= render partial: 'defendants', locals: { results: @results , prosecution_case: @prosecution_case}
+= render partial: 'defendants', locals: { prosecution_case: @prosecution_case }
 
-= render partial: 'hearing_summaries', locals: { results: @results }
+= render partial: 'hearing_summaries', locals: { prosecution_case: @prosecution_case }
 
 - if Rails.configuration.x.display_raw_responses
-  = render partial: 'raw_response'
+  = render partial: 'raw_response', locals: { prosecution_case: @prosecution_case }

--- a/config/locales/en/generic.yml
+++ b/config/locales/en/generic.yml
@@ -11,6 +11,7 @@ en:
     hearing: Hearing
     new_window: opens in a new window
     not_available: Not available
+    prosecution_case: Prosecution case
     search: Search
     view_raw_data: View raw data
     warning: Warning

--- a/spec/views/prosecution_cases/_cracked_ineffective_trial.html.haml_spec.rb
+++ b/spec/views/prosecution_cases/_cracked_ineffective_trial.html.haml_spec.rb
@@ -31,15 +31,17 @@ RSpec.shared_examples 'cracked_ineffective_trial with case level result' do |opt
 end
 
 RSpec.describe 'prosecution_cases/_cracked_ineffective_trial.html.haml', type: :view do
-  subject(:render_partial) { render partial: 'cracked_ineffective_trial', locals: { results: results } }
+  subject(:render_partial) do
+    render partial: 'cracked_ineffective_trial', locals: { prosecution_case: decorated_prosecution_case }
+  end
 
   include RSpecHtmlMatchers
 
-  let(:results) { [prosecution_case] }
+  let(:decorated_prosecution_case) { view.decorate(prosecution_case) }
   let(:prosecution_case) do
-    CourtDataAdaptor::Resource::ProsecutionCase
-      .new(prosecution_case_reference: 'THECASEURN')
+    CourtDataAdaptor::Resource::ProsecutionCase.new(prosecution_case_reference: 'THECASEURN')
   end
+
   let(:hearings) { [hearing] }
   let(:hearing) do
     CourtDataAdaptor::Resource::Hearing

--- a/spec/views/prosecution_cases/_hearing_summaries.html.haml_spec.rb
+++ b/spec/views/prosecution_cases/_hearing_summaries.html.haml_spec.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
 RSpec.describe 'prosecution_cases/_hearing_summaries.html.haml', type: :view do
-  subject(:render_partial) { render partial: 'hearing_summaries', locals: { results: results } }
+  subject(:render_partial) do
+    render partial: 'hearing_summaries', locals: { prosecution_case: decorated_prosecution_case }
+  end
 
-  let(:results) { [prosecution_case] }
+  let(:decorated_prosecution_case) { view.decorate(prosecution_case) }
   let(:prosecution_case) do
-    CourtDataAdaptor::Resource::ProsecutionCase
-      .new(prosecution_case_reference: 'THECASEURN')
+    CourtDataAdaptor::Resource::ProsecutionCase.new(prosecution_case_reference: 'THECASEURN')
   end
 
   let(:hearings) { [] }

--- a/spec/views/prosecution_cases/show.html.haml_spec.rb
+++ b/spec/views/prosecution_cases/show.html.haml_spec.rb
@@ -3,19 +3,16 @@
 RSpec.describe 'prosecution_cases/show.html.haml', type: :view do
   subject(:render_view) { render }
 
-  let(:results) { [prosecution_case] }
-
+  let(:decorated_prosecution_case) { view.decorate(prosecution_case) }
   let(:prosecution_case) do
-    CourtDataAdaptor::Resource::ProsecutionCase
-      .new(prosecution_case_reference: 'THECASEURN')
+    CourtDataAdaptor::Resource::ProsecutionCase.new(prosecution_case_reference: 'THECASEURN')
   end
 
   before do
     allow(view).to receive(:govuk_page_title).and_return 'A Gov uk page title'
     allow(prosecution_case).to receive(:hearings).and_return([])
     allow(prosecution_case).to receive(:defendants).and_return([])
-    assign(:prosecution_case, prosecution_case)
-    assign(:results, results)
+    assign(:prosecution_case, decorated_prosecution_case)
   end
 
   it { is_expected.to have_content('A Gov uk page title') }


### PR DESCRIPTION
#### What
Refactor the prosecution case "show" flow

#### Ticket

n/a

#### Why
Removes the need to iterate over an array of
results to retrieve the prosectution_case object.

There can only be one prosecution_case
per URN - we might want to consider raising
an error if there is ever more than one.

This removes a lot of clutter and logic
from the views. It also moves the decoration
of the prosecution_case to the controller so
any views/partials do not need to decorate
individually.

#### How

decorate prosecution_case in the prosecution_case_controller
and use this decorated object directly in the views.