### PR TITLE
AAC-263 - Use gem for liveness/readiness checks

### DIFF
--- a/.k8s/live-1/production/deployment-worker.yaml
+++ b/.k8s/live-1/production/deployment-worker.yaml
@@ -26,15 +26,13 @@ spec:
           image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/laa-get-paid/laa-court-data-ui:set-me
           command: ['bundle', 'exec', 'sidekiq']
           readinessProbe:
-            exec:
-              command: ['bundle', 'exec', 'rake', 'worker:healthcheck']
-            initialDelaySeconds: 15
-            periodSeconds: 10
+            httpGet:
+              path: /
+              port: 7433
           livenessProbe:
-            exec:
-              command: ['bundle', 'exec', 'rake', 'worker:healthcheck']
-            initialDelaySeconds: 30
-            periodSeconds: 30
+            httpGet:
+              path: /
+              port: 7433
           env:
             - name: ENV
               value: 'production'


### PR DESCRIPTION
#### What

Prod workers are not deploying due to a CrashBackoffLoop we saw in pre-prod. This was fixed by using the GEM.

#### Ticket

[Upgrade Ruby to version 3 in VCD](https://dsdmoj.atlassian.net/browse/AAC-263)

#### Why

#### How


