### PR TITLE
AAC-263 - Remove docker layer caching for deploying builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -279,7 +279,6 @@ jobs:
       - checkout
       - setup_remote_docker:
           version: 20.10.11
-          docker_layer_caching: true
       - *script-build-app-container
 
   deploy-dev:


### PR DESCRIPTION
#### What

The production build is complaining that it cannot find rails. I believe this is due to layer caching in the docker setup in circleci

#### Ticket

[Upgrade Ruby to version 3 in VCD](https://dsdmoj.atlassian.net/browse/AAC-263)

#### Why

#### How