### PR TITLE
[AAC-62] Display event hearing notes

### DIFF
--- a/app/views/hearings/_hearing_events.html.haml
+++ b/app/views/hearings/_hearing_events.html.haml
@@ -12,3 +12,5 @@
           = event.occurred_at.to_datetime.strftime('%H:%M')
         %td.govuk-table__cell
           = event.description
+          %br
+          = event&.note

--- a/app/views/hearings/_hearing_events.html.haml
+++ b/app/views/hearings/_hearing_events.html.haml
@@ -12,5 +12,6 @@
           = event.occurred_at.to_datetime.strftime('%H:%M')
         %td.govuk-table__cell
           = event.description
-          %br
-          = event&.note
+          - if event&.note.present?
+            %div{ class: 'govuk-!-padding-top-1' }
+              = event&.note

--- a/lib/court_data_adaptor/resource/hearing_event.rb
+++ b/lib/court_data_adaptor/resource/hearing_event.rb
@@ -9,6 +9,7 @@ module CourtDataAdaptor
 
       property :description, type: :string
       property :occurred_at, type: :time
+      property :note, type: :string
     end
   end
 end

--- a/spec/lib/court_data_adaptor/resource/hearing_event_spec.rb
+++ b/spec/lib/court_data_adaptor/resource/hearing_event_spec.rb
@@ -19,5 +19,6 @@ RSpec.describe CourtDataAdaptor::Resource::HearingEvent do
 
     it { is_expected.to respond_to :description }
     it { is_expected.to respond_to :occurred_at }
+    it { is_expected.to respond_to :note }
   end
 end

--- a/spec/views/hearings/_hearing_events.html.haml_spec.rb
+++ b/spec/views/hearings/_hearing_events.html.haml_spec.rb
@@ -10,15 +10,18 @@ RSpec.describe 'hearings/_hearing_events.html.haml', type: :view do
   let(:hearing_day) { Date.parse('2021-01-17T10:30:00.000Z') }
 
   let(:hearing_event1) do
-    hearing_event_class.new(description: 'day 1 start', occurred_at: '2021-01-17T10:30:00.000Z')
+    hearing_event_class.new(description: 'day 1 start', note: '1 hour delay',
+                            occurred_at: '2021-01-17T10:30:00.000Z')
   end
 
   let(:hearing_event2) do
-    hearing_event_class.new(description: 'day 1 end', occurred_at: '2021-01-17T16:30:00.000Z')
+    hearing_event_class.new(description: 'day 1 end', note: 'ended late',
+                            occurred_at: '2021-01-17T16:30:00.000Z')
   end
 
   let(:hearing_event3) do
-    hearing_event_class.new(description: 'day 2 start', occurred_at: '2021-01-18T10:45:00.000Z')
+    hearing_event_class.new(description: 'day 2 start', note: '2 hour delay',
+                            occurred_at: '2021-01-18T10:45:00.000Z')
   end
 
   let(:hearing_event_class) { CourtDataAdaptor::Resource::HearingEvent }
@@ -56,6 +59,50 @@ RSpec.describe 'hearings/_hearing_events.html.haml', type: :view do
       is_expected
         .to have_selector('tbody.govuk-table__body tr:nth-child(1)', text: '10:30')
         .and have_selector('tbody.govuk-table__body tr:nth-child(2)', text: '16:30')
+    end
+
+    context 'with hearing_events notes' do
+      it 'displays the notes' do
+        is_expected
+          .to have_content('1 hour delay')
+          .and have_content('ended late')
+      end
+
+      context 'with notes containing HTML' do
+        let(:hearing_event_with_html_notes) do
+          hearing_event_class.new(description: 'day 1 start', note: '<b>1 hour delay</b>',
+                                  occurred_at: '2021-01-17T10:30:00.000Z')
+        end
+        let(:hearing_events) { [hearing_event_with_html_notes] }
+
+        it 'displays any HTML raw' do
+          is_expected.to have_content('<b>1 hour delay</b>')
+        end
+      end
+
+      context 'with notes containing unicode characters' do
+        let(:hearing_event_with_unicode_notes) do
+          hearing_event_class.new(description: 'day 1 start', note: '!\"#£%&()*,-./',
+                                  occurred_at: '2021-01-17T10:30:00.000Z')
+        end
+        let(:hearing_events) { [hearing_event_with_unicode_notes] }
+
+        it 'renders unicode characters correctly' do
+          is_expected.to have_content('!\"#£%&()*,-./')
+        end
+      end
+    end
+
+    context 'with no hearing_events notes' do
+      let(:hearing_event_with_empty_notes) do
+        hearing_event_class.new(description: '1 hour delay', note: nil,
+                                occurred_at: '2021-01-17T10:30:00.000Z')
+      end
+      let(:hearing_events) { [hearing_event_with_empty_notes] }
+
+      it 'displays only the description' do
+        is_expected.to have_content('1 hour delay')
+      end
     end
   end
 end

--- a/spec/views/hearings/_hearing_events.html.haml_spec.rb
+++ b/spec/views/hearings/_hearing_events.html.haml_spec.rb
@@ -82,13 +82,13 @@ RSpec.describe 'hearings/_hearing_events.html.haml', type: :view do
 
       context 'with notes containing unicode characters' do
         let(:hearing_event_with_unicode_notes) do
-          hearing_event_class.new(description: 'day 1 start', note: '!\"#£%&()*,-./',
+          hearing_event_class.new(description: 'day 1 start', note: '!\"#£%&()*,-./Æ½ŵ€',
                                   occurred_at: '2021-01-17T10:30:00.000Z')
         end
         let(:hearing_events) { [hearing_event_with_unicode_notes] }
 
         it 'renders unicode characters correctly' do
-          is_expected.to have_content('!\"#£%&()*,-./')
+          is_expected.to have_content('!\"#£%&()*,-./Æ½ŵ€')
         end
       end
     end


### PR DESCRIPTION
#### What
Change View Court Data so that it can accept the free text field (notes) associated with various events sent from CP. Add small bump of space to indicate change between “hearing event” and “note”

#### Ticket
[Implement free text in VCD](https://dsdmoj.atlassian.net/browse/AAC-62)

#### Why
Court Clerks want to add free text so that they can send extra details related to hearing events. HMCTS has provided a new set of schemas that are intended to support the addition of free text to the hearing event log API. CDA has been modified to accommodate this new information & transmit this data from CPP to VCD.

New Information in relation to hearings will be added as a free text & this information is required for LAA billing caseworkers to evaluate bills effectively. 

#### How
- Display the notes field for each hearing event sent from Common Platform via CDA
- Ensure any UNICODE characters are supported
- Ensure free text does not create security vulnerabilities
- Ensure any HTML is escaped

