### PR TITLE
AAC-332 Increase ModSecurity threshold to 6

### DIFF
--- a/.k8s/dev/ingress.yaml
+++ b/.k8s/dev/ingress.yaml
@@ -8,6 +8,7 @@ metadata:
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
+      SecAction "id:900110,phase:1,nolog,pass,t:none,setvar:tx.inbound_anomaly_score_threshold=6"
     external-dns.alpha.kubernetes.io/set-identifier: laa-court-data-ui-app-ingress-laa-court-data-ui-dev-blue
     external-dns.alpha.kubernetes.io/aws-weight: "100"
     nginx.ingress.kubernetes.io/server-snippet: |

--- a/.k8s/production/ingress.yaml
+++ b/.k8s/production/ingress.yaml
@@ -8,6 +8,7 @@ metadata:
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
+      SecAction "id:900110,phase:1,nolog,pass,t:none,setvar:tx.inbound_anomaly_score_threshold=6"
     external-dns.alpha.kubernetes.io/set-identifier: laa-court-data-ui-app-ingress-laa-court-data-ui-production-blue
     external-dns.alpha.kubernetes.io/aws-weight: "100"
     nginx.ingress.kubernetes.io/server-snippet: |

--- a/.k8s/staging/ingress.yaml
+++ b/.k8s/staging/ingress.yaml
@@ -8,6 +8,7 @@ metadata:
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
+      SecAction "id:900110,phase:1,nolog,pass,t:none,setvar:tx.inbound_anomaly_score_threshold=6"
     external-dns.alpha.kubernetes.io/set-identifier: laa-court-data-ui-app-ingress-laa-court-data-ui-staging-blue
     external-dns.alpha.kubernetes.io/aws-weight: "100"
     nginx.ingress.kubernetes.io/server-snippet: |

--- a/.k8s/uat/ingress.yaml
+++ b/.k8s/uat/ingress.yaml
@@ -8,6 +8,7 @@ metadata:
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
+      SecAction "id:900110,phase:1,nolog,pass,t:none,setvar:tx.inbound_anomaly_score_threshold=6"
     external-dns.alpha.kubernetes.io/set-identifier: laa-court-data-ui-app-ingress-laa-court-data-ui-uat-blue
     external-dns.alpha.kubernetes.io/aws-weight: "100"
     nginx.ingress.kubernetes.io/server-snippet: |


### PR DESCRIPTION
Incident occurred where a user is receiving 403 https status errors. This PR assumes the cause is [ModSecurity/Firewall](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/modsecurity.html#modsecurity-web-application-firewall) and its threshold of 5 being too low.

#### AAC-332 Increase ModSecurity threshold to 6

Increase the modsecurity threshold to 6 as a fix.

#### Ticket

[AAC-332](https://dsdmoj.atlassian.net/browse/AAC-332?atlOrigin=eyJpIjoiYzQyMGIyZDBjZGY2NGNkOWIwNzVkZTVjNDFiMTgyNWIiLCJwIjoiaiJ9)

#### Why

This is because the default threshold of 5 is blocking users

#### How

By updating the SecAction rule for inbound anomaly score.
