### PR TITLE
AAC-393 - Update ingress to split traffic 50/50

### DIFF
--- a/.k8s/live-1/production/ingress.yaml
+++ b/.k8s/live-1/production/ingress.yaml
@@ -10,7 +10,7 @@ metadata:
       SecRuleEngine On
       SecAction "id:900110,phase:1,nolog,pass,t:none,setvar:tx.inbound_anomaly_score_threshold=6"
     external-dns.alpha.kubernetes.io/set-identifier: laa-court-data-ui-app-ingress-laa-court-data-ui-production-blue
-    external-dns.alpha.kubernetes.io/aws-weight: "100"
+    external-dns.alpha.kubernetes.io/aws-weight: "50"
     nginx.ingress.kubernetes.io/server-snippet: |
         deny 223.178.211.9;
         deny 143.244.161.10;

--- a/.k8s/live/production/ingress.yaml
+++ b/.k8s/live/production/ingress.yaml
@@ -10,7 +10,7 @@ metadata:
       SecRuleEngine On
       SecAction "id:900110,phase:1,nolog,pass,t:none,setvar:tx.inbound_anomaly_score_threshold=6"
     external-dns.alpha.kubernetes.io/set-identifier: laa-court-data-ui-app-ingress-laa-court-data-ui-production-green
-    external-dns.alpha.kubernetes.io/aws-weight: "0"
+    external-dns.alpha.kubernetes.io/aws-weight: "50"
     nginx.ingress.kubernetes.io/server-snippet: |
         deny 223.178.211.9;
         deny 143.244.161.10;


### PR DESCRIPTION
#### What

As apart of our EKS migration, we need to do a split of traffic to ensure that everything is working as we expect. 

#### Ticket

[Migrate View Court Data Prod onto the Production EKS Implementation](https://dsdmoj.atlassian.net/browse/AAC-393)

#### Why

Mandatory EKS Migration
