### PR TITLE
Update version of bundler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -533,4 +533,4 @@ RUBY VERSION
    ruby 2.7.0p0
 
 BUNDLED WITH
-   2.1.4
+   2.2.11


### PR DESCRIPTION
#### What

Update the version of Bundler used to 2.2.11.

#### Ticket

N/A

#### Why

This version of Bundler fixes a recently discovered dependency vulnerability. See [here](https://bundler.io/blog/2021/02/15/a-more-secure-bundler-we-fixed-our-source-priorities.html) for more details.

#### How

```bash
gem install bundler
bundle update --bundler
```