### PR TITLE
[CBO-1728] Update pagination UI of hearing days

### DIFF
--- a/app/helpers/govuk_design_system_helper.rb
+++ b/app/helpers/govuk_design_system_helper.rb
@@ -7,11 +7,12 @@
 require 'gds_design_system_breadcrumb_builder'
 
 module GovukDesignSystemHelper
-  def govuk_page_title(title = nil, caption = nil)
+  def govuk_page_title(title = nil, caption = nil, tag_options = {})
     content_for :page_title, page_title(title, caption)
 
     content_for :page_heading do
-      tag.h1(class: 'govuk-heading-xl') do
+      tag_options = prepend_classes('govuk-heading-xl', tag_options)
+      tag.h1(**tag_options) do
         page_heading(title, caption)
       end
     end

--- a/app/views/hearings/_pagination.html.haml
+++ b/app/views/hearings/_pagination.html.haml
@@ -1,4 +1,4 @@
-%nav#pagination-label.moj-pagination
+%nav#pagination-label.moj-pagination{ class: 'govuk-!-margin-bottom-8' }
   %p.govuk-visually-hidden{ 'aria-labelledby': 'pagination-label' }
     Pagination navigation
   %ul.moj-pagination__list

--- a/app/views/hearings/show.html.haml
+++ b/app/views/hearings/show.html.haml
@@ -1,4 +1,4 @@
-= govuk_page_title(@hearing_day&.strftime('%d/%m/%Y'), t('generic.hearing_day'))
+= govuk_page_title(@hearing_day&.strftime('%d/%m/%Y'), t('generic.hearing_day'), class: 'govuk-!-margin-bottom-2')
 
 = render partial: 'pagination', locals: { paginator: @paginator }
 

--- a/spec/helpers/govuk_design_system_helper_spec.rb
+++ b/spec/helpers/govuk_design_system_helper_spec.rb
@@ -74,6 +74,17 @@ RSpec.describe GovukDesignSystemHelper, type: :helper do
         end
       end
     end
+
+    context 'with custom classes' do
+      before do
+        helper.govuk_page_title('A page title', 'A page caption', class: 'my-custom-class1 my-custom-class2')
+      end
+
+      it ':page_heading contains custom classes, prepended by govuk class' do
+        markup = helper.content_for(:page_heading)
+        expect(markup).to have_tag(:h1, with: { class: 'govuk-heading-xl my-custom-class1 my-custom-class2' })
+      end
+    end
   end
 
   describe '#govuk_detail' do


### PR DESCRIPTION
#### What
Update pagination UI of hearing days

#### Ticket
[Update pagination UI of hearing days](https://dsdmoj.atlassian.net/browse/CBO-1728)

#### Why
The current style adds too much spacing between the heading and the pagination, and too little spacing between the pagination and the next sibling.
This did not meet the design reference.

#### How
Updated the `govuk_page_title` helper to accept a third argument that allows us to add custom classes, then, using [spacing overrides](https://design-system.service.gov.uk/styles/spacing/) to update the UI to match the design reference.

#### Design reference
![image](https://user-images.githubusercontent.com/8057224/109672142-a3386a80-7b6c-11eb-8c8f-097750881049.png)
