### PR TITLE
Modify alpha/beta banner to display environment for non-prod envs

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -35,6 +35,10 @@ module ApplicationHelper
     link_to(title, prosecution_case_path(id: prosecution_case.prosecution_case_reference, column: column, direction: direction, anchor: column), class: 'govuk-link govuk-link--no-visited-state', id: column, 'aria-label': "Sort #{column} #{direction}")
   end
 
+  def app_environment
+    "app-environment-#{ENV['ENV'] || 'local'}"
+  end
+
   private
 
   def decorator_instance(object, decorator_class = nil)

--- a/app/views/layouts/_phase_banner.html.haml
+++ b/app/views/layouts/_phase_banner.html.haml
@@ -1,10 +1,10 @@
 .govuk-phase-banner{ class: ENV['ENV'] }
   %p.govuk-phase-banner__content
     %strong.govuk-tag.govuk-phase-banner__content__tag
-      - if %w(uat staging dev).include? ENV['ENV']
-        = ENV['ENV']
-      - else
+      - if ENV['ENV'] == 'production'
         = t('generic.alpha')
+      - else
+        = ENV['ENV'] || 'local'
     %span.govuk-phase-banner__text
       = t('layouts.application.header.phase_banner_html', feedback: new_feedback_path)
 

--- a/app/views/layouts/_phase_banner.html.haml
+++ b/app/views/layouts/_phase_banner.html.haml
@@ -1,7 +1,10 @@
 .govuk-phase-banner
   %p.govuk-phase-banner__content
     %strong.govuk-tag.govuk-phase-banner__content__tag
-      = t('generic.alpha')
+      - if ENV['ENV'] == 'production'
+        = t('generic.alpha')
+      - else
+        = ENV['ENV'] || ENV['RAILS_ENV']
     %span.govuk-phase-banner__text
       = t('layouts.application.header.phase_banner_html', feedback: new_feedback_path)
 

--- a/app/views/layouts/_phase_banner.html.haml
+++ b/app/views/layouts/_phase_banner.html.haml
@@ -1,10 +1,10 @@
-.govuk-phase-banner
+.govuk-phase-banner{ class: ENV['ENV'] }
   %p.govuk-phase-banner__content
     %strong.govuk-tag.govuk-phase-banner__content__tag
-      - if ENV['ENV'] == 'production'
-        = t('generic.alpha')
+      - if %w(uat staging dev).include? ENV['ENV']
+        = ENV['ENV']
       - else
-        = ENV['ENV'] || ENV['RAILS_ENV']
+        = t('generic.alpha')
     %span.govuk-phase-banner__text
       = t('layouts.application.header.phase_banner_html', feedback: new_feedback_path)
 

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -28,7 +28,7 @@
 
     = render partial: 'layouts/cookie_banner'
 
-    %header.govuk-header{"data-module" => "govuk-header", role: "banner"}
+    %header.govuk-header{"data-module" => "govuk-header", role: "banner", class: ENV['ENV'] }
       .govuk-header__container.govuk-width-container
         .govuk-header__logo
           = render 'layouts/govuk_logo'

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -20,7 +20,7 @@
     %link{href: asset_pack_path("media/images/govuk-apple-touch-icon.png"), rel: "apple-touch-icon"}/
     = tag :meta, property: 'og:image', content: asset_pack_path('media/images/govuk-opengraph-image.png')
     = render partial: 'layouts/google_analytics'
-  %body.govuk-template__body
+  %body.govuk-template__body{ class: app_environment }
     :javascript
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
     %a.govuk-skip-link{href: "#main-content"}
@@ -28,7 +28,7 @@
 
     = render partial: 'layouts/cookie_banner'
 
-    %header.govuk-header{"data-module" => "govuk-header", role: "banner", class: ENV['ENV'] }
+    %header.govuk-header{"data-module" => "govuk-header", role: "banner" }
       .govuk-header__container.govuk-width-container
         .govuk-header__logo
           = render 'layouts/govuk_logo'

--- a/app/webpack/stylesheets/application.scss
+++ b/app/webpack/stylesheets/application.scss
@@ -18,3 +18,4 @@ $govuk-image-url-function: frontend-image-url;
 @import "components/hearing_events";
 @import "components/sortable_table";
 @import "components/summary";
+@import "components/phase_banner";

--- a/app/webpack/stylesheets/components/_phase_banner.scss
+++ b/app/webpack/stylesheets/components/_phase_banner.scss
@@ -1,8 +1,9 @@
 $app-uat-colour: govuk-colour('orange');
 $app-staging-colour: govuk-colour('turquoise');
 $app-dev-colour: govuk-colour('pink');
+$app-local-colour: govuk-colour('bright-purple');
 
-.uat {
+.app-environment-uat {
   .govuk-header__container {
     border-bottom-color: $app-uat-colour;
   }
@@ -12,7 +13,7 @@ $app-dev-colour: govuk-colour('pink');
   }
 }
 
-.staging {
+.app-environment-staging {
   .govuk-header__container {
     border-bottom-color: $app-staging-colour;
   }
@@ -22,12 +23,22 @@ $app-dev-colour: govuk-colour('pink');
   }
 }
 
-.dev {
+.app-environment-dev {
   .govuk-header__container {
     border-bottom-color: $app-dev-colour;
   }
 
   .govuk-tag.govuk-phase-banner__content__tag {
     background-color: $app-dev-colour;
+  }
+}
+
+.app-environment-local {
+  .govuk-header__container {
+    border-bottom-color: $app-local-colour;
+  }
+
+  .govuk-tag.govuk-phase-banner__content__tag {
+    background-color: $app-local-colour;
   }
 }

--- a/app/webpack/stylesheets/components/_phase_banner.scss
+++ b/app/webpack/stylesheets/components/_phase_banner.scss
@@ -1,0 +1,33 @@
+$laa-uat-colour: govuk-colour("orange");
+$laa-staging-colour: govuk-colour("turquoise");
+$laa-dev-colour: govuk-colour("pink");
+
+.uat {
+  .govuk-header__container {
+    border-bottom-color: $laa-uat-colour;
+  }
+
+  .govuk-tag.govuk-phase-banner__content__tag {
+    background-color: $laa-uat-colour;
+  }
+}
+
+.staging {
+  .govuk-header__container {
+    border-bottom-color: $laa-staging-colour;
+  }
+
+  .govuk-tag.govuk-phase-banner__content__tag {
+    background-color: $laa-staging-colour;
+  }
+}
+
+.dev {
+  .govuk-header__container {
+    border-bottom-color: $laa-dev-colour;
+  }
+
+  .govuk-tag.govuk-phase-banner__content__tag {
+    background-color: $laa-dev-colour;
+  }
+}

--- a/app/webpack/stylesheets/components/_phase_banner.scss
+++ b/app/webpack/stylesheets/components/_phase_banner.scss
@@ -1,33 +1,33 @@
-$laa-uat-colour: govuk-colour("orange");
-$laa-staging-colour: govuk-colour("turquoise");
-$laa-dev-colour: govuk-colour("pink");
+$app-uat-colour: govuk-colour('orange');
+$app-staging-colour: govuk-colour('turquoise');
+$app-dev-colour: govuk-colour('pink');
 
 .uat {
   .govuk-header__container {
-    border-bottom-color: $laa-uat-colour;
+    border-bottom-color: $app-uat-colour;
   }
 
   .govuk-tag.govuk-phase-banner__content__tag {
-    background-color: $laa-uat-colour;
+    background-color: $app-uat-colour;
   }
 }
 
 .staging {
   .govuk-header__container {
-    border-bottom-color: $laa-staging-colour;
+    border-bottom-color: $app-staging-colour;
   }
 
   .govuk-tag.govuk-phase-banner__content__tag {
-    background-color: $laa-staging-colour;
+    background-color: $app-staging-colour;
   }
 }
 
 .dev {
   .govuk-header__container {
-    border-bottom-color: $laa-dev-colour;
+    border-bottom-color: $app-dev-colour;
   }
 
   .govuk-tag.govuk-phase-banner__content__tag {
-    background-color: $laa-dev-colour;
+    background-color: $app-dev-colour;
   }
 }

--- a/spec/features/layout_spec.rb
+++ b/spec/features/layout_spec.rb
@@ -35,4 +35,28 @@ RSpec.feature 'Gov UK Layout', type: :feature do
       end
     end
   end
+
+  context 'when environment is staging' do
+    around do |example|
+      with_env('staging') { example.run }
+    end
+
+    scenario 'GDS styled home page' do
+      within '.govuk-phase-banner' do
+        expect(page).to have_css('.govuk-phase-banner__content', text: 'staging')
+      end
+    end
+  end
+
+  context 'when environment is dev' do
+    around do |example|
+      with_env('dev') { example.run }
+    end
+
+    scenario 'GDS styled home page' do
+      within '.govuk-phase-banner' do
+        expect(page).to have_css('.govuk-phase-banner__content', text: 'dev')
+      end
+    end
+  end
 end

--- a/spec/features/layout_spec.rb
+++ b/spec/features/layout_spec.rb
@@ -1,18 +1,38 @@
 # frozen_string_literal: true
 
 RSpec.feature 'Gov UK Layout', type: :feature do
-  scenario 'GDS styled home page' do
+  before do
     visit '/'
+  end
 
-    within '.govuk-header' do
-      within '.govuk-header__content' do
-        expect(page).to have_link('View court data')
-      end
+  context 'when environment is production' do
+    around do |example|
+      with_env('production') { example.run }
     end
 
-    within '.govuk-phase-banner' do
-      expect(page).to have_css('.govuk-phase-banner__content', text: 'alpha')
-      expect(page).to have_css('.govuk-phase-banner__text', text: 'This is a new service')
+    scenario 'GDS styled home page' do
+      within '.govuk-header' do
+        within '.govuk-header__content' do
+          expect(page).to have_link('View court data')
+        end
+      end
+
+      within '.govuk-phase-banner' do
+        expect(page).to have_css('.govuk-phase-banner__content', text: 'alpha')
+        expect(page).to have_css('.govuk-phase-banner__text', text: 'This is a new service')
+      end
+    end
+  end
+
+  context 'when environment is uat' do
+    around do |example|
+      with_env('uat') { example.run }
+    end
+
+    scenario 'GDS styled home page' do
+      within '.govuk-phase-banner' do
+        expect(page).to have_css('.govuk-phase-banner__content', text: 'uat')
+      end
     end
   end
 end

--- a/spec/features/layout_spec.rb
+++ b/spec/features/layout_spec.rb
@@ -59,4 +59,12 @@ RSpec.feature 'Gov UK Layout', type: :feature do
       end
     end
   end
+
+  context 'when running the application locally' do
+    scenario 'GDS styled home page' do
+      within '.govuk-phase-banner' do
+        expect(page).to have_css('.govuk-phase-banner__content', text: 'local')
+      end
+    end
+  end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -227,4 +227,20 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
     end
   end
+
+  describe '#app_environment' do
+    subject(:app_environment) { helper.app_environment }
+
+    context 'when application is running within the dev kubernetes namespace' do
+      around do |example|
+        with_env('dev') { example.run }
+      end
+
+      it { is_expected.to eql 'app-environment-dev' }
+    end
+
+    context 'when application is running locally' do
+      it { is_expected.to eql 'app-environment-local' }
+    end
+  end
 end

--- a/spec/support/application.rb
+++ b/spec/support/application.rb
@@ -12,6 +12,14 @@ module Application
         Rails.root.join(*path)
       )
     end
+
+    def with_env(env)
+      @original_env = ENV['ENV']
+      ENV['ENV'] = env
+      yield
+    ensure
+      ENV['ENV'] = @original_env
+    end
   end
 end
 


### PR DESCRIPTION
#### What
We need a banner on the UAT environment

#### Ticket
https://dsdmoj.atlassian.net/browse/AAC-79

#### Why
Some of our users have logged into UAT and reported bugs because they are using test data. We still need caseworkers and other “non-technical” users to be testing new features/data that comes through from Common Platform. A banner would help avoid any users making this mistake and accidentally causing disruption.

#### How
Followed the suggestion on the ticket of modifying the Alpha/Beta banner to display the environment with a different colour (NB this is only for the dev, staging and uat environment, all other environments should be as is).
