### PR TITLE
Configure vcr hook to match on path and query

### DIFF
--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -63,7 +63,7 @@ RSpec.configure do |config|
   config.around(:each, :vcr) do |example|
     if VCR.turned_on?
       cassette = cassette_name(example)
-      VCR.use_cassette(cassette, record: :new_episodes) do
+      VCR.use_cassette(cassette, record: :new_episodes, match_requests_on: %i[method path query]) do
         example.run
       end
     else


### PR DESCRIPTION
#### What
specs tagged with :vcr will only
match requests to recordings based on
the path and query of the request, not
the domain.

#### Why
Allows cassettes recorded against one
adaptor domain (or local) to function
as expected for feature tests, irrespective
of the app configuration which defines which
adaptor domain to make requests to.