### PR TITLE
Update local CDA setup documentation

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -21,7 +21,8 @@ cd .../hmcts-common-platform-mock-api
 - create dummy data
 ```
 # create some data
-$ rails console
+rails mock:demodata:load
+rails console
 Pry> FactoryBot.create(:realistic_prosecution_case, defendants: FactoryBot.create_list(:realistic_defendant, 3))
 ```
 
@@ -40,7 +41,20 @@ git clone git@github.com:ministryofjustice/laa-court-data-adaptor.git
 cd .../laa-court-data-adaptor
 ```
 
-- generate OAuth2 `client_credentials` - for the UI
+- configure local adaptor to use local mock common platform API, set database URL and, optionally, inline sidekiq jobs
+```
+# in .env.development.local
+COMMON_PLATFORM_URL=http://localhost:9293
+DATABASE_URL=postgres://localhost/laa_court_data_adaptor_development
+INLINE_SIDEKIQ=true
+```
+
+- setup CDA database
+```
+rails db:create db:migrate db:seed
+```
+
+- generate OAuth2 `client_credentials` - for the UI (see end of section for postgres error)
 ```
 rails console
 > application = Doorkeeper::Application.create(name: 'LAA Court data UI')
@@ -48,13 +62,6 @@ rails console
 => [6FYXUiqrR3Yuid2ispemVNPUT7-8W0LB1sSmB6c0f3k-example, K122aTsBeRj1GuP7u-Fdi3Vm6uSKaD8K2vq0pPRocIo-example]
 
 # These should be put in the UI's `.env.development.local` - see UI setup below
-```
-
-- configure local adaptor to use local mock common platform API and, optionally, inline sidekiq jobs
-```
-# in .env.development.local
-COMMON_PLATFORM_URL=http://localhost:9293
-INLINE_SIDEKIQ=true
 ```
 
 - start server

--- a/docs/development.md
+++ b/docs/development.md
@@ -51,10 +51,13 @@ INLINE_SIDEKIQ=true
 
 - setup CDA database
 ```
-rails db:create db:migrate db:seed
+# setup and seed database
+rails db:setup
 ```
+or
+`rails db:create db:migrate db:seed`
 
-- generate OAuth2 `client_credentials` - for the UI (see end of section for postgres error)
+- generate OAuth2 `client_credentials` - for the UI
 ```
 rails console
 > application = Doorkeeper::Application.create(name: 'LAA Court data UI')

--- a/docs/development.md
+++ b/docs/development.md
@@ -22,8 +22,6 @@ cd .../hmcts-common-platform-mock-api
 ```
 # create some data
 rails mock:demodata:load
-rails console
-Pry> FactoryBot.create(:realistic_prosecution_case, defendants: FactoryBot.create_list(:realistic_defendant, 3))
 ```
 
 - start server on port 9293


### PR DESCRIPTION
#### What
Update local CDA setup documentation

#### Ticket

[board ticket description](https://dsdmoj.atlassian.net/browse/AAC-91)

#### Why
Some Postgres setup errors were encountered when setting up CDA locally according to the README.

#### How
To avoid possible Postgres errors encountered when trying to run `rails console` to generate OAuth2 credentials, the readme now sets the CDA database URL and creates the database first which will hopefully prevent this for others.

