### PR TITLE
Test hearing_events template is not rendered if hearing_events is missing

### DIFF
--- a/spec/views/hearings/show.html.haml_spec.rb
+++ b/spec/views/hearings/show.html.haml_spec.rb
@@ -35,4 +35,10 @@ RSpec.describe 'hearings/show.html.haml', type: :view do
   it { is_expected.to render_template(:_listing_info) }
   it { is_expected.to render_template(:_attendees) }
   it { is_expected.to render_template(:_hearing_events) }
+
+  context 'when hearing_events is missing' do
+    let(:hearing) { CourtDataAdaptor::Resource::Hearing.new }
+
+    it { is_expected.not_to render_template(:_hearing_events) }
+  end
 end


### PR DESCRIPTION
#### What
Prosecution case page ([raw_response section](https://github.com/ministryofjustice/laa-court-data-ui/pull/573)) and hearings page ([hearing_events](https://github.com/ministryofjustice/laa-court-data-ui/pull/574/files)) were not displaying in VCD on UAT, causing the case page to return an error page when the user tries to view a case. A fix was put in to check that hearing_events is present before trying to render but it was missing tests.  

#### Ticket

[Add test for hearing events fix](https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=622&projectKey=AAC&selectedIssue=AAC-83)

#### Why
The fix was made urgently and so it is missing a unit test. 

#### How
Test that if hearing_events is not present, the relevant partial will not be rendered. 

