### PR TITLE
AAC-146 Error Page Styling

### DIFF
--- a/app/views/errors/internal_error.html.haml
+++ b/app/views/errors/internal_error.html.haml
@@ -1,4 +1,4 @@
 = govuk_page_title(t('error.500_title'))
 
-%p= t('error.500_message')
-%p= t('error.description_html')
+%p.govuk-body= t('error.500_message')
+%p.govuk-body= t('error.description_html')

--- a/app/views/errors/not_found.html.haml
+++ b/app/views/errors/not_found.html.haml
@@ -1,4 +1,5 @@
 = govuk_page_title(t('error.404_title'))
 
-%p= t('error.404_message')
-%p= t('error.description_html')
+%p.govuk-body= t('error.404_message')
+%p.govuk-body= t('error.404_message_2')
+%p.govuk-body= t('error.description_html')

--- a/app/views/errors/unacceptable.html.haml
+++ b/app/views/errors/unacceptable.html.haml
@@ -1,4 +1,4 @@
 = govuk_page_title(t('error.422_title'))
 
-%p= t('error.422_message')
-%p= t('error.description_html')
+%p.govuk-body= t('error.422_message')
+%p.govuk-body= t('error.description_html')

--- a/config/locales/en/views/error.yml
+++ b/config/locales/en/views/error.yml
@@ -1,12 +1,13 @@
 ---
 en:
   error:
-    401_message: Unauthorized connection to source data
+    401_message: Unauthorized connection to source data.
     401_title: Unauthorized
-    404_message: If you entered a web address please check it was correct.
+    404_message: If you typed the web address, check it is correct.
+    404_message_2: If you pasted the web address, check you copied the entire address.
     404_title: Page not found
-    422_message: Maybe you tried to change something you didn't have access to.
+    422_message: Maybe you tried to change something you didn’t have access to.
     422_title: The change you wanted was rejected
-    500_message: Please try again soon or
-    500_title: We're sorry, but something went wrong
+    500_message: Try again later.
+    500_title: Sorry, something went wrong
     description_html: You can also <a href="/">browse from the homepage</a> to find the information you need.

--- a/config/locales/en/views/error.yml
+++ b/config/locales/en/views/error.yml
@@ -10,4 +10,4 @@ en:
     422_title: The change you wanted was rejected
     500_message: Try again later.
     500_title: Sorry, something went wrong
-    description_html: You can also <a href="/">browse from the homepage</a> to find the information you need.
+    description_html: You can also <a class="govuk-link" href="/">browse from the homepage</a> to find the information you need.

--- a/spec/features/errors_spec.rb
+++ b/spec/features/errors_spec.rb
@@ -5,11 +5,12 @@ RSpec.feature 'Error page', type: :feature do
     visit '/not-exists'
 
     within '.govuk-main-wrapper' do
-      expect(page).to have_css('.govuk-heading-xl', text: I18n.t('error.404_title'))
+      expect(page).to have_css('.govuk-heading-xl', text: 'Page not found')
       expect(page).to have_css('.govuk-body', text: 'If you typed the web address, check it is correct.')
       expect(page).to have_css('.govuk-body',
                                text: 'If you pasted the web address, check you copied the entire address.')
-      expect(page).to have_css('.govuk-body', text: 'You can also ')
+      expect(page).to have_css('.govuk-body',
+                               text: 'You can also browse from the homepage to find the information you need')
       expect(page).to have_css('.govuk-link', text: 'browse from the homepage')
     end
     click_link 'browse from the homepage'
@@ -20,10 +21,11 @@ RSpec.feature 'Error page', type: :feature do
     visit '/422'
 
     within '.govuk-main-wrapper' do
-      expect(page).to have_css('.govuk-heading-xl', text: I18n.t('error.422_title'))
+      expect(page).to have_css('.govuk-heading-xl', text: 'The change you wanted was rejected')
       expect(page).to have_css('.govuk-body',
                                text: 'Maybe you tried to change something you didn’t have access to.')
-      expect(page).to have_css('.govuk-body', text: 'You can also ')
+      expect(page).to have_css('.govuk-body',
+                               text: 'You can also browse from the homepage to find the information you need')
       expect(page).to have_css('.govuk-link', text: 'browse from the homepage')
     end
     click_link 'browse from the homepage'
@@ -34,9 +36,10 @@ RSpec.feature 'Error page', type: :feature do
     visit '/401'
 
     within '.govuk-main-wrapper' do
-      expect(page).to have_css('.govuk-heading-xl', text: I18n.t('error.401_title'))
+      expect(page).to have_css('.govuk-heading-xl', text: 'Unauthorized')
       expect(page).to have_css('.govuk-body', text: 'Unauthorized connection to source data.')
-      expect(page).to have_css('.govuk-body', text: 'You can also ')
+      expect(page).to have_css('.govuk-body',
+                               text: 'You can also browse from the homepage to find the information you need')
       expect(page).to have_css('.govuk-link', text: 'browse from the homepage')
     end
     click_link 'browse from the homepage'
@@ -56,9 +59,10 @@ RSpec.feature 'Error page', type: :feature do
       visit user_path(user.id)
 
       within '.govuk-main-wrapper' do
-        expect(page).to have_css('.govuk-heading-xl', text: I18n.t('error.500_title'))
+        expect(page).to have_css('.govuk-heading-xl', text: 'Sorry, something went wrong')
         expect(page).to have_css('.govuk-body', text: 'Try again later.')
-        expect(page).to have_css('.govuk-body', text: 'You can also ')
+        expect(page).to have_css('.govuk-body',
+                                 text: 'You can also browse from the homepage to find the information ')
         expect(page).to have_css('.govuk-link', text: 'browse from the homepage')
       end
       click_link 'browse from the homepage'

--- a/spec/features/errors_spec.rb
+++ b/spec/features/errors_spec.rb
@@ -6,7 +6,14 @@ RSpec.feature 'Error page', type: :feature do
 
     within '.govuk-main-wrapper' do
       expect(page).to have_css('.govuk-heading-xl', text: I18n.t('error.404_title'))
+      expect(page).to have_css('.govuk-body', text: 'If you typed the web address, check it is correct.')
+      expect(page).to have_css('.govuk-body',
+                               text: 'If you pasted the web address, check you copied the entire address.')
+      expect(page).to have_css('.govuk-body', text: 'You can also ')
+      expect(page).to have_css('.govuk-link', text: 'browse from the homepage')
     end
+    click_link 'browse from the homepage'
+    expect(page).to have_current_path('/')
   end
 
   scenario 'returns 422' do
@@ -14,7 +21,26 @@ RSpec.feature 'Error page', type: :feature do
 
     within '.govuk-main-wrapper' do
       expect(page).to have_css('.govuk-heading-xl', text: I18n.t('error.422_title'))
+      expect(page).to have_css('.govuk-body',
+                               text: 'Maybe you tried to change something you didn’t have access to.')
+      expect(page).to have_css('.govuk-body', text: 'You can also ')
+      expect(page).to have_css('.govuk-link', text: 'browse from the homepage')
     end
+    click_link 'browse from the homepage'
+    expect(page).to have_current_path('/')
+  end
+
+  scenario 'returns 401' do
+    visit '/401'
+
+    within '.govuk-main-wrapper' do
+      expect(page).to have_css('.govuk-heading-xl', text: I18n.t('error.401_title'))
+      expect(page).to have_css('.govuk-body', text: 'Unauthorized connection to source data.')
+      expect(page).to have_css('.govuk-body', text: 'You can also ')
+      expect(page).to have_css('.govuk-link', text: 'browse from the homepage')
+    end
+    click_link 'browse from the homepage'
+    expect(page).to have_current_path('/')
   end
 
   context 'when unexpected error raised' do
@@ -31,7 +57,12 @@ RSpec.feature 'Error page', type: :feature do
 
       within '.govuk-main-wrapper' do
         expect(page).to have_css('.govuk-heading-xl', text: I18n.t('error.500_title'))
+        expect(page).to have_css('.govuk-body', text: 'Try again later.')
+        expect(page).to have_css('.govuk-body', text: 'You can also ')
+        expect(page).to have_css('.govuk-link', text: 'browse from the homepage')
       end
+      click_link 'browse from the homepage'
+      expect(page).to have_current_path('/')
     end
   end
 end


### PR DESCRIPTION
#### What
Added GDS styling to error pages
Minor changes to wording to reflect wording used on [GDS Design System patterns](https://design-system.service.gov.uk/patterns/problem-with-the-service-pages/)
Adds and updates existing RSpec tests for error page content.

#### Ticket

[Change Styling on Error pages to match the GDS pattern](https://dsdmoj.atlassian.net/browse/AAC-146)

#### Why
Uses set font sizes and typeface as used elsewhere to make these error pages easier to read and in line with the standard.

#### How
Apply GDS classes
