### PR TITLE
AAC-199 - Increase GA site sample speed for page load times

### DIFF
--- a/app/views/layouts/_google_analytics.html.haml
+++ b/app/views/layouts/_google_analytics.html.haml
@@ -14,5 +14,6 @@
     }
     gtag('js', new Date())
     gtag('config', `${googleTrackingID}`, {
-      anonymize_ip: true
+      anonymize_ip: true,
+      siteSpeedSampleRate: 100
     })

--- a/app/views/layouts/_google_analytics.html.haml
+++ b/app/views/layouts/_google_analytics.html.haml
@@ -15,5 +15,5 @@
     gtag('js', new Date())
     gtag('config', `${googleTrackingID}`, {
       anonymize_ip: true,
-      siteSpeedSampleRate: 100
+      site_speed_sample_rate: 100
     })


### PR DESCRIPTION
#### What

Update the config for GA to allow the siteSpeedSampleRate to be at 100% so that we can understand what page load times our consumers have

#### Ticket

[AAC-195](https://dsdmoj.atlassian.net/browse/AAC-195)

#### Why

Currently GA doesnt show anything for Page load times. This is because as default GA sets this to 1% so our sample rate is too low to understand what is happening. 

#### How

Value updated as per https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#siteSpeedSampleRate

#### Evidence

Screenshot to show page timings now coming through to GA in Dev. 
![Screenshot 2021-07-16 at 09 59 35](https://user-images.githubusercontent.com/84575729/125922211-9774403d-deee-4cdf-82a1-c09340596b3b.png)

