### PR TITLE
Extract common rspec `let` api_url to a helper

### DIFF
--- a/spec/features/unlinking_a_defendant_from_maat_spec.rb
+++ b/spec/features/unlinking_a_defendant_from_maat_spec.rb
@@ -5,7 +5,6 @@ require 'court_data_adaptor'
 RSpec.feature 'Unlinking a defendant from MAAT', type: :feature do
   let(:defendant_nino_from_fixture) { 'JC123456A' }
   let(:case_reference_from_fixture) { 'TEST12345' }
-  let(:api_url) { ENV['COURT_DATA_ADAPTOR_API_URL'] }
 
   let(:user) { create(:user) }
 

--- a/spec/requests/defendants_spec.rb
+++ b/spec/requests/defendants_spec.rb
@@ -17,13 +17,13 @@ RSpec.describe 'defendants', type: :request do
     before do
       sign_in user
 
-      stub_request(:get, %r{#{ENV['COURT_DATA_ADAPTOR_API_URL']}/prosecution_cases.*})
+      stub_request(:get, %r{#{api_url}/prosecution_cases.*})
         .to_return(
           body: defendant_fixture,
           headers: { 'Content-Type' => 'application/vnd.api+json' }
         )
 
-      stub_request(:get, %r{#{ENV['COURT_DATA_ADAPTOR_API_URL']}/defendants/#{defendant_id_from_fixture}})
+      stub_request(:get, %r{#{api_url}/defendants/#{defendant_id_from_fixture}})
         .to_return(
           body: defendant_by_id_fixture,
           headers: { 'Content-Type' => 'application/vnd.api+json' }

--- a/spec/requests/linking/unlink_defendant_maat_reference_spec.rb
+++ b/spec/requests/linking/unlink_defendant_maat_reference_spec.rb
@@ -34,7 +34,6 @@ RSpec.describe 'unlink defendant maat reference', type: :request do
   end
 
   let(:user) { create(:user) }
-  let(:api_url) { ENV['COURT_DATA_ADAPTOR_API_URL'] }
   let(:defendant_fixture) { load_json_stub('linked/defendant_by_reference_body.json') }
   let(:defendant_by_id_fixture) { load_json_stub('linked_defendant.json') }
   let(:json_api_content) { { 'Content-Type' => 'application/vnd.api+json' } }

--- a/spec/support/stub_helper.rb
+++ b/spec/support/stub_helper.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+def api_url
+  CourtDataAdaptor.configuration.api_url
+end
+
 def load_json_stub(relative_path)
   path = Rails.root.join('spec', 'fixtures', 'stubs', relative_path)
   File.read(path)


### PR DESCRIPTION
#### What
move the api_url to a spec support helper

#### Why
Its use in quite a few places