### PR TITLE
[DRAFT] Capture not_found error with sentry

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -39,13 +39,20 @@ class ApplicationController < ActionController::Base
     raise unless Rails.env.production?
 
     case exception
-    when ActiveRecord::RecordNotFound || ActionController::RoutingError
-      redirect_to controller: :errors, action: :not_found
+    when ActiveRecord::RecordNotFound
+      Sentry.capture_exception(exception)
+      redirect_to_not_found
+    when ActionController::RoutingError
+      redirect_to_not_found
     when JsonApiClient::Errors::NotAuthorized
       redirect_to controller: :errors, action: :unauthorized
     else
       Sentry.capture_exception(exception)
       redirect_to controller: :errors, action: :internal_error
     end
+  end
+
+  def redirect_to_not_found
+    redirect_to controller: :errors, action: :not_found
   end
 end


### PR DESCRIPTION
#### What

Use Sentry to capture the exception and raise to sentry.io .

#### Ticket

[board ticket description](link)

#### Why

This allows for capturing php attempts on the service / failed attempts on cyber hacking and not needed to scrape through the logs.

--------

#### TODO (wip)

 - [ ] item 1
 - [X] item 2
