### PR TITLE
AAC-103 Added Ruby helper for GDS description lists

### DIFF
--- a/app/helpers/govuk_design_system_helper.rb
+++ b/app/helpers/govuk_design_system_helper.rb
@@ -34,6 +34,29 @@ module GovukDesignSystemHelper
     end
   end
 
+  def govuk_summary_list_entry(key, value, tag_options_key = {}, tag_options_value = {})
+    tag_options_key = prepend_classes('govuk-summary-list__key', tag_options_key)
+    tag_options_value = prepend_classes('govuk-summary-list__value', tag_options_value)
+
+    tag.div do
+      govuk_summary_key(key, tag_options_key).concat(
+        govuk_summary_value(value, tag_options_value)
+      )
+    end
+  end
+
+  def govuk_summary_key(key, tag_options_key)
+    tag.dt(**tag_options_key) do
+      key
+    end
+  end
+
+  def govuk_summary_value(value, tag_options_value)
+    tag.dd(**tag_options_value) do
+      value
+    end
+  end
+  
   private
 
   def prepend_classes(classes_to_prepend, options = {})
@@ -57,28 +80,5 @@ module GovukDesignSystemHelper
     page_title_var = title || contextual_title
     caption_var = caption.strip.concat if caption.present?
     "#{caption_var} #{page_title_var} - #{service_name} - GOV.UK".strip
-  end
-
-  def govuk_summary_list_entry(key, value, tag_options_key = {}, tag_options_value = {})
-    tag_options_key = prepend_classes('govuk-summary-list__key', tag_options_key)
-    tag_options_value = prepend_classes('govuk-summary-list__value', tag_options_value)
-
-    tag.div do
-      govuk_summary_key(key, tag_options_key).concat(
-        govuk_summary_value(value, tag_options_value)
-      )
-    end
-  end
-
-  def govuk_summary_key(key, tag_options_key)
-    tag.dt(**tag_options_key) do
-      key
-    end
-  end
-
-  def govuk_summary_value(value, tag_options_value)
-    tag.dd(**tag_options_value) do
-      value
-    end
   end
 end

--- a/app/helpers/govuk_design_system_helper.rb
+++ b/app/helpers/govuk_design_system_helper.rb
@@ -35,10 +35,11 @@ module GovukDesignSystemHelper
   end
 
   def govuk_summary_list_entry(key, value, tag_options_key = {}, tag_options_value = {})
+    tag_class = prepend_classes('govuk-summary-list__row')
     tag_options_key = prepend_classes('govuk-summary-list__key', tag_options_key)
     tag_options_value = prepend_classes('govuk-summary-list__value', tag_options_value)
 
-    tag.div do
+    tag.div(**tag_class) do
       govuk_summary_key(key, tag_options_key).concat(
         govuk_summary_value(value, tag_options_value)
       )
@@ -56,7 +57,7 @@ module GovukDesignSystemHelper
       value
     end
   end
-  
+
   private
 
   def prepend_classes(classes_to_prepend, options = {})

--- a/app/helpers/govuk_design_system_helper.rb
+++ b/app/helpers/govuk_design_system_helper.rb
@@ -46,6 +46,8 @@ module GovukDesignSystemHelper
     end
   end
 
+  private
+
   def govuk_summary_key(key, tag_options_key)
     tag.dt(**tag_options_key) do
       key
@@ -57,8 +59,6 @@ module GovukDesignSystemHelper
       value
     end
   end
-
-  private
 
   def prepend_classes(classes_to_prepend, options = {})
     classes = options[:class].present? ? options[:class].split : []

--- a/app/helpers/govuk_design_system_helper.rb
+++ b/app/helpers/govuk_design_system_helper.rb
@@ -58,4 +58,27 @@ module GovukDesignSystemHelper
     caption_var = caption.strip.concat if caption.present?
     "#{caption_var} #{page_title_var} - #{service_name} - GOV.UK".strip
   end
+
+  def govuk_summary_list_entry(key, value, tag_options_key = {}, tag_options_value = {})
+    tag_options_key = prepend_classes('govuk-summary-list__key', tag_options_key)
+    tag_options_value = prepend_classes('govuk-summary-list__value', tag_options_value)
+
+    tag.div do
+      govuk_summary_key(key, tag_options_key).concat(
+        govuk_summary_value(value, tag_options_value)
+      )
+    end
+  end
+
+  def govuk_summary_key(key, tag_options_key)
+    tag.dt(**tag_options_key) do
+      key
+    end
+  end
+
+  def govuk_summary_value(value, tag_options_value)
+    tag.dd(**tag_options_value) do
+      value
+    end
+  end
 end

--- a/app/views/hearings/_court_applications.html.haml
+++ b/app/views/hearings/_court_applications.html.haml
@@ -11,51 +11,22 @@
           .govuk-accordion__section-summary.govuk-body
             = l(court_application.received_date&.to_date, :format => :long)
         .govuk-accordion__section-content.govuk-details__text
+          - key_class = {}
+          - value_class = {class: "vcd-capitalize-first-letter"}
           %dl.govuk-summary-list
-            .govuk-summary-list__row
-              %dt.govuk-summary-list__key
-                = t('hearings.show.court_applications.received_date')
-              %dd.govuk-summary-list__value.vcd-capitalize-first-letter
-                = l(court_application.received_date&.to_date, :format => :long)
-            .govuk-summary-list__row
-              %dt.govuk-summary-list__key
-                = t('hearings.show.court_applications.type')
-              %dd.govuk-summary-list__value.vcd-capitalize-first-letter
-                = court_application&.type&.description || t('generic.not_available')
-            .govuk-summary-list__row
-              %dt.govuk-summary-list__key
-                = t('hearings.show.court_applications.code')
-              %dd.govuk-summary-list__value.vcd-capitalize-first-letter
-                = court_application&.type&.code || t('generic.not_available')
-            .govuk-summary-list__row
-              %dt.govuk-summary-list__key
-                = t('hearings.show.court_applications.legislation')
-              %dd.govuk-summary-list__value.vcd-capitalize-first-letter
-                = court_application&.type&.legislation  || t('generic.not_available')
+            = govuk_summary_list_entry(t('hearings.show.court_applications.received_date'), l(court_application.received_date&.to_date, :format => :long), key_class, value_class)
+            = govuk_summary_list_entry(t('hearings.show.court_applications.type'), court_application&.type&.description || t('generic.not_available'), key_class, value_class)
+            = govuk_summary_list_entry(t('hearings.show.court_applications.code'), court_application&.type&.code || t('generic.not_available'), key_class, value_class)
+            = govuk_summary_list_entry(t('hearings.show.court_applications.legislation'), court_application&.type&.legislation  || t('generic.not_available'), key_class, value_class)
             - court_application.judicial_results&.each do |result|
-              .govuk-summary-list__row
-                %dt.govuk-summary-list__key
-                  = t('hearings.show.court_applications.result_codes')
-                %dd.govuk-summary-list__value.vcd-capitalize-first-letter
-                  = result&.cjs_code || t('generic.not_available')
-              .govuk-summary-list__row
-                %dt.govuk-summary-list__key
-                  = t('hearings.show.court_applications.result_text')
-                %dd.govuk-summary-list__value.vcd-capitalize-first-letter
-                  - if result&.text.present?
-                    = transform_and_sanitize(result&.text)
-                  - else
-                    = t('generic.not_available')
-            .govuk-summary-list__row
-              %dt.govuk-summary-list__key
-                = t('hearings.show.court_applications.respondent_synonyms')
-              %dd.govuk-summary-list__value.vcd-capitalize-first-letter
-                = court_application.respondent_list
-            .govuk-summary-list__row
-              %dt.govuk-summary-list__key
-                = t('hearings.show.court_applications.applicant_synonym')
-              %dd.govuk-summary-list__value.vcd-capitalize-first-letter
-                = court_application.applicant_synonym
+              = govuk_summary_list_entry(t('hearings.show.court_applications.result_codes'), result&.cjs_code || t('generic.not_available'), key_class, value_class)
+              - if result&.text.present?
+                = govuk_summary_list_entry(t('hearings.show.court_applications.result_text'), transform_and_sanitize(result&.text), key_class, value_class)
+              - else
+                = govuk_summary_list_entry(t('hearings.show.court_applications.result_text'), t('generic.not_available'), key_class, value_class)
+            = govuk_summary_list_entry(t('hearings.show.court_applications.respondent_synonyms'), court_application.respondent_list, key_class, value_class)
+            = govuk_summary_list_entry(t('hearings.show.court_applications.applicant_synonym'), court_application.applicant_synonym, key_class, value_class)
+
 - else
   %p.govuk-body
     = t('hearings.show.court_applications.none')

--- a/spec/helpers/govuk_design_system_helper_spec.rb
+++ b/spec/helpers/govuk_design_system_helper_spec.rb
@@ -184,4 +184,24 @@ RSpec.describe GovukDesignSystemHelper, type: :helper do
       end
     end
   end
+
+  describe '#govuk_summary_list_entry' do
+    subject(:markup) do
+      helper.govuk_summary_list_entry('My summary list key', 'My summary list value') do
+        'My content'
+      end
+    end
+
+    it 'adds row with govuk class' do
+      is_expected.to have_tag(:div, with: { class: 'govuk-summary-list__row' })
+    end
+
+    it 'adds nested key in dt tag with govuk class' do
+      is_expected.to have_tag(:dt, with: { class: 'govuk-summary-list__key' })
+    end
+
+    it 'adds nested value in dd tag with govuk class' do
+      is_expected.to have_tag(:dd, with: { class: 'govuk-summary-list__value' })
+    end
+  end
 end


### PR DESCRIPTION
#### What
Simplified the code and added a helper for the GDS description lists

#### Ticket

[AAC-103 Refactor to use helpers to reduce duplication](https://dsdmoj.atlassian.net/browse/AAC-103)

#### Why
Description lists are common components used several times in the bespoke accordion for court applications.  Using a helper makes maintenance easier and the court applications file considerably shorter

#### How
New Ruby helpers for:
- each row in a `<dl>` list
- each key in a row
- each value in a row

The first helper calls the remaining two - which can be called separately if needed on a different page.
