### PR TITLE
Supply hearing day for cracked ineffective trial link

### DIFF
--- a/app/decorators/cracked_ineffective_trial_decorator.rb
+++ b/app/decorators/cracked_ineffective_trial_decorator.rb
@@ -25,8 +25,11 @@ class CrackedIneffectiveTrialDecorator < BaseDecorator
   private
 
   def cracked_at_link(hearing, prosecution_case)
-    view.link_to(hearing.hearing_days.first.to_date.strftime('%d/%m/%Y'),
+    heard_at = hearing.hearing_days.first.to_date.strftime('%d/%m/%Y')
+    view.link_to(heard_at,
                  view.hearing_path(id: hearing.id,
-                                   urn: prosecution_case.prosecution_case_reference))
+                                   urn: prosecution_case.prosecution_case_reference,
+                                   hearing_day: heard_at),
+                 class: 'govuk-link')
   end
 end

--- a/spec/decorators/cracked_ineffective_trial_decorator_spec.rb
+++ b/spec/decorators/cracked_ineffective_trial_decorator_spec.rb
@@ -77,6 +77,10 @@ RSpec.describe CrackedIneffectiveTrialDecorator, type: :decorator do
       CourtDataAdaptor::Resource::ProsecutionCase.new(prosecution_case_reference: 'MY-CASE-URN')
     end
 
+    let(:expected_href) do
+      %r{hearings/a-hearing-uuid\?hearing_day=#{CGI.escape('19/01/2021')}&urn=MY-CASE-URN}
+    end
+
     let(:hearing) do
       instance_double(CourtDataAdaptor::Resource::Hearing,
                       id: 'a-hearing-uuid',
@@ -91,14 +95,15 @@ RSpec.describe CrackedIneffectiveTrialDecorator, type: :decorator do
       let(:type) { 'CrACKed' }
 
       it { is_expected.to include('Cracked on') }
-      it { is_expected.to have_link('19/01/2021', href: %r{hearings/a-hearing-uuid\?urn=MY-CASE-URN}) }
+
+      it { is_expected.to have_link('19/01/2021', href: expected_href, class: 'govuk-link') }
     end
 
     context 'when type is vacated' do
       let(:type) { 'Vacated' }
 
       it { is_expected.to include('Vacated on') }
-      it { is_expected.to have_link('19/01/2021', href: %r{hearings/a-hearing-uuid\?urn=MY-CASE-URN}) }
+      it { is_expected.to have_link('19/01/2021', href: expected_href, class: 'govuk-link') }
     end
   end
 

--- a/spec/views/prosecution_cases/_cracked_ineffective_trial.html.haml_spec.rb
+++ b/spec/views/prosecution_cases/_cracked_ineffective_trial.html.haml_spec.rb
@@ -7,26 +7,24 @@ RSpec.shared_examples 'cracked_ineffective_trial with case level result' do |opt
 
   it 'displays case result section' do
     render_partial
-    expect(rendered).to have_tag('th.govuk-table__header', text: /Case results/)
+    expect(rendered).to have_selector('th.govuk-table__header', text: /Case results/)
   end
 
   it 'displays the cracked_ineffective_trial type' do
     render_partial
-    expect(rendered).to have_tag('td.govuk-table__cell', text: /#{type_text} on/)
+    expect(rendered).to have_selector('td.govuk-table__cell', text: /#{type_text} on/)
   end
 
   it 'displays link to hearing' do
     render_partial
-    expect(rendered).to have_tag('a', with: { href: '/hearings/the-hearing-uuid?urn=THECASEURN' }) do
-      with_text(%r{15/01/2021})
-    end
+    expected_href = %r{hearings/the-hearing-uuid\?hearing_day=#{CGI.escape('15/01/2021')}&urn=THECASEURN}
+    expect(rendered).to have_link('15/01/2021', href: expected_href, class: 'govuk-link')
   end
 
   it 'displays reason' do
     render_partial
-    expect(rendered).to have_tag('td.govuk-table__cell') do
-      with_text(/Reason for cracked, vacated or ineffective trial/)
-    end
+    expect(rendered).to have_selector('td.govuk-table__cell',
+                                      text: /Reason for cracked, vacated or ineffective trial/)
   end
 end
 


### PR DESCRIPTION
#### What
Supply hearing day for cracked ineffective trial link

#### Why
This was missed from previous PR to add the hearing
days for other hearing summary links.

It also styles the link correctly.