### PR TITLE
AAC-263 - Downgrade docker version to 3.13

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.0.3-alpine
+FROM ruby:3.0.3-alpine3.13
 LABEL Organisation="Ministry of Justice"
 LABEL Team="LAA Get Paid"
 LABEL Contact="<laa-get-paid@digital.justice.gov.uk>"


### PR DESCRIPTION
#### What

Due to environmental issues it appears the latest version of the docker image is failing in production

#### Ticket

[Upgrade Ruby to version 3 in VCD](https://dsdmoj.atlassian.net/browse/AAC-263)

#### Why

#### How
