### PR TITLE
Add fix for where hearing_events is not present in response

### DIFF
--- a/app/views/prosecution_cases/_raw_response.html.haml
+++ b/app/views/prosecution_cases/_raw_response.html.haml
@@ -25,14 +25,14 @@
       = JSON.pretty_generate(hearing.attributes)
 
     %h4="Hearing events for hearing #{hidx}"
-    = 'none' if hearing.hearing_events.empty?
-    - hearing.hearing_events.each.with_index do |event, eidx|
+    = 'none' if hearing.hearing_events.blank?
+    - Array(hearing.hearing_events).each.with_index do |event, eidx|
       %pre
         = JSON.pretty_generate(event.attributes)
 
     %h4="Providers for hearing #{hidx}"
-    = 'none' if hearing.providers.empty?
-    - hearing.providers.each.with_index do |event, pidx|
+    = 'none' if hearing.providers.blank?
+    - Array(hearing.providers).each.with_index do |event, pidx|
       %pre
         = JSON.pretty_generate(event.attributes)
 


### PR DESCRIPTION
#### What
When viewing a prosecution case where the hearing_events is not present, an error is encountered in the raw json response of the request.

#### Why
Error is encountered where hearing_events is not present, preventing the page from loading.

#### How
Adding checks for where hearing_events is blank in the json before trying to render it.
