### PR TITLE
Add CharLengthValidator spec

### DIFF
--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe Search, type: :model do
         let(:filter) { nil }
 
         it { is_expected.to be_invalid }
-        it { is_expected.to have_activerecord_error(:filter, 'Filter required') }
+        it { is_expected.to have_activemodel_error_message(:filter, 'Filter required') }
       end
 
       context 'with not included filter' do
@@ -118,7 +118,7 @@ RSpec.describe Search, type: :model do
 
         it {
           is_expected.to \
-            have_activerecord_error(:filter, 'Filter "invalid_filter" is not recognized')
+            have_activemodel_error_message(:filter, 'Filter "invalid_filter" is not recognized')
         }
       end
 
@@ -126,7 +126,7 @@ RSpec.describe Search, type: :model do
         let(:term) { nil }
 
         it { is_expected.to be_invalid }
-        it { is_expected.to have_activerecord_error(:term, 'Search term required') }
+        it { is_expected.to have_activemodel_error_message(:term, 'Search term required') }
       end
 
       context 'with blank dob' do
@@ -145,15 +145,14 @@ RSpec.describe Search, type: :model do
         let(:filter) { nil }
 
         it { is_expected.to be_invalid }
-        it { is_expected.to have_activerecord_error(:filter, 'Filter required') }
+        it { is_expected.to have_activemodel_error_message(:filter, 'Filter required') }
       end
 
       context 'with blank term' do
         let(:term) { nil }
 
         it { is_expected.to be_invalid }
-        it { is_expected.to have_activerecord_error(:term, 'Search term required') }
-        it { is_expected.not_to have_activerecord_error(:term, 'Search term must be at least 2 characters') }
+        it { is_expected.to have_activemodel_error_message(:term, 'Search term required') }
       end
 
       context 'with non-alphanumeric chars as term' do
@@ -163,7 +162,7 @@ RSpec.describe Search, type: :model do
 
         it {
           is_expected
-            .to have_activerecord_error(:term, 'Search term must contain only letters and numbers')
+            .to have_activemodel_error_message(:term, 'Search term must contain only letters and numbers')
         }
       end
 
@@ -171,21 +170,29 @@ RSpec.describe Search, type: :model do
         let(:term) { "\s\s\t" }
 
         it { is_expected.to be_invalid }
-        it { is_expected.to have_activerecord_error(:term, 'Search term required') }
+        it { is_expected.to have_activemodel_error_message(:term, 'Search term required') }
       end
 
       context 'with single char as term' do
         let(:term) { 'a' }
 
         it { is_expected.to be_invalid }
-        it { is_expected.to have_activerecord_error(:term, 'Search term must be at least 2 characters') }
+
+        it {
+          is_expected
+            .to have_activemodel_error_message(:term, 'Search term must be at least 2 characters')
+        }
       end
 
       context 'with single char and whitespace as term' do
         let(:term) { "a\s\s\t" }
 
         it { is_expected.to be_invalid }
-        it { is_expected.to have_activerecord_error(:term, 'Search term must be at least 2 characters') }
+
+        it {
+          is_expected
+            .to have_activemodel_error_message(:term, 'Search term must be at least 2 characters')
+        }
       end
 
       context 'with 2 chars as term' do
@@ -207,7 +214,7 @@ RSpec.describe Search, type: :model do
 
         it {
           is_expected
-            .to have_activerecord_error(:term, 'Search term must contain only letters and numbers')
+            .to have_activemodel_error_message(:term, 'Search term must contain only letters and numbers')
         }
       end
 
@@ -215,7 +222,7 @@ RSpec.describe Search, type: :model do
         let(:dob) { nil }
 
         it { is_expected.to be_invalid }
-        it { is_expected.to have_activerecord_error(:dob, 'Defendant date of birth required') }
+        it { is_expected.to have_activemodel_error_message(:dob, 'Defendant date of birth required') }
       end
     end
 
@@ -228,14 +235,14 @@ RSpec.describe Search, type: :model do
         let(:filter) { nil }
 
         it { is_expected.to be_invalid }
-        it { is_expected.to have_activerecord_error(:filter, 'Filter required') }
+        it { is_expected.to have_activemodel_error_message(:filter, 'Filter required') }
       end
 
       context 'with blank term' do
         let(:term) { nil }
 
         it { is_expected.to be_invalid }
-        it { is_expected.to have_activerecord_error(:term, 'Search term required') }
+        it { is_expected.to have_activemodel_error_message(:term, 'Search term required') }
       end
     end
   end

--- a/spec/support/matchers/have_activemodel_error_message.rb
+++ b/spec/support/matchers/have_activemodel_error_message.rb
@@ -2,22 +2,22 @@
 
 require 'rspec/expectations'
 
-# have_activerecord_error
+# have_activemodel_error_message
 # e.g.
-# expect(model_isntance).to have_activerecord_error(:first_name, "First name can\'t be blank")
+# expect(model_instance).to have_activemodel_error_message(:first_name, "First name can\'t be blank")
 #
-RSpec::Matchers.define :have_activerecord_error do |attribute, message|
+RSpec::Matchers.define :have_activemodel_error_message do |attribute, message|
   match do |model_instance|
     model_instance.valid?
     model_instance.errors.messages[attribute.to_sym].include?(message)
   end
 
   description do
-    "have activerecord error with message \"#{message}\""
+    "have activemodel error with message \"#{message}\""
   end
 
   failure_message do |model_instance|
-    "expected activerecord error message: \"#{message}\" on #{attribute}\n" \
+    "expected activemodel error message: \"#{message}\" on #{attribute}\n" \
       "but received: #{model_instance.errors.messages[attribute.to_sym] || 'none'}"
   end
 end

--- a/spec/support/matchers/have_activemodel_error_type.rb
+++ b/spec/support/matchers/have_activemodel_error_type.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rspec/expectations'
+
+# have_activemodel_error_type
+# e.g.
+# expect(model_instance).to have_activemodel_error_type(:first_name, :too_short)
+#
+RSpec::Matchers.define :have_activemodel_error_type do |attribute, error_type|
+  match do |model_instance|
+    model_instance.valid?
+    errors_for(attribute).map(&:type).include?(error_type)
+  end
+
+  def errors_for(attribute)
+    model_instance.errors.select { |err| err.attribute.eql?(attribute) }
+  end
+
+  description do
+    "have activemodel error of type \"#{error_type}\" on #{attribute}"
+  end
+
+  failure_message do
+    "expected activemodel error type: \"#{error_type}\" on #{attribute}\n" \
+      "but received: #{errors_for(attribute).map(&:type) || 'none'}"
+  end
+end

--- a/spec/support/matchers/have_activemodel_error_type.rb
+++ b/spec/support/matchers/have_activemodel_error_type.rb
@@ -9,10 +9,10 @@ require 'rspec/expectations'
 RSpec::Matchers.define :have_activemodel_error_type do |attribute, error_type|
   match do |model_instance|
     model_instance.valid?
-    errors_for(attribute).map(&:type).include?(error_type)
+    errors_for(model_instance, attribute).map(&:type).include?(error_type)
   end
 
-  def errors_for(attribute)
+  def errors_for(model_instance, attribute)
     model_instance.errors.select { |err| err.attribute.eql?(attribute) }
   end
 

--- a/spec/validators/char_length_validator_spec.rb
+++ b/spec/validators/char_length_validator_spec.rb
@@ -1,11 +1,15 @@
 # frozen_string_literal: true
 
 RSpec.describe CharLengthValidator, type: :validator do
-  subject(:model_instance) { foo_model.new(string_field: string_value) }
+  subject(:foo_instance) { foo_model.new(string_field: string_value) }
 
   let(:foo_model) do
     Class.new do
       include ActiveModel::Model
+
+      def self.name
+        'FooModel'
+      end
 
       attr_accessor :string_field
 
@@ -44,5 +48,54 @@ RSpec.describe CharLengthValidator, type: :validator do
 
     it { is_expected.to be_invalid }
     it { is_expected.to have_activemodel_error_type(:string_field, :too_short) }
+  end
+
+  context 'with no message option' do
+    let(:foo_model) do
+      Class.new do
+        include ActiveModel::Model
+
+        def self.name
+          'FooModel'
+        end
+
+        attr_accessor :string_field
+
+        validates :string_field,
+                  char_length: { minimum: 10 }
+      end
+    end
+
+    context 'with invalid value' do
+      let(:string_value) { 'a' }
+
+      it {
+        is_expected
+          .to have_activemodel_error_message(:string_field, 'is too short (minimum is 10 characters)')
+      }
+    end
+  end
+
+  context 'with message option' do
+    let(:foo_model) do
+      Class.new do
+        include ActiveModel::Model
+
+        def self.name
+          'FooModel'
+        end
+
+        attr_accessor :string_field
+
+        validates :string_field,
+                  char_length: { minimum: 3, message: 'that is too short!' }
+      end
+    end
+
+    context 'with invalid value' do
+      let(:string_value) { 'a' }
+
+      it { is_expected.to have_activemodel_error_message(:string_field, 'that is too short!') }
+    end
   end
 end

--- a/spec/validators/char_length_validator_spec.rb
+++ b/spec/validators/char_length_validator_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+RSpec.describe CharLengthValidator, type: :validator do
+  subject(:model_instance) { foo_model.new(string_field: string_value) }
+
+  let(:foo_model) do
+    Class.new do
+      include ActiveModel::Model
+
+      attr_accessor :string_field
+
+      validates :string_field,
+                char_length: { minimum: 3 }
+    end
+  end
+
+  context 'with nil' do
+    let(:string_value) { nil }
+
+    it { is_expected.to be_valid }
+  end
+
+  context 'with exactly the minimum number of chars' do
+    let(:string_value) { 'aaa' }
+
+    it { is_expected.to be_valid }
+  end
+
+  context 'with over the minimum number of chars' do
+    let(:string_value) { 'aaaa' }
+
+    it { is_expected.to be_valid }
+  end
+
+  context 'with less chars than minimum' do
+    let(:string_value) { 'aa' }
+
+    it { is_expected.to be_invalid }
+    it { is_expected.to have_activemodel_error_type(:string_field, :too_short) }
+  end
+
+  context 'with less chars than minimum plus whitespace' do
+    let(:string_value) { "\s\sa\sa\s\s\t" }
+
+    it { is_expected.to be_invalid }
+    it { is_expected.to have_activemodel_error_type(:string_field, :too_short) }
+  end
+end


### PR DESCRIPTION
#### What
Spec the validator that was added as
part of partial name search

#### Why
Was missed/not-added as part of partial name
search implementation

#### How
Add spec and a custom rspec matcher
to help with tests. Also rename the
previous have_activerecord_error custom
matcher to better reflects its use and
purpose and remove a redundant use of
it.