### PR TITLE
Change header for hearings page

### DIFF
--- a/app/controllers/hearings_controller.rb
+++ b/app/controllers/hearings_controller.rb
@@ -13,7 +13,7 @@ class HearingsController < ApplicationController
                  (proc { |v| v.prosecution_case_path(v.controller.prosecution_case_reference) })
 
   def show
-    add_breadcrumb "Hearing #{@hearing_day&.strftime('%d/%m/%Y')}", ''
+    add_breadcrumb "#{t('generic.hearing_day')} #{@hearing_day&.strftime('%d/%m/%Y')}", ''
 
     return if @hearing
 

--- a/app/views/hearings/_listing_info.html.haml
+++ b/app/views/hearings/_listing_info.html.haml
@@ -1,6 +1,6 @@
 %table.govuk-table
   %caption.govuk-table__caption.govuk-visually-hidden
-    = t('generic.hearing')
+    = t('generic.hearing_day')
   %tbody.govuk-table__body
     %tr.govuk-table__row
       %th.govuk-table__header{ scope: 'row' }

--- a/app/views/hearings/show.html.haml
+++ b/app/views/hearings/show.html.haml
@@ -1,4 +1,4 @@
-= govuk_page_title(@hearing_day&.strftime('%d/%m/%Y'), t('generic.hearing'))
+= govuk_page_title(@hearing_day&.strftime('%d/%m/%Y'), t('generic.hearing_day'))
 - hearing = decorate(@hearing)
 
 = render partial: 'listing_info', locals: { hearing: hearing, hearing_day: @hearing_day }

--- a/config/locales/en/generic.yml
+++ b/config/locales/en/generic.yml
@@ -8,7 +8,7 @@ en:
     form:
       select:
         blank_option: Please select
-    hearing: Hearing
+    hearing_day: Hearing day
     new_window: opens in a new window
     not_available: Not available
     search: Search

--- a/spec/features/breadcrumbs_spec.rb
+++ b/spec/features/breadcrumbs_spec.rb
@@ -195,6 +195,6 @@ RSpec.feature 'Breadcrumb', type: :feature, stub_unlinked: true do
     expect(page).to have_govuk_breadcrumb_link('Home')
     expect(page).to have_govuk_breadcrumb_link('Search')
     expect(page).to have_govuk_breadcrumb_link("Case #{case_ref}")
-    expect(page).to have_govuk_breadcrumb("Hearing #{hearing_day}", aria_current: true)
+    expect(page).to have_govuk_breadcrumb("Hearing day #{hearing_day}", aria_current: true)
   end
 end

--- a/spec/features/unlinked_defendant_flow_spec.rb
+++ b/spec/features/unlinked_defendant_flow_spec.rb
@@ -158,7 +158,7 @@ RSpec.feature 'Unlinked defendant page flow', type: :feature, stub_unlinked: tru
   end
 
   def has_hearing_table_row_header_columns
-    within :table, 'Hearing' do
+    within :table, 'Hearing day' do
       rows = find_all('tbody .govuk-table__row')
       expect(rows[0].first('.govuk-table__header')).to have_text 'Hearing type'
       expect(rows[1].first('.govuk-table__header')).to have_text 'Court'


### PR DESCRIPTION
#### What
Change header and breadcrumb for hearings page to "Hearing day {date}"

#### Ticket

[CBO-1417](https://dsdmoj.atlassian.net/browse/CBO-1417)

#### Why
Designer wants to make it clear to users that they are
only viewing a single hearing days event logs
for the hearing.