### PR TITLE
Bump mimemagic to 0.3.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -219,7 +219,7 @@ GEM
       rack-contrib (>= 1.1, < 3)
       railties (>= 3.0.0, < 7)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.3.6)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.4)


### PR DESCRIPTION
#### What
Bump mimemagic to 0.3.6

#### Ticket
n/a

#### Why
The prior version (0.3.5) was yanked causing builds to fail

#### How
Updated version in Gemfile.lock
