### PR TITLE
Do not display a link to the hearing_day where the hearing_day is in …

### DIFF
--- a/app/views/prosecution_cases/_hearing_summaries.html.haml
+++ b/app/views/prosecution_cases/_hearing_summaries.html.haml
@@ -13,7 +13,12 @@
       - hearing.hearing_days.map(&:to_date).sort.each do |hearing_day|
         %tr.govuk-table__row
           %td.govuk-table__cell
-            = link_to hearing_day.to_date.strftime('%d/%m/%Y'), hearing_path(id: hearing.id, urn: prosecution_case.prosecution_case_reference, hearing_day: hearing_day.to_date.strftime('%d/%m/%Y')), class: 'govuk-link'
+            - if hearing_day > Date.today
+              = hearing_day.to_date.strftime('%d/%m/%Y')
+              %br
+              = 'Scheduled'
+            - else
+              = link_to hearing_day.to_date.strftime('%d/%m/%Y'), hearing_path(id: hearing.id, urn: prosecution_case.prosecution_case_reference, hearing_day: hearing_day.to_date.strftime('%d/%m/%Y')), class: 'govuk-link'
           %td.govuk-table__cell
             = hearing.hearing_type
           %td.govuk-table__cell

--- a/spec/views/prosecution_cases/_hearing_summaries.html.haml_spec.rb
+++ b/spec/views/prosecution_cases/_hearing_summaries.html.haml_spec.rb
@@ -112,5 +112,33 @@ RSpec.describe 'prosecution_cases/_hearing_summaries.html.haml', type: :view do
           .and have_selector('tbody.govuk-table__body tr:nth-child(4)', text: %r{20/01/2021.*Sentence}m)
       end
     end
+
+    context 'with a hearing day in the future' do
+      let(:hearings) { [hearing] }
+
+      let(:hearing) do
+        CourtDataAdaptor::Resource::Hearing
+          .new(id: 'hearing-uuid',
+               hearing_type: 'Future hearing',
+               hearing_days: hearing_days,
+               providers: providers)
+      end
+
+      let(:future_date) { Time.zone.today + 1.day }
+      let(:hearing_days) { [future_date] }
+
+      it 'renders the date of the scheduled hearing followed by the text Scheduled' do
+        expect(rendered)
+          .to have_selector('tbody.govuk-table__body tr:nth-child(1)',
+                            text: "#{future_date.strftime('%d/%m/%Y')}\n\nScheduled")
+      end
+
+      it 'does not render a link to the scheduled hearing' do
+        expect(rendered)
+          .not_to have_link(future_date.strftime('%d/%m/%Y'),
+                            href: %r{hearings/.*\?.*hearing_day=#{CGI.escape(future_date
+                              .strftime('%d/%m/%Y'))}})
+      end
+    end
   end
 end


### PR DESCRIPTION

#### What
Do not display a link to the hearing_day where the hearing_day is in the future.

#### Ticket
https://dsdmoj.atlassian.net/browse/CBO-1694

#### Why
Currently all hearings are being handled the same – the date is a link that navigates to the specific hearing day. This means future hearings are not visually distinguished from those that have happened and contain events etc, and also that clicking a link causes an error, which is unexpected (no warning) and frustrating.

#### How
Do not display link if hearing_day > Date.today
