### PR TITLE
Add integer to factory usernames

### DIFF
--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     password_confirmation { 'testing123' }
     first_name { Faker::Name.first_name }
     last_name { Faker::Name.last_name }
-    username { "#{last_name.delete('\'')[0, 4]}-#{first_name.delete('\'')[0, 1]}".downcase }
+    username { "#{last_name.delete('\'')[0, 4]}-#{first_name.delete('\'')[0, 1]}#{rand(99)}".downcase }
     roles { ['caseworker'] }
 
     trait :with_caseworker_role do


### PR DESCRIPTION
#### What

Flashing test in CI complaining of uniqueness validation error on usernames.

#### Why

The uniqueness validation is triggered because the user factory (`spec/factories/users.rb`) generates usernames using the first 4 letters of the surname and first letter of first name of the user, where random names are generated by the Faker gem. 

There are therefore situations by chance where two users created by FactoryBot have the same username.

Example failure in CI: https://app.circleci.com/pipelines/github/ministryofjustice/laa-court-data-ui/3809/workflows/6d1dce72-93ca-40ff-bc55-834ed498e5bc/jobs/12867/tests#failed-test-0

```
Failure/Error: let(:other_user) { create(:user, roles: ['caseworker']) }

ActiveRecord::RecordInvalid:
  Validation failed: Username Username already taken
Shared Example Group: "not manage others" called from ./spec/models/ability_spec.rb:57
./spec/models/ability_spec.rb:41:in `block (2 levels) in <top (required)>'
./spec/models/ability_spec.rb:32:in `block (2 levels) in <top (required)>'
```

#### How
The usernames are based on that of MAAT/MLRA usernames, which append a number to the end of the username if a username already exists. I therefore appended a random number <99 to the end of the username in the user factory.