### PR TITLE
AAC-11: Add Veracode Policy Scan into CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -299,8 +299,6 @@ jobs:
             ls *.zip
             echo '-----------end env--------------'
       - sast-orb/policy-scan:
-          vid: ${VERACODE_API_ID}
-          vkey: ${VERACODE_API_KEY}
           appname: ${CIRCLE_PROJECT_REPONAME}
           filepath: ${CIRCLE_PROJECT_REPONAME}.zip
           teams: laa-access-a-claim

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -274,7 +274,7 @@ jobs:
       - checkout
       - run:
           name: Package for upload to Veracode
-          command: zip -r ${CIRCLE_PROJECT_REPONAME}.zip project
+          command: zip -r ${CIRCLE_PROJECT_REPONAME}.zip ./project/
       - sast-orb/policy-scan:
           appname: ${CIRCLE_PROJECT_REPONAME}
           filepath: ${CIRCLE_PROJECT_REPONAME}.zip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -277,13 +277,10 @@ jobs:
           command: zip -r ${CIRCLE_PROJECT_REPONAME}.zip
       - sast-orb/policy-scan:
           appname: ${CIRCLE_PROJECT_REPONAME}
-          createprofile: false
           filepath: ${CIRCLE_PROJECT_REPONAME}.zip
-          teams: Development
+          teams: access-a-claim
           version: CircleCI - ${CIRCLE_SHA1:0:7} - $CIRCLE_BUILD_NUM
-          vid: ${VERACODE_API_ID}
-          vkey: ${VERACODE_API_KEY}
-
+          
 # ------------------
 # WORKFLOWS
 # ------------------

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,12 +138,6 @@ commands:
           name: Run brakeman
           command: bundle exec brakeman
 
-  veracode-prepare:
-    steps:
-      - run:
-          name: Package Veracode
-          command: RAILS_ENV=test bundle exec veracode prepare
-
   rspec:
     steps:
       - db-setup
@@ -274,17 +268,32 @@ jobs:
       - deploy-to:
           environment: production
 
-  veracode-scan:
+  veracode-prepare:
     executor: test-executor
     steps:
       - checkout
       - build-base
-      - veracode-prepare
+      - *attach-tmp-workspace
+      - run:
+          name: Package Veracode
+          command: RAILS_ENV=test bundle exec veracode prepare
+      - persist_to_workspace:
+          root: tmp
+          paths:
+            - veracode-*.zip
+
+  veracode-upload:
+    executor: sast-orb/default
+    steps:
+      - checkout
+      - *attach-tmp-workspace
       - run:
           name: Move Veracode Zip
           command: |
             pwd
             ls -la
+            ls tmp/
+            ls ~/repo/tmp
             mv ~/repo/tmp/veracode-*.zip ${CIRCLE_PROJECT_REPONAME}.zip
       - sast-orb/policy-scan:
           appname: ${CIRCLE_PROJECT_REPONAME}
@@ -352,6 +361,12 @@ workflows:
       - rspec-tests:
           requires:
             - build-test-container
+      - veracode-prepare:
+          requires:
+            - build-test-container
+      - veracode-upload:
+          requires:
+            - veracode-prepare
 
   build-deploy-branch:
     jobs:
@@ -385,6 +400,3 @@ workflows:
       - deploy-uat:
           requires:
             - hold-uat
-      - veracode-scan:
-          requires:
-            - build-app-container

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,9 +142,7 @@ commands:
     steps:
       - run:
           name: Package Veracode
-          command: |
-            cd repo
-            RAILS_ENV=test bundle exec veracode prepare
+          command: RAILS_ENV=test bundle exec veracode prepare
 
   rspec:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -274,7 +274,9 @@ jobs:
       - checkout
       - run:
           name: Package for upload to Veracode
-          command: zip -r ${CIRCLE_PROJECT_REPONAME}.zip ./project/
+          command: |
+            echo ls
+            zip -r ${CIRCLE_PROJECT_REPONAME}.zip . -i project
       - sast-orb/policy-scan:
           appname: ${CIRCLE_PROJECT_REPONAME}
           filepath: ${CIRCLE_PROJECT_REPONAME}.zip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -274,13 +274,11 @@ jobs:
       - checkout
       - run:
           name: Package for upload to Veracode
-          command: |
-            echo ls
-            zip -r ${CIRCLE_PROJECT_REPONAME}.zip . -i project
+          command: zip -r ${CIRCLE_PROJECT_REPONAME}.zip . -i project
       - sast-orb/policy-scan:
           appname: ${CIRCLE_PROJECT_REPONAME}
           filepath: ${CIRCLE_PROJECT_REPONAME}.zip
-          teams: access-a-claim
+          teams: laa-access-a-claim
           version: CircleCI - ${CIRCLE_SHA1:0:7} - $CIRCLE_BUILD_NUM
           
 # ------------------

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,8 +137,8 @@ commands:
       - run:
           name: Run brakeman
           command: bundle exec brakeman
-  
-  veracode:
+
+  veracode-prepare:
     steps:
       - run:
           name: Package Veracode
@@ -275,22 +275,24 @@ jobs:
           environment: production
 
   veracode-scan:
-    executor: sast-orb/default
+    executor: test-executor
     steps:
       - checkout
       - build-base
-      - veracode
+      - veracode-prepare
       - run:
           name: Move Veracode Zip
           command: |
             cd project/tmp
             mv veracode-*.zip ${CIRCLE_PROJECT_REPONAME}.zip
       - sast-orb/policy-scan:
+          vid: ${VERACODE_API_ID}
+          vkey: ${VERACODE_API_KEY}
           appname: ${CIRCLE_PROJECT_REPONAME}
           filepath: ${CIRCLE_PROJECT_REPONAME}.zip
           teams: laa-access-a-claim
           version: CircleCI - ${CIRCLE_SHA1:0:7} - $CIRCLE_BUILD_NUM
-          
+
 # ------------------
 # WORKFLOWS
 # ------------------

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -272,6 +272,7 @@ jobs:
     executor: sast-orb/default
     steps:
       - checkout
+      - build-base
       - run:
           name: Package Veracode
           command: bundle exec veracode prepare

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -275,9 +275,8 @@ jobs:
       - run:
           name: Package for upload to Veracode
           command: | 
-            gem install veracode
-            veracode prepare
-            mv tmp/veracode-${CIRCLE_PROJECT_REPONAME}-*.zip ${CIRCLE_PROJECT_REPONAME}.zip
+            pwd
+            zip -r ${CIRCLE_PROJECT_REPONAME}.zip . -i project
       - sast-orb/policy-scan:
           appname: ${CIRCLE_PROJECT_REPONAME}
           filepath: ${CIRCLE_PROJECT_REPONAME}.zip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -292,10 +292,9 @@ jobs:
           command: |
             pwd
             echo '-----------start move--------------'
-            echo 'ls /tmp'
-            ls -la tmp/
             echo 'ls ~/repo/tmp'
-            mv tmp/veracode-*.zip ${CIRCLE_PROJECT_REPONAME}.zip
+            ls ~/repo/tmp
+            mv ~/repo/tmp/veracode-*.zip ${CIRCLE_PROJECT_REPONAME}.zip
             echo 'ls *.zip'
             ls *.zip
             echo '-----------end env--------------'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -276,7 +276,7 @@ jobs:
           name: Package for upload to Veracode
           command: | 
             pwd
-            zip -r ${CIRCLE_PROJECT_REPONAME}.zip . -i project
+            zip -r ../${CIRCLE_PROJECT_REPONAME}.zip . -i project
       - sast-orb/policy-scan:
           appname: ${CIRCLE_PROJECT_REPONAME}
           filepath: ${CIRCLE_PROJECT_REPONAME}.zip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -329,10 +329,8 @@ workflows:
             - hold-production
       - veracode-scan:
           context: VERACODE
-          filters:
-            branches:
-              only:
-                - main
+          requires:
+            - build-app-container
 
   test-branch:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -275,8 +275,8 @@ jobs:
       - run:
           name: Package for upload to Veracode
           command: | 
-            pwd
-            zip -r ../${CIRCLE_PROJECT_REPONAME}.zip . -i project
+            cd ../
+            zip -r ${CIRCLE_PROJECT_REPONAME}.zip . -i project
       - sast-orb/policy-scan:
           appname: ${CIRCLE_PROJECT_REPONAME}
           filepath: ${CIRCLE_PROJECT_REPONAME}.zip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -273,10 +273,13 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Package for upload to Veracode
-          command: | 
-            cd ../
-            zip -r ${CIRCLE_PROJECT_REPONAME}.zip . -i project
+          name: Package Veracode
+          command: bundle exec veracode prepare
+      - run:
+          name: Move Veracode Zip
+          command: |
+            cd project/tmp
+            mv veracode-*.zip ${CIRCLE_PROJECT_REPONAME}.zip
       - sast-orb/policy-scan:
           appname: ${CIRCLE_PROJECT_REPONAME}
           filepath: ${CIRCLE_PROJECT_REPONAME}.zip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -274,15 +274,15 @@ jobs:
       - checkout
       - run:
           name: Package for upload to Veracode
-          command: 'zip -r ${CIRCLE_PROJECT_REPONAME}.zip'
+          command: zip -r ${CIRCLE_PROJECT_REPONAME}.zip
       - sast-orb/policy-scan:
-          appname: '${CIRCLE_PROJECT_REPONAME}'
+          appname: ${CIRCLE_PROJECT_REPONAME}
           createprofile: false
-          filepath: '${CIRCLE_PROJECT_REPONAME}.zip'
+          filepath: ${CIRCLE_PROJECT_REPONAME}.zip
           teams: Development
-          version: 'CircleCI - ${CIRCLE_SHA1:0:7} - $CIRCLE_BUILD_NUM'
-          vid: '${VERACODE_API_ID}'
-          vkey: '${VERACODE_API_KEY}'
+          version: CircleCI - ${CIRCLE_SHA1:0:7} - $CIRCLE_BUILD_NUM
+          vid: ${VERACODE_API_ID}
+          vkey: ${VERACODE_API_KEY}
 
 # ------------------
 # WORKFLOWS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,7 +142,10 @@ commands:
     steps:
       - run:
           name: Package Veracode
-          command: bundle exec veracode prepare
+          command: |
+            cd repo
+            bundle exec veracode prepare
+
 
   rspec:
     steps:
@@ -283,8 +286,7 @@ jobs:
       - run:
           name: Move Veracode Zip
           command: |
-            cd project/tmp
-            mv veracode-*.zip ${CIRCLE_PROJECT_REPONAME}.zip
+            mv ~/repo/tmp/veracode-*.zip ${CIRCLE_PROJECT_REPONAME}.zip
       - sast-orb/policy-scan:
           appname: ${CIRCLE_PROJECT_REPONAME}
           filepath: ${CIRCLE_PROJECT_REPONAME}.zip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,8 +144,7 @@ commands:
           name: Package Veracode
           command: |
             cd repo
-            bundle exec veracode prepare
-
+            RAILS_ENV=test bundle exec veracode prepare
 
   rspec:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -299,6 +299,8 @@ jobs:
             ls *.zip
             echo '-----------end env--------------'
       - sast-orb/policy-scan:
+          vid: ${VERACODE_API_ID}
+          vkey: ${VERACODE_API_KEY}
           appname: ${CIRCLE_PROJECT_REPONAME}
           filepath: ${CIRCLE_PROJECT_REPONAME}.zip
           teams: laa-access-a-claim

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -292,8 +292,8 @@ jobs:
           command: |
             pwd
             echo '-----------start move--------------'
-            echo 'ls ~/repo/tmp'
-            ls ~/repo/tmp
+            echo 'ls ~/project'
+            ls ~/project
             mv ~/repo/tmp/veracode-*.zip ${CIRCLE_PROJECT_REPONAME}.zip
             echo 'ls *.zip'
             ls *.zip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,7 +137,16 @@ commands:
       - run:
           name: Run brakeman
           command: bundle exec brakeman
-
+  
+  veracode:
+      - run:
+          name: Package Veracode
+          command: bundle exec veracode prepare
+      - run:
+          name: Move Veracode Zip
+          command: |
+            cd project/tmp
+            mv veracode-*.zip ${CIRCLE_PROJECT_REPONAME}.zip
   rspec:
     steps:
       - db-setup
@@ -273,14 +282,7 @@ jobs:
     steps:
       - checkout
       - build-base
-      - run:
-          name: Package Veracode
-          command: bundle exec veracode prepare
-      - run:
-          name: Move Veracode Zip
-          command: |
-            cd project/tmp
-            mv veracode-*.zip ${CIRCLE_PROJECT_REPONAME}.zip
+      - veracode
       - sast-orb/policy-scan:
           appname: ${CIRCLE_PROJECT_REPONAME}
           filepath: ${CIRCLE_PROJECT_REPONAME}.zip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -276,7 +276,7 @@ jobs:
       - *attach-tmp-workspace
       - run:
           name: Package Veracode
-          command: RAILS_ENV=test bundle exec veracode prepare
+          command: RAILS_ENV=test bundle exec veracode prepare --verbose
       - persist_to_workspace:
           root: tmp
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -327,10 +327,6 @@ workflows:
       - deploy-production:
           requires:
             - hold-production
-      - veracode-scan:
-          context: VERACODE
-          requires:
-            - build-app-container
 
   test-branch:
     jobs:
@@ -378,3 +374,7 @@ workflows:
       - deploy-uat:
           requires:
             - hold-uat
+      - veracode-scan:
+          context: VERACODE
+          requires:
+            - build-app-container

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -275,6 +275,8 @@ jobs:
       - run:
           name: Package for upload to Veracode
           command: | 
+            gem install veracode
+            veracode prepare
             mv tmp/veracode-${CIRCLE_PROJECT_REPONAME}-*.zip ${CIRCLE_PROJECT_REPONAME}.zip
       - sast-orb/policy-scan:
           appname: ${CIRCLE_PROJECT_REPONAME}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -283,6 +283,8 @@ jobs:
       - run:
           name: Move Veracode Zip
           command: |
+            pwd
+            ls -la
             mv ~/repo/tmp/veracode-*.zip ${CIRCLE_PROJECT_REPONAME}.zip
       - sast-orb/policy-scan:
           appname: ${CIRCLE_PROJECT_REPONAME}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -275,7 +275,6 @@ jobs:
       - run:
           name: Package for upload to Veracode
           command: | 
-            bundle update veracode
             mv tmp/veracode-${CIRCLE_PROJECT_REPONAME}-*.zip ${CIRCLE_PROJECT_REPONAME}.zip
       - sast-orb/policy-scan:
           appname: ${CIRCLE_PROJECT_REPONAME}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -375,6 +375,5 @@ workflows:
           requires:
             - hold-uat
       - veracode-scan:
-          context: VERACODE
           requires:
             - build-app-container

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -291,10 +291,14 @@ jobs:
           name: Move Veracode Zip
           command: |
             pwd
-            ls -la
-            ls tmp/
-            ls ~/repo/tmp
-            mv ~/repo/tmp/veracode-*.zip ${CIRCLE_PROJECT_REPONAME}.zip
+            echo '-----------start move--------------'
+            echo 'ls /tmp'
+            ls -la tmp/
+            echo 'ls ~/repo/tmp'
+            mv tmp/veracode-*.zip ${CIRCLE_PROJECT_REPONAME}.zip
+            echo 'ls *.zip'
+            ls *.zip
+            echo '-----------end env--------------'
       - sast-orb/policy-scan:
           appname: ${CIRCLE_PROJECT_REPONAME}
           filepath: ${CIRCLE_PROJECT_REPONAME}.zip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   slack: circleci/slack@3.4.2
+  sast-orb: orb-01scan/sast-orb@0.0.8
 
 references:
   _restore-bundle: &restore-bundle
@@ -267,6 +268,22 @@ jobs:
       - deploy-to:
           environment: production
 
+  veracode-scan:
+    executor: sast-orb/default
+    steps:
+      - checkout
+      - run:
+          name: Package for upload to Veracode
+          command: 'zip -r ${CIRCLE_PROJECT_REPONAME}.zip'
+      - sast-orb/policy-scan:
+          appname: '${CIRCLE_PROJECT_REPONAME}'
+          createprofile: false
+          filepath: '${CIRCLE_PROJECT_REPONAME}.zip'
+          teams: Development
+          version: 'CircleCI - ${CIRCLE_SHA1:0:7} - $CIRCLE_BUILD_NUM'
+          vid: '${VERACODE_API_ID}'
+          vkey: '${VERACODE_API_KEY}'
+
 # ------------------
 # WORKFLOWS
 # ------------------
@@ -313,6 +330,12 @@ workflows:
       - deploy-production:
           requires:
             - hold-production
+      - veracode-scan:
+          context: VERACODE
+          filters:
+            branches:
+              only:
+                - main
 
   test-branch:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,11 +142,7 @@ commands:
       - run:
           name: Package Veracode
           command: bundle exec veracode prepare
-      - run:
-          name: Move Veracode Zip
-          command: |
-            cd project/tmp
-            mv veracode-*.zip ${CIRCLE_PROJECT_REPONAME}.zip
+
   rspec:
     steps:
       - db-setup
@@ -283,6 +279,11 @@ jobs:
       - checkout
       - build-base
       - veracode
+      - run:
+          name: Move Veracode Zip
+          command: |
+            cd project/tmp
+            mv veracode-*.zip ${CIRCLE_PROJECT_REPONAME}.zip
       - sast-orb/policy-scan:
           appname: ${CIRCLE_PROJECT_REPONAME}
           filepath: ${CIRCLE_PROJECT_REPONAME}.zip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -286,8 +286,6 @@ jobs:
             cd project/tmp
             mv veracode-*.zip ${CIRCLE_PROJECT_REPONAME}.zip
       - sast-orb/policy-scan:
-          vid: ${VERACODE_API_ID}
-          vkey: ${VERACODE_API_KEY}
           appname: ${CIRCLE_PROJECT_REPONAME}
           filepath: ${CIRCLE_PROJECT_REPONAME}.zip
           teams: laa-access-a-claim

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -274,7 +274,9 @@ jobs:
       - checkout
       - run:
           name: Package for upload to Veracode
-          command: zip -r ${CIRCLE_PROJECT_REPONAME}.zip . -i project
+          command: | 
+            bundle update veracode
+            mv tmp/veracode-${CIRCLE_PROJECT_REPONAME}-*.zip ${CIRCLE_PROJECT_REPONAME}.zip
       - sast-orb/policy-scan:
           appname: ${CIRCLE_PROJECT_REPONAME}
           filepath: ${CIRCLE_PROJECT_REPONAME}.zip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -274,7 +274,7 @@ jobs:
       - checkout
       - run:
           name: Package for upload to Veracode
-          command: zip -r ${CIRCLE_PROJECT_REPONAME}.zip
+          command: zip -r ${CIRCLE_PROJECT_REPONAME}.zip project
       - sast-orb/policy-scan:
           appname: ${CIRCLE_PROJECT_REPONAME}
           filepath: ${CIRCLE_PROJECT_REPONAME}.zip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,6 +139,7 @@ commands:
           command: bundle exec brakeman
   
   veracode:
+    steps:
       - run:
           name: Package Veracode
           command: bundle exec veracode prepare

--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 source 'https://rubygems.org'
-source 'https://gems.veracode.com'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby '2.7.2'
+
+gem 'veracode', :source => 'https://gems.veracode.com'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.7.0', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -76,9 +76,6 @@ group :development do
   gem 'spring-watcher-listen', '~> 2.0.0'
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
   gem 'web-console', '>= 3.3.0'
-  # Veracode packages
-  gem 'veracode'
-  gem 'rubyzip', '2.3.0'
 
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 source 'https://rubygems.org'
+source 'https://gems.veracode.com'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby '2.7.2'
@@ -74,6 +75,10 @@ group :development do
   gem 'spring-watcher-listen', '~> 2.0.0'
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
   gem 'web-console', '>= 3.3.0'
+  # Veracode packages
+  gem 'veracode'
+  gem 'rubyzip', '2.3.0'
+
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile
+++ b/Gemfile
@@ -75,7 +75,6 @@ group :development do
   gem 'spring-watcher-listen', '~> 2.0.0'
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
   gem 'web-console', '>= 3.3.0'
-
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,6 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby '2.7.2'
 
-gem 'veracode', :source => 'https://gems.veracode.com'
-
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.7.0', require: false
 
@@ -30,6 +28,7 @@ gem 'redis', '~> 4.2.5'
 gem 'sentry-rails', '~> 4.3.4'
 gem 'sentry-sidekiq', '~> 4.3.0'
 gem 'sidekiq', '~> 6.2'
+gem 'veracode', '~> 1.1'
 gem 'webpacker', '~> 5.2'
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,5 @@
 GEM
   remote: https://rubygems.org/
-  remote: https://gems.veracode.com/
   specs:
     actioncable (6.1.3.1)
       actionpack (= 6.1.3.1)
@@ -522,7 +521,6 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   rubocop-rspec
-  rubyzip (= 2.3.0)
   sentry-rails (~> 4.3.4)
   sentry-sidekiq (~> 4.3.0)
   shoulda-matchers
@@ -532,7 +530,7 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data
   vcr
-  veracode
+  veracode (~> 1.1)
   web-console (>= 3.3.0)
   webdrivers
   webmock

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,6 @@
 GEM
   remote: https://rubygems.org/
+  remote: https://gems.veracode.com/
   specs:
     actioncable (6.1.3.1)
       actionpack (= 6.1.3.1)
@@ -430,6 +431,8 @@ GEM
       tzinfo (>= 1.0.0)
     unicode-display_width (1.7.0)
     vcr (6.0.0)
+    veracode (1.1.0)
+      rubyzip (>= 1.3)
     virtus (1.0.5)
       axiom-types (~> 0.1)
       coercible (~> 1.0)
@@ -519,6 +522,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   rubocop-rspec
+  rubyzip (= 2.3.0)
   sentry-rails (~> 4.3.4)
   sentry-sidekiq (~> 4.3.0)
   shoulda-matchers
@@ -528,6 +532,7 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data
   vcr
+  veracode
   web-console (>= 3.3.0)
   webdrivers
   webmock


### PR DESCRIPTION
#### What

Adding Veracode policy scans into the circleci config file. Policy scans do not block builds. A zipped version of the app is uploaded to Veracode for static scanning, and any security alerts are then emailed to listed parties for later prioritisation.

This is a proof of concept for the security team. We plan to run this for a month and then to assess the use of the tool.

#### Ticket

[AAC-11: Implement Veracode Scans PoC in CircleCI](https://dsdmoj.atlassian.net/browse/AAC-11)

#### Why

The security team want a single static analysis tool used across MoJ to give them better visibility of the health of the whole estate and to help inform teams of high risk areas.

#### How

Changes made to the configuration files based on the following documents and examples:

- [The Veracode Orb documentation](https://circleci.com/developer/orbs/orb/orb-01scan/sast-orb)
- [The Veracode Orb on GitHub](https://github.com/e10quent/sast-orb/tree/main/.circleci)
- [Example implementation for a Node project](https://github.com/buzzcode/NodeGoat/blob/master/.circleci/config.yml)
- [HMPPS implementation for a Java project](https://github.com/buzzcode/NodeGoat/blob/master/.circleci/config.yml)

