### PR TITLE
AAC-188 Add a github CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# @ministryofjustice/laa-assess-a-claim team will be the default owners for everything in
+# the repo. Unless a later match takes precedence
+
+* @ministryofjustice/laa-assess-a-claim


### PR DESCRIPTION
#### Add CODEOWNERS file which includes the laa-assess-a-claim team as code owners

Codeowners is a github functionality. It allows for automatically adding a reviewer to a PR if it changes something they "own" e.g. any PR that changes a javascript file will request a review from the frontend team members etc.

#### Ticket

[AAC-188](https://dsdmoj.atlassian.net/browse/AAC-188)

#### Why

This allows us to abstract away automatic Pull Request reviewers from Dependabot. Aswell as making it known which team member needs to know about changes to which file. This means we can make sure the right people are aware and reviewing changes merged to the app.

#### How

Add a CODEOWNERS file and configurate it to alert the whole laa-assess-a-claim team for any changes in the app.