### PR TITLE
[Security] Selectively bump ansi-regex to 5.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "webpack-dev-server": "^4.6.0"
   },
   "resolutions": {
+    "ansi-regex": "^5.0.1",
     "css-what": "^5.0.1",
     "dot-prop": "^5.2.0",
     "glob-parent": "^5.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1607,15 +1607,10 @@ ansi-html-community@^0.0.8:
   resolved "https://registry.yarnpkg.com/ansi-html-community/-/ansi-html-community-0.0.8.tgz#69fbc4d6ccbe383f9736934ae34c3f8290f1bf41"
   integrity sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw==
 
-ansi-regex@^5.0.1:
+ansi-regex@^5.0.1, ansi-regex@^6.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
-
-ansi-regex@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.0.0.tgz#ecc7f5933cbe5ac7b33e209a5ff409ab1669c6b2"
-  integrity sha512-tAaOSrWCHF+1Ear1Z4wnJCXA9GGox4K6Ic85a5qalES2aeEwQGr7UC93mwef49536PkCYjzkp0zIxfFvexJ6zQ==
 
 ansi-styles@^3.2.1:
   version "3.2.1"


### PR DESCRIPTION
#### What

Patch to resolve vulnerability: Inefficient Regular Expression Complexity in chalk/ansi-regex

#### Ticket

n/a

#### Why

A security vulnerability in a npm peer dependency