### PR TITLE
AAC-245 Enable Sentry performance monitoring

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -4,5 +4,8 @@ if Rails.env.eql?('production') && ENV['SENTRY_DSN'].present?
   Sentry.init do |config|
     config.dsn = ENV['SENTRY_DSN']
     config.breadcrumbs_logger = [:active_support_logger]
+
+    # Sample rate is set to 5%
+    config.traces_sample_rate = 0.05
   end
 end


### PR DESCRIPTION
#### Ticket


[Sentry performance ticket](https://dsdmoj.atlassian.net/browse/AAC-245)

#### Why
Enable Sentry performance monitoring

#### How

- Set the sample rate to 0.5% which is 0.05 for traces_sample_rate
