### PR TITLE
Change names search to handle extra whitespace

### DIFF
--- a/lib/court_data_adaptor/query/defendant/by_name.rb
+++ b/lib/court_data_adaptor/query/defendant/by_name.rb
@@ -23,7 +23,7 @@ module CourtDataAdaptor
         private
 
         def name
-          term.strip
+          term.squish
         end
 
         def date_of_birth
@@ -34,7 +34,7 @@ module CourtDataAdaptor
           cases.each_with_object([]) do |c, results|
             c.defendants.each do |d|
               d.prosecution_case_reference = c.prosecution_case_reference
-              results << d if d.name.casecmp(name).zero?
+              results << d if d.name.squish.casecmp(name).zero?
             end
           end
         end

--- a/spec/lib/court_data_adaptor/query/defendant/by_name_spec.rb
+++ b/spec/lib/court_data_adaptor/query/defendant/by_name_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe CourtDataAdaptor::Query::Defendant::ByName do
   subject { described_class }
 
   let(:instance) { described_class.new(nil) }
-  let(:term) { 'josefa theadore FRanecki  ' }
+  let(:term) { '    josefa      theadore    FRanecki  ' }
   let(:dob) { Date.parse('15-06-1961') }
 
   def self.resource
@@ -46,7 +46,7 @@ RSpec.describe CourtDataAdaptor::Query::Defendant::ByName do
       expect(resource).to have_received(:includes).with(:defendants)
     end
 
-    it 'sends where query to resource' do
+    it 'sends where query to resource, squishing name whitespace' do
       expect(resultset)
         .to have_received(:where)
         .with(name: 'josefa theadore FRanecki', date_of_birth: '1961-06-15')


### PR DESCRIPTION
#### What
squish names for search to ensure extra whitespace
has no impact

#### Why
Additional whitespace is being added to the
the name coming from the adaptor, making
comparison fail.

I have [raised an issue with the adaptor](https://github.com/ministryofjustice/laa-court-data-adaptor/issues/395)
and a [fix PR for it](https://github.com/ministryofjustice/laa-court-data-adaptor/pull/397) but we can handle this our side to for assurance.


#### How
By removing whitespace from ends and between multiple names
and doing a case insensitive search against the adaptor
results we can remove search failures resulting from whitespace