### PR TITLE
Remove the climate_control gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,6 @@ group :test do
   gem 'brakeman'
   gem 'capybara'
   gem 'capybara_table'
-  gem 'climate_control'
   gem 'codeclimate-test-reporter', require: false
   gem 'fakeredis', require: 'fakeredis/rspec'
   gem 'i18n-tasks', '~> 0.9.34'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,7 +102,6 @@ GEM
       terminal-table
       xpath (>= 2.1)
     childprocess (3.0.0)
-    climate_control (0.2.0)
     codeclimate-test-reporter (1.0.7)
       simplecov
     coderay (1.1.2)
@@ -485,7 +484,6 @@ DEPENDENCIES
   cancancan
   capybara
   capybara_table
-  climate_control
   codeclimate-test-reporter
   colorize
   devise (~> 4.7)


### PR DESCRIPTION
#### What

Remove the `climate_control` gem.

#### Ticket

N/A

#### Why

This gem is no longer, or never was, used.
