### PR TITLE
Add fix for hearings view where hearing_events is not present in response 

### DIFF
--- a/app/views/hearings/_hearing_events.html.haml
+++ b/app/views/hearings/_hearing_events.html.haml
@@ -6,9 +6,10 @@
       %th.govuk-table__header{ scope: 'col' }= t('hearings.show.events.time')
       %th.govuk-table__header{ scope: 'col' }= t('hearings.show.events.event')
   %tbody.govuk-table__body
-    - hearing.hearing_events_for_day(hearing_day).each do |event|
-      %tr.govuk-table__row
-        %td.govuk-table__cell
-          = event.occurred_at.to_datetime.strftime('%H:%M')
-        %td.govuk-table__cell
-          = event.description
+    - if hearing.hearing_events.present?
+      - hearing.hearing_events_for_day(hearing_day).each do |event|
+        %tr.govuk-table__row
+          %td.govuk-table__cell
+            = event.occurred_at.to_datetime.strftime('%H:%M')
+          %td.govuk-table__cell
+            = event.description

--- a/app/views/hearings/_hearing_events.html.haml
+++ b/app/views/hearings/_hearing_events.html.haml
@@ -6,10 +6,9 @@
       %th.govuk-table__header{ scope: 'col' }= t('hearings.show.events.time')
       %th.govuk-table__header{ scope: 'col' }= t('hearings.show.events.event')
   %tbody.govuk-table__body
-    - if hearing.hearing_events.present?
-      - hearing.hearing_events_for_day(hearing_day).each do |event|
-        %tr.govuk-table__row
-          %td.govuk-table__cell
-            = event.occurred_at.to_datetime.strftime('%H:%M')
-          %td.govuk-table__cell
-            = event.description
+    - hearing.hearing_events_for_day(hearing_day).each do |event|
+      %tr.govuk-table__row
+        %td.govuk-table__cell
+          = event.occurred_at.to_datetime.strftime('%H:%M')
+        %td.govuk-table__cell
+          = event.description

--- a/app/views/hearings/show.html.haml
+++ b/app/views/hearings/show.html.haml
@@ -6,7 +6,8 @@
 
 = render partial: 'attendees', locals: { hearing: @hearing }
 
-= render partial: 'hearing_events', locals: { hearing: @hearing, hearing_day: @hearing_day }
+- if @hearing.hearing_events
+  = render partial: 'hearing_events', locals: { hearing: @hearing, hearing_day: @hearing_day }
 
 - if Rails.configuration.x.display_raw_responses
   = render partial: 'raw_response', locals: { hearing: @hearing }


### PR DESCRIPTION
#### What
An error is thrown when viewing a hearing where the hearing_events is not present. Part 2 to [this PR](https://github.com/ministryofjustice/laa-court-data-ui/pull/573), which fixes the case view.

#### Why
Error is encountered where hearing_events is not present, preventing the page from loading.

#### How
Adding check for if hearing_events is present before trying to render it.