### PR TITLE
[DRAFT] Update dependabot schedule to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
 - package-ecosystem: bundler
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
     time: "03:00"
     timezone: Europe/London
   open-pull-requests-limit: 10
@@ -48,7 +48,7 @@ updates:
 - package-ecosystem: npm
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
     time: "03:00"
     timezone: Europe/London
   open-pull-requests-limit: 10


### PR DESCRIPTION
~~Update the dependabot config to the update_schedule of weekly for npm and bundler updates.~~

~~This reduces dependabot PRs bumping a version more than once a week and having lots of emails of dependabot merges daily.~~

[CLOSED]
This is because a daily schedule can reveal zero day attack vulnerabilities and more as opposed to a weekly (less often appraoch)
An alternative would be to change the team schedule to update dependants weekly or as often in a week as possible.