### PR TITLE
[AAC-54] events free text

### DIFF
--- a/app/helpers/hearing_helper.rb
+++ b/app/helpers/hearing_helper.rb
@@ -8,4 +8,15 @@ module HearingHelper
   def earliest_day_for(hearing)
     hearing&.hearing_days&.map(&:to_datetime)&.sort&.first
   end
+
+  def display_crlf_and_sanitize(event_note)
+    note_with_converted_crlf = convert_crlf_to_html(event_note)
+    sanitize(note_with_converted_crlf, tags: %w[br p])
+  end
+
+  private
+
+  def convert_crlf_to_html(event_note)
+    simple_format(event_note, {}, wrapper_tag: 'span')
+  end
 end

--- a/app/helpers/hearing_helper.rb
+++ b/app/helpers/hearing_helper.rb
@@ -9,7 +9,7 @@ module HearingHelper
     hearing&.hearing_days&.map(&:to_datetime)&.sort&.first
   end
 
-  def display_crlf_and_sanitize(event_note)
+  def transform_and_sanitize(event_note)
     note_with_converted_crlf = convert_crlf_to_html(event_note)
     sanitize(note_with_converted_crlf, tags: %w[br p])
   end

--- a/app/views/hearings/_hearing_events.html.haml
+++ b/app/views/hearings/_hearing_events.html.haml
@@ -14,4 +14,4 @@
           = event.description
           - if event&.note.present?
             %div{ class: 'govuk-!-padding-top-1' }
-              = display_crlf_and_sanitize(event.note)
+              = transform_and_sanitize(event.note)

--- a/app/views/hearings/_hearing_events.html.haml
+++ b/app/views/hearings/_hearing_events.html.haml
@@ -12,3 +12,6 @@
           = event.occurred_at.to_datetime.strftime('%H:%M')
         %td.govuk-table__cell.hearing-events-table__cell--overflow-wrap
           = event.description
+          - if event&.note.present?
+            %div{ class: 'govuk-!-padding-top-1' }
+              = display_crlf_and_sanitize(event.note)

--- a/app/views/hearings/_hearing_events.html.haml
+++ b/app/views/hearings/_hearing_events.html.haml
@@ -10,5 +10,5 @@
       %tr.govuk-table__row
         %td.govuk-table__cell
           = event.occurred_at.to_datetime.strftime('%H:%M')
-        %td.govuk-table__cell
+        %td.govuk-table__cell.hearing-events-table__cell--overflow-wrap
           = event.description

--- a/app/webpack/stylesheets/application.scss
+++ b/app/webpack/stylesheets/application.scss
@@ -14,5 +14,6 @@ $govuk-image-url-function: frontend-image-url;
 
 @import "components/cookie_banner";
 @import "components/forms";
+@import "components/hearing_events";
 @import "components/sortable_table";
 @import "components/summary";

--- a/app/webpack/stylesheets/components/_hearing_events.scss
+++ b/app/webpack/stylesheets/components/_hearing_events.scss
@@ -1,0 +1,7 @@
+
+td.hearing-events-table__cell--overflow-wrap {
+    overflow-wrap: anywhere;
+		overflow-y: hidden;
+    ms-word-wrap: break-word;
+    max-width: 600px; /*For IE*/
+}

--- a/app/webpack/stylesheets/components/_hearing_events.scss
+++ b/app/webpack/stylesheets/components/_hearing_events.scss
@@ -1,8 +1,6 @@
-td {
-  .hearing-events-table__cell--overflow-wrap {
-    max-width: 600px; /* For IE */
-    overflow-y: hidden;
-    overflow-wrap: anywhere;
-    -ms-word-wrap: break-word;
-  }
+.hearing-events-table__cell--overflow-wrap {
+  max-width: 600px; /* For IE */
+  overflow-y: hidden;
+  overflow-wrap: anywhere;
+  -ms-word-wrap: break-word;
 }

--- a/app/webpack/stylesheets/components/_hearing_events.scss
+++ b/app/webpack/stylesheets/components/_hearing_events.scss
@@ -1,7 +1,8 @@
-
-td.hearing-events-table__cell--overflow-wrap {
+td {
+  .hearing-events-table__cell--overflow-wrap {
+    max-width: 600px; /* For IE */
+    overflow-y: hidden;
     overflow-wrap: anywhere;
-		overflow-y: hidden;
-    ms-word-wrap: break-word;
-    max-width: 600px; /*For IE*/
+    -ms-word-wrap: break-word;
+  }
 }

--- a/lib/court_data_adaptor/resource/hearing_event.rb
+++ b/lib/court_data_adaptor/resource/hearing_event.rb
@@ -9,6 +9,7 @@ module CourtDataAdaptor
 
       property :description, type: :string
       property :occurred_at, type: :time
+      property :note, type: :string
     end
   end
 end

--- a/spec/helpers/hearing_helper_spec.rb
+++ b/spec/helpers/hearing_helper_spec.rb
@@ -35,8 +35,8 @@ RSpec.describe HearingHelper, type: :helper do
     it { is_expected.to eql('2021-01-19T10:45:15.000Z'.to_datetime) }
   end
 
-  describe '#display_crlf_and_sanitize' do
-    subject { helper.display_crlf_and_sanitize(event_note) }
+  describe '#transform_and_sanitize' do
+    subject { helper.transform_and_sanitize(event_note) }
 
     context 'with notes containing unsafe and unpermitted html' do
       let(:event_note) { '<b>warning</b> <script>alert(123)</script>' }

--- a/spec/helpers/hearing_helper_spec.rb
+++ b/spec/helpers/hearing_helper_spec.rb
@@ -34,4 +34,26 @@ RSpec.describe HearingHelper, type: :helper do
 
     it { is_expected.to eql('2021-01-19T10:45:15.000Z'.to_datetime) }
   end
+
+  describe '#format_and_dislay_crlf' do
+    subject { helper.display_crlf_and_sanitize(event_note) }
+
+    context 'with notes containing unsafe and unpermitted html' do
+      let(:event_note) { '<b>warning</b> <script>alert(123)</script>' }
+
+      it { is_expected.to eq('warning alert(123)') }
+    end
+
+    context 'with notes containing crlf escape sequences' do
+      let(:event_note) { "early start\nlate finish\r\ncase adjourned\rresume next week" }
+
+      it { is_expected.to eq("early start\n<br>late finish\n<br>case adjourned\n<br>resume next week") }
+    end
+
+    context 'with plain text' do
+      let(:event_note) { 'hearing begins' }
+
+      it { is_expected.to eq('hearing begins') }
+    end
+  end
 end

--- a/spec/helpers/hearing_helper_spec.rb
+++ b/spec/helpers/hearing_helper_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe HearingHelper, type: :helper do
     it { is_expected.to eql('2021-01-19T10:45:15.000Z'.to_datetime) }
   end
 
-  describe '#format_and_dislay_crlf' do
+  describe '#display_crlf_and_sanitize' do
     subject { helper.display_crlf_and_sanitize(event_note) }
 
     context 'with notes containing unsafe and unpermitted html' do

--- a/spec/lib/court_data_adaptor/resource/hearing_event_spec.rb
+++ b/spec/lib/court_data_adaptor/resource/hearing_event_spec.rb
@@ -19,5 +19,6 @@ RSpec.describe CourtDataAdaptor::Resource::HearingEvent do
 
     it { is_expected.to respond_to :description }
     it { is_expected.to respond_to :occurred_at }
+    it { is_expected.to respond_to :note }
   end
 end

--- a/spec/views/hearings/_hearing_events.html.haml_spec.rb
+++ b/spec/views/hearings/_hearing_events.html.haml_spec.rb
@@ -10,15 +10,18 @@ RSpec.describe 'hearings/_hearing_events.html.haml', type: :view do
   let(:hearing_day) { Date.parse('2021-01-17T10:30:00.000Z') }
 
   let(:hearing_event1) do
-    hearing_event_class.new(description: 'day 1 start', occurred_at: '2021-01-17T10:30:00.000Z')
+    hearing_event_class.new(description: 'day 1 start', note: '1 hour delay',
+                            occurred_at: '2021-01-17T10:30:00.000Z')
   end
 
   let(:hearing_event2) do
-    hearing_event_class.new(description: 'day 1 end', occurred_at: '2021-01-17T16:30:00.000Z')
+    hearing_event_class.new(description: 'day 1 end', note: 'ended late',
+                            occurred_at: '2021-01-17T16:30:00.000Z')
   end
 
   let(:hearing_event3) do
-    hearing_event_class.new(description: 'day 2 start', occurred_at: '2021-01-18T10:45:00.000Z')
+    hearing_event_class.new(description: 'day 2 start', note: '2 hour delay',
+                            occurred_at: '2021-01-18T10:45:00.000Z')
   end
 
   let(:hearing_event_class) { CourtDataAdaptor::Resource::HearingEvent }

--- a/spec/views/hearings/_hearing_events.html.haml_spec.rb
+++ b/spec/views/hearings/_hearing_events.html.haml_spec.rb
@@ -57,5 +57,37 @@ RSpec.describe 'hearings/_hearing_events.html.haml', type: :view do
         .to have_selector('tbody.govuk-table__body tr:nth-child(1)', text: '10:30')
         .and have_selector('tbody.govuk-table__body tr:nth-child(2)', text: '16:30')
     end
+
+    context 'with hearing_events notes' do
+      it 'displays the notes' do
+        is_expected
+          .to have_content('1 hour delay')
+          .and have_content('ended late')
+      end
+
+      context 'with notes containing unicode characters' do
+        let(:hearing_event_with_unicode_notes) do
+          hearing_event_class.new(description: 'day 1 start', note: '!\"#£%&()*,-./Æ½ŵ€',
+                                  occurred_at: '2021-01-17T10:30:00.000Z')
+        end
+        let(:hearing_events) { [hearing_event_with_unicode_notes] }
+
+        it 'renders unicode characters correctly' do
+          is_expected.to have_content('!\"#£%&()*,-./Æ½ŵ€')
+        end
+      end
+    end
+
+    context 'with no hearing_events notes' do
+      let(:hearing_event_with_empty_notes) do
+        hearing_event_class.new(description: '1 hour delay', note: nil,
+                                occurred_at: '2021-01-17T10:30:00.000Z')
+      end
+      let(:hearing_events) { [hearing_event_with_empty_notes] }
+
+      it 'displays only the description' do
+        is_expected.to have_content('1 hour delay')
+      end
+    end
   end
 end


### PR DESCRIPTION
#### What
Change View Court Data so that it can display free text field (hearing event notes) associated with various hearing events sent from CP. Hearing event notes will be max 3000 characters. Add small bump of space to indicate change between “hearing event description” and “note”.

A [PR was previously opened](https://github.com/ministryofjustice/laa-court-data-ui/pull/570#issue-643325845) with comments. Two additional commits were made in this PR with changes to:
- Ensure carriage return and new line characters `\n` `\r` are displayed as new line, etc.
- Limit width of table column width to enforce a line break in case of long unbreakable string inputs

#### Ticket
[Implement free text in VCD](https://dsdmoj.atlassian.net/browse/AAC-62)

#### Why
Court Clerks want to add free text so that they can send extra details related to hearing events. HMCTS has provided a new set of schemas that are intended to support the addition of free text to the hearing event log API. CDA has been modified to accommodate this new information & transmit this data from CPP to VCD.

New Information in relation to hearings will be added as a free text & this information is required for LAA billing caseworkers to evaluate bills effectively. 

#### How
- Display the notes field for each hearing event sent from Common Platform via CDA
- Ensure any UNICODE characters are supported
- Sanitize against any unsafe inputs
- Ensure any HTML is escaped
- Ensure carriage return and new line characters (\n \r) are displayed as new line, etc.
- Limit width of table column width to enforce a line break in case of long unbreakable string inputs
