### PR TITLE
Bump mimemagic 0.3.9

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
 brew 'postgresql', restart_service: true
+brew 'shared-mime-info'
 brew 'nvm'
 brew 'yarn'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -219,7 +219,9 @@ GEM
       rack-contrib (>= 1.1, < 3)
       railties (>= 3.0.0, < 7)
     method_source (1.0.0)
-    mimemagic (0.3.6)
+    mimemagic (0.3.9)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.4)


### PR DESCRIPTION
#### What
Bump mimemagic 0.3.9

#### Why
see https://www.theregister.com/2021/03/25/ruby_rails_code/

Previous versions to 0.3.6 yanked
plus 0.3.9 seems to just work.

We do not actually use it anyway, but is a rails
dependency that we are currently pulling in,
even though it should be possible not to by removing
`require 'rails'` from `config/application.rb`