### PR TITLE
[Security] Selectively bump css-what to 5.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "webpack-dev-server": "^3.11.2"
   },
   "resolutions": {
+    "css-what": "^5.0.1",
     "dot-prop": "^5.2.0",
     "hosted-git-info": "^3.0.8",
     "http-proxy": "^1.18.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2528,10 +2528,10 @@ css-tree@^1.1.2:
     mdn-data "2.0.14"
     source-map "^0.6.1"
 
-css-what@^3.2.1:
-  version "3.4.2"
-  resolved "https://registry.yarnpkg.com/css-what/-/css-what-3.4.2.tgz#ea7026fcb01777edbde52124e21f327e7ae950e4"
-  integrity sha512-ACUm3L0/jiZTqfzRM3Hi9Q8eZqd6IK37mMWPLz9PJxkLWllYeRf+EHUSHYEtFop2Eqytaq1FizFVh7XfBnXCDQ==
+css-what@^3.2.1, css-what@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-5.0.1.tgz#3efa820131f4669a8ac2408f9c32e7c7de9f4cad"
+  integrity sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg==
 
 cssdb@^4.4.0:
   version "4.4.0"


### PR DESCRIPTION
#### What
Selective dependency resolutions of css-what to v5.0.1

#### Why
[Denial of service in css-what](https://github.com/advisories/GHSA-q8pj-2vqx-8ggc)
