### PR TITLE
AAC-168 Notification Banner Helper and Spec Tests

### DIFF
--- a/app/helpers/govuk_design_system_helper.rb
+++ b/app/helpers/govuk_design_system_helper.rb
@@ -47,21 +47,47 @@ module GovukDesignSystemHelper
   end
 
   def govuk_notification_banner(text, key = 'Important', tag_options = {})
-    type_class = ''
-    type_class = 'govuk-notification-banner--success' if key == 'Success'
-    type_class = 'govuk-notification-banner--failure' if key == 'Failure'
-    tag_options = prepend_classes("govuk-notification-banner #{type_class}", tag_options)
-    tag_options[:data] = { module: 'govuk-notification-banner' }
-    banner_title = tag.h2(key, id: 'govuk-notification-banner-title',
-                               class: 'govuk-notification-banner__title')
-    banner_text = tag.p(text, class: 'govuk-body')
+    type_role = govuk_notification_banner_role(key)
+    type_class = govuk_notification_banner_extra_class(key)
+    tag_options = govuk_notification_banner_tag_options(type_role, type_class, tag_options)
     tag.div(**tag_options) do
-      concat tag.div(banner_title, class: 'govuk-notification-banner__header')
-      concat tag.div(banner_text, class: 'govuk-notification-banner__content')
+      concat tag.div(govuk_notification_banner_title(key), class: 'govuk-notification-banner__header')
+      concat tag.div(govuk_notification_banner_content(text),
+                     class: 'govuk-notification-banner__content')
     end
   end
 
   private
+
+  def govuk_notification_banner_tag_options(type_role, type_class, tag_options = {})
+    tag_options = prepend_classes("govuk-notification-banner #{type_class}", tag_options)
+    tag_options[:data] = { module: 'govuk-notification-banner' }
+    tag_options[:role] = type_role
+    tag_options[:aria] = { labelledby: 'govuk-notification-banner-title' }
+    tag_options
+  end
+
+  def govuk_notification_banner_role(key)
+    if %w[Success Failure].include?(key)
+      'alert'
+    else
+      'region'
+    end
+  end
+
+  def govuk_notification_banner_extra_class(key)
+    type_class = 'govuk-notification-banner--success' if key == 'Success'
+    type_class = 'govuk-notification-banner--failure' if key == 'Failure'
+    type_class
+  end
+
+  def govuk_notification_banner_title(title)
+    tag.h2(title, id: 'govuk-notification-banner-title', class: 'govuk-notification-banner__title')
+  end
+
+  def govuk_notification_banner_content(text)
+    tag.p(text, class: 'govuk-notification-banner__heading')
+  end
 
   def govuk_summary_key(key, tag_options_key)
     tag.dt(**tag_options_key) do

--- a/app/helpers/govuk_design_system_helper.rb
+++ b/app/helpers/govuk_design_system_helper.rb
@@ -46,6 +46,21 @@ module GovukDesignSystemHelper
     end
   end
 
+  def govuk_notification_banner(text, key = 'Important', tag_options = {})
+    type_class = ''
+    type_class = 'govuk-notification-banner--success' if key == 'Success'
+    type_class = 'govuk-notification-banner--failure' if key == 'Failure'
+    tag_options = prepend_classes("govuk-notification-banner #{type_class}", tag_options)
+    tag_options[:data] = { module: 'govuk-notification-banner' }
+    banner_title = tag.h2(key, id: 'govuk-notification-banner-title',
+                               class: 'govuk-notification-banner__title')
+    banner_text = tag.p(text, class: 'govuk-body')
+    tag.div(**tag_options) do
+      concat tag.div(banner_title, class: 'govuk-notification-banner__header')
+      concat tag.div(banner_text, class: 'govuk-notification-banner__content')
+    end
+  end
+
   private
 
   def govuk_summary_key(key, tag_options_key)

--- a/app/helpers/govuk_design_system_helper.rb
+++ b/app/helpers/govuk_design_system_helper.rb
@@ -46,21 +46,21 @@ module GovukDesignSystemHelper
     end
   end
 
-  def govuk_notification_banner(text, key = 'Important', tag_options = {})
+  def govuk_notification_banner(text = nil, key = 'Important', content = nil)
     type_role = govuk_notification_banner_role(key)
     type_class = govuk_notification_banner_extra_class(key)
-    tag_options = govuk_notification_banner_tag_options(type_role, type_class, tag_options)
+    tag_options = govuk_notification_banner_tag_options(type_role, type_class)
     tag.div(**tag_options) do
       concat tag.div(govuk_notification_banner_title(key), class: 'govuk-notification-banner__header')
-      concat tag.div(govuk_notification_banner_content(text),
+      concat tag.div(govuk_notification_banner_content(text, content),
                      class: 'govuk-notification-banner__content')
     end
   end
 
   private
 
-  def govuk_notification_banner_tag_options(type_role, type_class, tag_options = {})
-    tag_options = prepend_classes("govuk-notification-banner #{type_class}", tag_options)
+  def govuk_notification_banner_tag_options(type_role, type_class)
+    tag_options = prepend_classes("govuk-notification-banner #{type_class}")
     tag_options[:data] = { module: 'govuk-notification-banner' }
     tag_options[:role] = type_role
     tag_options[:aria] = { labelledby: 'govuk-notification-banner-title' }
@@ -85,8 +85,10 @@ module GovukDesignSystemHelper
     tag.h2(title, id: 'govuk-notification-banner-title', class: 'govuk-notification-banner__title')
   end
 
-  def govuk_notification_banner_content(text)
-    tag.p(text, class: 'govuk-notification-banner__heading')
+  def govuk_notification_banner_content(text, content)
+    tag.p(text, class: 'govuk-notification-banner__heading').concat(
+      (tag.p(content, class: 'govuk-body') unless content.nil?)
+    )
   end
 
   def govuk_summary_key(key, tag_options_key)

--- a/app/views/layouts/_flashes.html.haml
+++ b/app/views/layouts/_flashes.html.haml
@@ -16,11 +16,4 @@
           .govuk-error-message
 
     - when 'success'
-      .govuk-notification-banner.govuk-notification-banner--success{ 'role': 'alert', 'aria-labelledby': 'govuk-notification-banner-title', 'data-module': 'govuk-notification-banner' }
-        .govuk-notification-banner__header
-          %h2#govuk-notification-banner-title.govuk-notification-banner__title
-            = key.capitalize
-        .govuk-notification-banner__content
-          %p.govuk-notification-banner__heading
-            = value.html_safe
-
+      = govuk_notification_banner(value.html_safe, key.capitalize)

--- a/app/webpack/stylesheets/application.scss
+++ b/app/webpack/stylesheets/application.scss
@@ -15,6 +15,7 @@ $govuk-image-url-function: frontend-image-url;
 @import "components/forms";
 @import "components/custom_styles";
 @import "components/hearing_events";
+@import "components/notification_banner";
 @import "components/sortable_table";
 @import "components/summary";
 @import "components/phase_banner";

--- a/app/webpack/stylesheets/components/_notification_banner.scss
+++ b/app/webpack/stylesheets/components/_notification_banner.scss
@@ -1,0 +1,18 @@
+.govuk-notification-banner--failure {
+    border-color: $govuk-error-colour;
+    background-color: $govuk-error-colour;
+
+    .govuk-notification-banner__link:link,
+    .govuk-notification-banner__link:visited {
+        color: $govuk-error-colour;
+    }
+    .govuk-notification-banner__link:hover {
+        color: govuk-shade($govuk-error-colour, 20%);
+    }
+    .govuk-notification-banner__link:active {
+        color: $govuk-error-colour;
+    }
+    .govuk-notification-banner__link:focus {
+        color: $govuk-text-colour;
+    }
+}

--- a/app/webpack/stylesheets/components/_notification_banner.scss
+++ b/app/webpack/stylesheets/components/_notification_banner.scss
@@ -1,18 +1,18 @@
 .govuk-notification-banner--failure {
-    border-color: $govuk-error-colour;
-    background-color: $govuk-error-colour;
+  border-color: $govuk-error-colour;
+  background-color: $govuk-error-colour;
 
-    .govuk-notification-banner__link:link,
-    .govuk-notification-banner__link:visited {
-        color: $govuk-error-colour;
-    }
-    .govuk-notification-banner__link:hover {
-        color: govuk-shade($govuk-error-colour, 20%);
-    }
-    .govuk-notification-banner__link:active {
-        color: $govuk-error-colour;
-    }
-    .govuk-notification-banner__link:focus {
-        color: $govuk-text-colour;
-    }
+  .govuk-notification-banner__link:link,
+  .govuk-notification-banner__link:visited {
+    color: $govuk-error-colour;
+  }
+  .govuk-notification-banner__link:hover {
+    color: govuk-shade($govuk-error-colour, 20%);
+  }
+  .govuk-notification-banner__link:active {
+    color: $govuk-error-colour;
+  }
+  .govuk-notification-banner__link:focus {
+    color: $govuk-text-colour;
+  }
 }

--- a/app/webpack/stylesheets/components/_notification_banner.scss
+++ b/app/webpack/stylesheets/components/_notification_banner.scss
@@ -6,12 +6,15 @@
   .govuk-notification-banner__link:visited {
     color: $govuk-error-colour;
   }
+
   .govuk-notification-banner__link:hover {
     color: govuk-shade($govuk-error-colour, 20%);
   }
+
   .govuk-notification-banner__link:active {
     color: $govuk-error-colour;
   }
+
   .govuk-notification-banner__link:focus {
     color: $govuk-text-colour;
   }

--- a/app/webpack/stylesheets/components/_notification_banner.scss
+++ b/app/webpack/stylesheets/components/_notification_banner.scss
@@ -2,20 +2,7 @@
   border-color: $govuk-error-colour;
   background-color: $govuk-error-colour;
 
-  .govuk-notification-banner__link:link,
-  .govuk-notification-banner__link:visited {
-    color: $govuk-error-colour;
-  }
-
-  .govuk-notification-banner__link:hover {
-    color: govuk-shade($govuk-error-colour, 20%);
-  }
-
-  .govuk-notification-banner__link:active {
-    color: $govuk-error-colour;
-  }
-
-  .govuk-notification-banner__link:focus {
-    color: $govuk-text-colour;
+  .govuk-notification-banner__link {
+    @include govuk-link-style-error;
   }
 }

--- a/spec/helpers/govuk_design_system_helper_spec.rb
+++ b/spec/helpers/govuk_design_system_helper_spec.rb
@@ -204,4 +204,72 @@ RSpec.describe GovukDesignSystemHelper, type: :helper do
       is_expected.to have_tag(:dd, with: { class: 'govuk-summary-list__value' })
     end
   end
+
+  describe '#govuk_notification_banner' do
+    subject(:markup) do
+      helper.govuk_notification_banner('Some text value') do
+        'My content'
+      end
+    end
+
+    it 'adds a title tag' do
+      is_expected.to have_text('Important')
+    end
+
+    it 'adds the content tag' do
+      is_expected.to have_tag(:div, with: { class: 'govuk-notification-banner__content' })
+    end
+
+    it 'adds the text' do
+      is_expected.to have_text('Some text value')
+    end
+  end
+
+  describe '#govuk_notification_success_banner' do
+    subject(:markup) do
+      helper.govuk_notification_banner('Some text value', 'Success') do
+        'My content'
+      end
+    end
+
+    it 'adds a title tag' do
+      is_expected.to have_text('Success')
+    end
+
+    it 'changes the colour to green' do
+      is_expected.to have_tag(:div, with: { class: 'govuk-notification-banner--success' })
+    end
+  end
+
+  describe '#govuk_notification_failure_banner' do
+    subject(:markup) do
+      helper.govuk_notification_banner('Some text value', 'Failure') do
+        'My content'
+      end
+    end
+
+    it 'adds a title tag' do
+      is_expected.to have_text('Failure')
+    end
+
+    it 'changes the colour to red' do
+      is_expected.to have_tag(:div, with: { class: 'govuk-notification-banner--failure' })
+    end
+  end
+
+  describe '#govuk_notification_custom_banner' do
+    subject(:markup) do
+      helper.govuk_notification_banner('Some text value', 'Something') do
+        'My content'
+      end
+    end
+
+    it 'adds a title tag' do
+      is_expected.to have_text('Something')
+    end
+
+    it "doesn't add a different class" do
+      is_expected.not_to have_tag(:div, with: { class: 'govuk-notification-banner--something' })
+    end
+  end
 end

--- a/spec/helpers/govuk_design_system_helper_spec.rb
+++ b/spec/helpers/govuk_design_system_helper_spec.rb
@@ -228,6 +228,22 @@ RSpec.describe GovukDesignSystemHelper, type: :helper do
       is_expected.to have_text('Some text value')
     end
 
+    it 'does not add a body class' do
+      is_expected.not_to have_tag(:p, with: { class: 'govuk-body' })
+    end
+
+    context 'when extra content is provided' do
+      subject(:markup) do
+        helper.govuk_notification_banner('Some text value', '', 'Some content') do
+          'My content'
+        end
+      end
+
+      it 'adds the extra content in a body class' do
+        is_expected.to have_tag(:p, with: { class: 'govuk-body' }, text: 'Some content')
+      end
+    end
+
     context 'when it is a success banner' do
       subject(:markup) do
         helper.govuk_notification_banner('Some text value', 'Success') do

--- a/spec/helpers/govuk_design_system_helper_spec.rb
+++ b/spec/helpers/govuk_design_system_helper_spec.rb
@@ -216,6 +216,10 @@ RSpec.describe GovukDesignSystemHelper, type: :helper do
       is_expected.to have_text('Important')
     end
 
+    it 'adds the role of "region"' do
+      is_expected.to have_tag(:div, role: 'region')
+    end
+
     it 'adds the content tag' do
       is_expected.to have_tag(:div, with: { class: 'govuk-notification-banner__content' })
     end
@@ -223,53 +227,61 @@ RSpec.describe GovukDesignSystemHelper, type: :helper do
     it 'adds the text' do
       is_expected.to have_text('Some text value')
     end
-  end
 
-  describe '#govuk_notification_success_banner' do
-    subject(:markup) do
-      helper.govuk_notification_banner('Some text value', 'Success') do
-        'My content'
+    context 'when it is a success banner' do
+      subject(:markup) do
+        helper.govuk_notification_banner('Some text value', 'Success') do
+          'My content'
+        end
+      end
+
+      it 'adds a title tag' do
+        is_expected.to have_text('Success')
+      end
+
+      it 'adds the success class' do
+        is_expected.to have_tag(:div, with: { class: 'govuk-notification-banner--success' })
+      end
+
+      it 'changes the role to "alert"' do
+        is_expected.to have_tag(:div, role: 'alert')
       end
     end
 
-    it 'adds a title tag' do
-      is_expected.to have_text('Success')
-    end
+    context 'when it is a failure banner' do
+      subject(:markup) do
+        helper.govuk_notification_banner('Some text value', 'Failure') do
+          'My content'
+        end
+      end
 
-    it 'changes the colour to green' do
-      is_expected.to have_tag(:div, with: { class: 'govuk-notification-banner--success' })
-    end
-  end
+      it 'adds a title tag' do
+        is_expected.to have_text('Failure')
+      end
 
-  describe '#govuk_notification_failure_banner' do
-    subject(:markup) do
-      helper.govuk_notification_banner('Some text value', 'Failure') do
-        'My content'
+      it 'adds the failure class' do
+        is_expected.to have_tag(:div, with: { class: 'govuk-notification-banner--failure' })
+      end
+
+      it 'changes the role to "alert"' do
+        is_expected.to have_tag(:div, role: 'alert')
       end
     end
 
-    it 'adds a title tag' do
-      is_expected.to have_text('Failure')
-    end
-
-    it 'changes the colour to red' do
-      is_expected.to have_tag(:div, with: { class: 'govuk-notification-banner--failure' })
-    end
-  end
-
-  describe '#govuk_notification_custom_banner' do
-    subject(:markup) do
-      helper.govuk_notification_banner('Some text value', 'Something') do
-        'My content'
+    context 'when the banner has a bespoke title' do
+      subject(:markup) do
+        helper.govuk_notification_banner('Some text value', 'Something') do
+          'My content'
+        end
       end
-    end
 
-    it 'adds a title tag' do
-      is_expected.to have_text('Something')
-    end
+      it 'adds a title tag' do
+        is_expected.to have_text('Something')
+      end
 
-    it "doesn't add a different class" do
-      is_expected.not_to have_tag(:div, with: { class: 'govuk-notification-banner--something' })
+      it "doesn't add a different class" do
+        is_expected.not_to have_tag(:div, with: { class: 'govuk-notification-banner--something' })
+      end
     end
   end
 end


### PR DESCRIPTION
#### What
Introduces a notification banner helper and spec tests


#### Ticket

[AAC-168 Add Ruby helper for notification banners including a failure option](https://dsdmoj.atlassian.net/browse/AAC-168)

