### PR TITLE
AAC-262 - Add Rogue IP addresses to deny list

### DIFF
--- a/.k8s/dev/ingress.yaml
+++ b/.k8s/dev/ingress.yaml
@@ -4,12 +4,12 @@ metadata:
   name: laa-court-data-ui-app-ingress
   namespace: laa-court-data-ui-dev
   annotations:
-  nginx.ingress.kubernetes.io/server-snippet: |
-    location / {
-      deny 223.178.211.9;
-      deny 143.244.161.10;
-      deny 206.72.194.213;
-    }
+    nginx.ingress.kubernetes.io/server-snippet: |
+      location / {
+        deny 223.178.211.9;
+        deny 143.244.161.10;
+        deny 206.72.194.213;
+      }
 spec:
   rules:
     - host: dev.view-court-data.service.justice.gov.uk

--- a/.k8s/dev/ingress.yaml
+++ b/.k8s/dev/ingress.yaml
@@ -5,11 +5,9 @@ metadata:
   namespace: laa-court-data-ui-dev
   annotations:
     nginx.ingress.kubernetes.io/server-snippet: |
-      location / {
         deny 223.178.211.9;
         deny 143.244.161.10;
         deny 206.72.194.213;
-      }
 spec:
   rules:
     - host: dev.view-court-data.service.justice.gov.uk

--- a/.k8s/dev/ingress.yaml
+++ b/.k8s/dev/ingress.yaml
@@ -3,6 +3,13 @@ kind: Ingress
 metadata:
   name: laa-court-data-ui-app-ingress
   namespace: laa-court-data-ui-dev
+  annotations:
+  nginx.ingress.kubernetes.io/server-snippet: |-
+    location / {
+      deny 223.178.211.9;
+      deny 143.244.161.10;
+      deny 206.72.194.213;
+    }
 spec:
   rules:
     - host: dev.view-court-data.service.justice.gov.uk

--- a/.k8s/dev/ingress.yaml
+++ b/.k8s/dev/ingress.yaml
@@ -4,7 +4,7 @@ metadata:
   name: laa-court-data-ui-app-ingress
   namespace: laa-court-data-ui-dev
   annotations:
-  nginx.ingress.kubernetes.io/server-snippet: |-
+  nginx.ingress.kubernetes.io/server-snippet: |
     location / {
       deny 223.178.211.9;
       deny 143.244.161.10;

--- a/.k8s/production/ingress.yaml
+++ b/.k8s/production/ingress.yaml
@@ -4,7 +4,7 @@ metadata:
   name: laa-court-data-ui-app-ingress
   namespace: laa-court-data-ui-production
   annotations:
-    nginx.ingress.kubernetes.io/server-snippet: |-
+    nginx.ingress.kubernetes.io/server-snippet: |
       location / {
         deny 223.178.211.9;
         deny 143.244.161.10;

--- a/.k8s/production/ingress.yaml
+++ b/.k8s/production/ingress.yaml
@@ -3,6 +3,13 @@ kind: Ingress
 metadata:
   name: laa-court-data-ui-app-ingress
   namespace: laa-court-data-ui-production
+  annotations:
+    nginx.ingress.kubernetes.io/server-snippet: |-
+      location / {
+        deny 223.178.211.9;
+        deny 143.244.161.10;
+        deny 206.72.194.213;
+      }
 spec:
   rules:
     - host: view-court-data.service.justice.gov.uk

--- a/.k8s/production/ingress.yaml
+++ b/.k8s/production/ingress.yaml
@@ -5,11 +5,9 @@ metadata:
   namespace: laa-court-data-ui-production
   annotations:
     nginx.ingress.kubernetes.io/server-snippet: |
-      location / {
         deny 223.178.211.9;
         deny 143.244.161.10;
         deny 206.72.194.213;
-      }
 spec:
   rules:
     - host: view-court-data.service.justice.gov.uk

--- a/.k8s/staging/ingress.yaml
+++ b/.k8s/staging/ingress.yaml
@@ -5,11 +5,9 @@ metadata:
   namespace: laa-court-data-ui-staging
   annotations:
     nginx.ingress.kubernetes.io/server-snippet: |
-      location / {
         deny 223.178.211.9;
         deny 143.244.161.10;
         deny 206.72.194.213;
-      }
 spec:
   rules:
     - host: staging.view-court-data.service.justice.gov.uk

--- a/.k8s/staging/ingress.yaml
+++ b/.k8s/staging/ingress.yaml
@@ -3,6 +3,13 @@ kind: Ingress
 metadata:
   name: laa-court-data-ui-app-ingress
   namespace: laa-court-data-ui-staging
+  annotations:
+    nginx.ingress.kubernetes.io/server-snippet: |-
+      location / {
+        deny 223.178.211.9;
+        deny 143.244.161.10;
+        deny 206.72.194.213;
+      }
 spec:
   rules:
     - host: staging.view-court-data.service.justice.gov.uk

--- a/.k8s/staging/ingress.yaml
+++ b/.k8s/staging/ingress.yaml
@@ -4,7 +4,7 @@ metadata:
   name: laa-court-data-ui-app-ingress
   namespace: laa-court-data-ui-staging
   annotations:
-    nginx.ingress.kubernetes.io/server-snippet: |-
+    nginx.ingress.kubernetes.io/server-snippet: |
       location / {
         deny 223.178.211.9;
         deny 143.244.161.10;

--- a/.k8s/uat/ingress.yaml
+++ b/.k8s/uat/ingress.yaml
@@ -4,7 +4,7 @@ metadata:
   name: laa-court-data-ui-app-ingress
   namespace: laa-court-data-ui-uat
   annotations:
-    nginx.ingress.kubernetes.io/server-snippet: |-
+    nginx.ingress.kubernetes.io/server-snippet: |
       location / {
         deny 223.178.211.9;
         deny 143.244.161.10;

--- a/.k8s/uat/ingress.yaml
+++ b/.k8s/uat/ingress.yaml
@@ -3,6 +3,13 @@ kind: Ingress
 metadata:
   name: laa-court-data-ui-app-ingress
   namespace: laa-court-data-ui-uat
+  annotations:
+    nginx.ingress.kubernetes.io/server-snippet: |-
+      location / {
+        deny 223.178.211.9;
+        deny 143.244.161.10;
+        deny 206.72.194.213;
+      }
 spec:
   rules:
     - host: uat.view-court-data.service.justice.gov.uk

--- a/.k8s/uat/ingress.yaml
+++ b/.k8s/uat/ingress.yaml
@@ -5,11 +5,9 @@ metadata:
   namespace: laa-court-data-ui-uat
   annotations:
     nginx.ingress.kubernetes.io/server-snippet: |
-      location / {
         deny 223.178.211.9;
         deny 143.244.161.10;
         deny 206.72.194.213;
-      }
 spec:
   rules:
     - host: uat.view-court-data.service.justice.gov.uk


### PR DESCRIPTION
#### What

Add Rogue IP addresses that are path scanning to the deny list on the K8s ingress.

#### Ticket

[VCD - Block Rogue IP addresses from Path scanning application](https://dsdmoj.atlassian.net/browse/AAC-262)

#### Why

To remove the security concern of being path scanned

#### How

Using the nginx annotation, i have added the 3 ip addresses to a deny list on the base url of the site which should disallow access to the whole site. 
