### PR TITLE
AAC-162 Cypress Test Cookies and Login/Logout

### DIFF
--- a/app/views/cookies/_form.html.haml
+++ b/app/views/cookies/_form.html.haml
@@ -11,4 +11,4 @@
     legend: { text: t('cookie_settings.form.heading') },
     hint: { text: t('cookie_settings.form.hint') }
 
-  = f.govuk_submit t('cookie_settings.form.save_changes')
+  = f.govuk_submit(t('cookie_settings.form.save_changes'), 'data-cy': 'submit-cookies')

--- a/app/views/layouts/_cookie_banner.html.haml
+++ b/app/views/layouts/_cookie_banner.html.haml
@@ -35,5 +35,5 @@
               = @analytics_cookies_accepted ? t('layouts.application.cookies.confirmation_accept') : t('layouts.application.cookies.confirmation_reject') 
               = t('layouts.application.cookies.confirmation_link_to_settings_html', href: cookies_settings_path).html_safe
       .govuk-button-group
-        %a.govuk-button{'data-module': 'govuk-button', type: 'button', draggable: 'false', 'href': '?'}
+        %a.govuk-button{'data-module': 'govuk-button', type: 'button', draggable: 'false', 'href': '?', 'data-cy': 'hide_message'}
           = t('layouts.application.cookies.hide_message')

--- a/app/views/layouts/_cookie_banner.html.haml
+++ b/app/views/layouts/_cookie_banner.html.haml
@@ -12,13 +12,13 @@
               = t('layouts.application.cookies.analytics_cookies')
 
       .govuk-button-group.app-js-only
-        %a.govuk-button{'data-accept-cookies': 'true', 'data-module': 'govuk-button', name: 'cookies', type: 'button', value: 'accept',
+        %a.govuk-button{'data-accept-cookies': 'true', 'data-cy': 'accept_cookies', 'data-module': 'govuk-button', name: 'cookies', type: 'button', value: 'accept',
           'href': '?analytics_cookies_set=true&show_confirm_banner=true'}
           = t('layouts.application.cookies.accept_cookies')
-        %a.govuk-button{'data-reject-cookies': 'true', 'data-module': 'govuk-button', name: 'cookies', type: 'button', value: 'reject',
+        %a.govuk-button{'data-reject-cookies': 'true', 'data-cy': 'reject_cookies', 'data-module': 'govuk-button', name: 'cookies', type: 'button', value: 'reject',
           'href': '?analytics_cookies_set=false&show_confirm_banner=true'}
           = t('layouts.application.cookies.reject_cookies')
-        = link_to t('layouts.application.cookies.cookie_settings'), cookies_settings_path, class: 'govuk-link'
+        = link_to t('layouts.application.cookies.cookie_settings'), cookies_settings_path, class: 'govuk-link', 'data-cy': 'cookie_settings'
       .govuk-button-group.app-no-js-only
         %a.govuk-button{'data-reject-cookies': 'true', 'data-module': 'govuk-button', name: 'cookies', type: 'button', value: 'reject',
           'href': '?analytics_cookies_set=false'}

--- a/cypress.json
+++ b/cypress.json
@@ -1,4 +1,5 @@
 {
+  "blockHosts": ["*.google-analytics.com"],
   "baseUrl": "http://localhost:3000",
   "video": false
 }

--- a/cypress/config/develop.json
+++ b/cypress/config/develop.json
@@ -1,4 +1,5 @@
 {
+  "blockHosts": ["*.google-analytics.com"],
   "baseUrl": "https://dev.view-court-data.service.justice.gov.uk",
   "video": false
 }

--- a/cypress/config/staging.json
+++ b/cypress/config/staging.json
@@ -1,4 +1,5 @@
 {
+  "blockHosts": ["*.google-analytics.com"],
   "baseUrl": "https://staging.view-court-data.service.justice.gov.uk/",
   "video": false
 }

--- a/cypress/config/uat.json
+++ b/cypress/config/uat.json
@@ -1,4 +1,5 @@
 {
+  "blockHosts": ["*.google-analytics.com"],
   "baseUrl": "https://uat.view-court-data.service.justice.gov.uk",
   "video": false
 }

--- a/cypress/integration/index/cookie_banner.spec.js
+++ b/cypress/integration/index/cookie_banner.spec.js
@@ -4,34 +4,26 @@ describe('Cookie banner', () => {
     cy.checkBanner()
   })
 
-  context('logged in with javascript enabled', () => {
+  context('not logged in and javascript enabled', () => {
     beforeEach(() => {
       cy.visit('/')
-      cy.fixture('users').then((users) => {
-        cy.login(users[0].username, users[0].password)
-      })
     })
 
     const changeCookingSettings = 'Change your cookie settings'
-
-    it('displays search filters page', () => {
-      cy.get('.govuk-fieldset__legend').should(
-        'contain',
-        'Search for'
-      )
-    })
+    const rejectedAdditionalCookies = "You've rejected additional cookies"
+    const hideMessageText = 'Hide this message'
 
     it('can reject cookie preferences', () => {
       cy.getCookie('cookies_preferences_set').should('not.exist')
       cy.checkCookieValue('analytics_cookies_set', 'false')
       cy.get("[data-cy='reject_cookies']")
         .should('contain', 'Reject analytics cookies')
-        .should('have.attr', 'href').and('include', 'analytics_cookies_set=false&show_confirm_banner=true')
+        .and('have.attr', 'href').and('include', 'analytics_cookies_set=false&show_confirm_banner=true')
 
       cy.get(".app-js-only > [data-cy='reject_cookies']").click()
       cy.get('.govuk-cookie-banner__content > p').should(
         'contain',
-        "You've rejected additional cookies."
+        rejectedAdditionalCookies
       )
       cy.checkCookieValue('cookies_preferences_set', 'true')
       cy.checkCookieValue('analytics_cookies_set', 'false')
@@ -42,7 +34,7 @@ describe('Cookie banner', () => {
       cy.checkCookieValue('analytics_cookies_set', 'false')
       cy.get("[data-cy='accept_cookies']")
         .should('contain', 'Accept analytics cookies')
-        .should('have.attr', 'href').and('include', 'analytics_cookies_set=true&show_confirm_banner=true')
+        .and('have.attr', 'href').and('include', 'analytics_cookies_set=true&show_confirm_banner=true')
 
       cy.get("[data-cy='accept_cookies']").click()
       cy.get('.govuk-cookie-banner__content > p').should(
@@ -57,7 +49,7 @@ describe('Cookie banner', () => {
       beforeEach(() => {
         cy.get("[data-cy='accept_cookies']")
           .should('contain', 'Accept analytics cookies')
-          .should('have.attr', 'href').and('include', 'analytics_cookies_set=true&show_confirm_banner=true')
+          .and('have.attr', 'href').and('include', 'analytics_cookies_set=true&show_confirm_banner=true')
         cy.get("[data-cy='accept_cookies']").click()
       })
       const bannerMessageElement = '.govuk-cookie-banner__content > p'
@@ -67,8 +59,8 @@ describe('Cookie banner', () => {
         cy.get(`${bannerMessageElement}`)
           .should('contain', "You've accepted additional cookies")
         cy.get(`${hideMessageElement}`)
-          .should('contain', 'Hide this message')
-          .should('have.attr', 'href').and('include', '?')
+          .should('contain', hideMessageText)
+          .and('have.attr', 'href').and('include', '?')
 
         cy.get(`${hideMessageElement}`).click()
         cy.get(`${hideMessageElement}`).should('not.exist')
@@ -77,7 +69,7 @@ describe('Cookie banner', () => {
       it('can go to cookie settings from cookie banner', () => {
         cy.get(`${bannerMessageElement} > a`)
           .contains(changeCookingSettings, { matchCase: false })
-          .should('have.attr', 'href').and('include', '/cookies/settings')
+          .and('have.attr', 'href').and('include', '/cookies/settings')
         cy.get(`${bannerMessageElement} > a`).click()
         cy.get('.govuk-heading-xl').should('contain', changeCookingSettings)
       })
@@ -87,7 +79,7 @@ describe('Cookie banner', () => {
       beforeEach(() => {
         cy.get("[data-cy='reject_cookies']")
           .should('contain', 'Reject analytics cookies')
-          .should('have.attr', 'href').and('include', 'analytics_cookies_set=false&show_confirm_banner=true')
+          .and('have.attr', 'href').and('include', 'analytics_cookies_set=false&show_confirm_banner=true')
 
         cy.get("[data-cy='reject_cookies']").click()
       })
@@ -96,10 +88,10 @@ describe('Cookie banner', () => {
 
       it('can hide confirmation message', () => {
         cy.get(`${bannerMessageElement}`)
-          .should('contain', "You've rejected additional cookies")
+          .should('contain', rejectedAdditionalCookies)
         cy.get(`${hideMessageElement}`)
-          .should('contain', 'Hide this message')
-          .should('have.attr', 'href').and('include', '?')
+          .should('contain', hideMessageText)
+          .and('have.attr', 'href').and('include', '?')
 
         cy.get(`${hideMessageElement}`).click()
         cy.get(`${hideMessageElement}`).should('not.exist')
@@ -108,7 +100,7 @@ describe('Cookie banner', () => {
       it('can go to cookie settings from cookie banner', () => {
         cy.get(`${bannerMessageElement} > a`)
           .contains(changeCookingSettings, { matchCase: false })
-          .should('have.attr', 'href').and('include', '/cookies/settings')
+          .and('have.attr', 'href').and('include', '/cookies/settings')
         cy.get(`${bannerMessageElement} > a`).click()
         cy.get('.govuk-heading-xl').should('contain', changeCookingSettings)
       })
@@ -117,62 +109,13 @@ describe('Cookie banner', () => {
     it('can go to cookie settings', () => {
       cy.get("[data-cy='cookie_settings']")
         .should('contain', 'Cookie settings')
-        .should('have.attr', 'href').and('include', '/cookies/settings')
+        .and('have.attr', 'href').and('include', '/cookies/settings')
 
       cy.get(".app-js-only > [data-cy='cookie_settings']").click()
       cy.get('.govuk-heading-xl').should(
         'contain',
         changeCookingSettings
       )
-    })
-  })
-})
-
-describe('Cookie settings', () => {
-  beforeEach(() => {
-    cy.visit('/')
-    cy.get("[data-cy='cookie_settings']")
-      .should('contain', 'Cookie settings')
-      .should('have.attr', 'href').and('include', '/cookies/settings')
-
-    cy.get(".app-js-only > [data-cy='cookie_settings']").click()
-  })
-
-  const successfullySetCookies = "You've set your cookie preferences."
-
-  context('Cookies storing is set as false', () => {
-    beforeEach(() => {
-      cy.getCookie('cookies_preferences_set').should('not.exist')
-      cy.checkCookieValue('analytics_cookies_set', 'false')
-
-      cy.get(".app-js-only > [data-cy='cookie_settings']").click()
-    })
-
-    it('can change cookie settings', () => {
-      cy.get('input#cookie-analytics-true-field').should('have.value', 'true')
-      cy.get('input#cookie-analytics-true-field').check()
-      cy.get("[data-cy='submit-cookies']").click()
-      cy.get('.govuk-notification-banner__heading').should('contain', successfullySetCookies)
-      cy.checkCookieValue('cookies_preferences_set', 'true')
-      cy.checkCookieValue('analytics_cookies_set', 'true')
-    })
-  })
-
-  context('Cookies storing is set as true', () => {
-    beforeEach(() => {
-      cy.visit('/')
-      cy.get(".app-js-only > [data-cy='cookie_settings']").click()
-      cy.setCookie('cookies_preferences_set', 'true')
-      cy.setCookie('analytics_cookies_set', 'true')
-    })
-
-    it('can change cookie settings', () => {
-      cy.get('input#cookie-analytics-false-field').should('have.value', 'false')
-      cy.get('input#cookie-analytics-false-field').check()
-      cy.get("[data-cy='submit-cookies']").click()
-      cy.get('.govuk-notification-banner__heading').should('contain', successfullySetCookies)
-      cy.checkCookieValue('cookies_preferences_set', 'true')
-      cy.checkCookieValue('analytics_cookies_set', 'false')
     })
   })
 })

--- a/cypress/integration/index/cookie_banner.spec.js
+++ b/cypress/integration/index/cookie_banner.spec.js
@@ -20,7 +20,7 @@ describe('Cookie banner', () => {
         .should('contain', 'Reject analytics cookies')
         .and('have.attr', 'href').and('include', 'analytics_cookies_set=false&show_confirm_banner=true')
 
-      cy.get(".app-js-only > [data-cy='reject_cookies']").click()
+      cy.get("[data-cy='reject_cookies']").click()
       cy.get('.govuk-cookie-banner__content > p').should(
         'contain',
         rejectedAdditionalCookies
@@ -56,14 +56,14 @@ describe('Cookie banner', () => {
       const hideMessageElement = "[data-cy='hide_message']"
 
       it('can hide confirmation message', () => {
-        cy.get(`${bannerMessageElement}`)
+        cy.get(bannerMessageElement)
           .should('contain', "You've accepted additional cookies")
-        cy.get(`${hideMessageElement}`)
+        cy.get(hideMessageElement)
           .should('contain', hideMessageText)
           .and('have.attr', 'href').and('include', '?')
 
-        cy.get(`${hideMessageElement}`).click()
-        cy.get(`${hideMessageElement}`).should('not.exist')
+        cy.get(hideMessageElement).click()
+        cy.get(hideMessageElement).should('not.exist')
       })
 
       it('can go to cookie settings from cookie banner', () => {
@@ -87,14 +87,14 @@ describe('Cookie banner', () => {
       const hideMessageElement = "[data-cy='hide_message']"
 
       it('can hide confirmation message', () => {
-        cy.get(`${bannerMessageElement}`)
+        cy.get(bannerMessageElement)
           .should('contain', rejectedAdditionalCookies)
-        cy.get(`${hideMessageElement}`)
+        cy.get(hideMessageElement)
           .should('contain', hideMessageText)
           .and('have.attr', 'href').and('include', '?')
 
-        cy.get(`${hideMessageElement}`).click()
-        cy.get(`${hideMessageElement}`).should('not.exist')
+        cy.get(hideMessageElement).click()
+        cy.get(hideMessageElement).should('not.exist')
       })
 
       it('can go to cookie settings from cookie banner', () => {
@@ -111,7 +111,7 @@ describe('Cookie banner', () => {
         .should('contain', 'Cookie settings')
         .and('have.attr', 'href').and('include', '/cookies/settings')
 
-      cy.get(".app-js-only > [data-cy='cookie_settings']").click()
+      cy.get("[data-cy='cookie_settings']").click()
       cy.get('.govuk-heading-xl').should(
         'contain',
         changeCookingSettings

--- a/cypress/integration/index/cookie_banner.spec.js
+++ b/cypress/integration/index/cookie_banner.spec.js
@@ -4,6 +4,8 @@ describe('Cookie banner', () => {
     cy.checkEnvBanner()
   })
 
+  const bannerMessageElement = '.govuk-cookie-banner__content > p'
+
   context('not logged in and javascript enabled', () => {
     beforeEach(() => {
       cy.visit('/')
@@ -52,18 +54,16 @@ describe('Cookie banner', () => {
           .and('have.attr', 'href').and('include', 'analytics_cookies_set=true&show_confirm_banner=true')
         cy.get("[data-cy='accept_cookies']").click()
       })
-      const bannerMessageElement = '.govuk-cookie-banner__content > p'
-      const hideMessageElement = "[data-cy='hide_message']"
 
       it('can hide confirmation message', () => {
         cy.get(bannerMessageElement)
           .should('contain', "You've accepted additional cookies")
-        cy.get(hideMessageElement)
+        cy.get("[data-cy='hide_message']")
           .should('contain', hideMessageText)
           .and('have.attr', 'href').and('include', '?')
 
-        cy.get(hideMessageElement).click()
-        cy.get(hideMessageElement).should('not.exist')
+        cy.get("[data-cy='hide_message']").click()
+        cy.get("[data-cy='hide_message']").should('not.exist')
       })
 
       it('can go to cookie settings from cookie banner', () => {
@@ -83,18 +83,16 @@ describe('Cookie banner', () => {
 
         cy.get("[data-cy='reject_cookies']").click()
       })
-      const bannerMessageElement = '.govuk-cookie-banner__content > p'
-      const hideMessageElement = "[data-cy='hide_message']"
 
       it('can hide confirmation message', () => {
         cy.get(bannerMessageElement)
           .should('contain', rejectedAdditionalCookies)
-        cy.get(hideMessageElement)
+        cy.get("[data-cy='hide_message']")
           .should('contain', hideMessageText)
           .and('have.attr', 'href').and('include', '?')
 
-        cy.get(hideMessageElement).click()
-        cy.get(hideMessageElement).should('not.exist')
+        cy.get("[data-cy='hide_message']").click()
+        cy.get("[data-cy='hide_message']").should('not.exist')
       })
 
       it('can go to cookie settings from cookie banner', () => {

--- a/cypress/integration/index/cookie_banner.spec.js
+++ b/cypress/integration/index/cookie_banner.spec.js
@@ -1,7 +1,7 @@
 describe('Cookie banner', () => {
   before(() => {
     cy.visit('/')
-    cy.checkBanner()
+    cy.checkEnvBanner()
   })
 
   context('not logged in and javascript enabled', () => {

--- a/cypress/integration/index/cookie_settings.spec.js
+++ b/cypress/integration/index/cookie_settings.spec.js
@@ -6,7 +6,7 @@ describe('Cookie settings page', () => {
         .should('contain', 'Cookie settings')
         .should('have.attr', 'href').and('include', '/cookies/settings')
 
-      cy.get(".app-js-only > [data-cy='cookie_settings']").click()
+      cy.get("[data-cy='cookie_settings']").click()
     })
 
     const successfullySetCookies = "You've set your cookie preferences."
@@ -16,7 +16,7 @@ describe('Cookie settings page', () => {
         cy.getCookie('cookies_preferences_set').should('not.exist')
         cy.checkCookieValue('analytics_cookies_set', 'false')
 
-        cy.get(".app-js-only > [data-cy='cookie_settings']").click()
+        cy.get("[data-cy='cookie_settings']").click()
       })
 
       it('can change cookie settings', () => {
@@ -32,7 +32,7 @@ describe('Cookie settings page', () => {
     context('Cookies storing is set as true', () => {
       beforeEach(() => {
         cy.visit('/')
-        cy.get(".app-js-only > [data-cy='cookie_settings']").click()
+        cy.get("[data-cy='cookie_settings']").click()
         cy.setCookie('cookies_preferences_set', 'true')
         cy.setCookie('analytics_cookies_set', 'true')
       })

--- a/cypress/integration/index/cookie_settings.spec.js
+++ b/cypress/integration/index/cookie_settings.spec.js
@@ -1,0 +1,50 @@
+describe('Cookie settings page', () => {
+  context('not logged in and javascript enabled', () => {
+    beforeEach(() => {
+      cy.visit('/')
+      cy.get("[data-cy='cookie_settings']")
+        .should('contain', 'Cookie settings')
+        .should('have.attr', 'href').and('include', '/cookies/settings')
+
+      cy.get(".app-js-only > [data-cy='cookie_settings']").click()
+    })
+
+    const successfullySetCookies = "You've set your cookie preferences."
+
+    context('Cookies storing is set as false', () => {
+      beforeEach(() => {
+        cy.getCookie('cookies_preferences_set').should('not.exist')
+        cy.checkCookieValue('analytics_cookies_set', 'false')
+
+        cy.get(".app-js-only > [data-cy='cookie_settings']").click()
+      })
+
+      it('can change cookie settings', () => {
+        cy.get('input#cookie-analytics-true-field').should('have.value', 'true')
+        cy.get('input#cookie-analytics-true-field').check()
+        cy.get("[data-cy='submit-cookies']").click()
+        cy.get('.govuk-notification-banner__heading').should('contain', successfullySetCookies)
+        cy.checkCookieValue('cookies_preferences_set', 'true')
+        cy.checkCookieValue('analytics_cookies_set', 'true')
+      })
+    })
+
+    context('Cookies storing is set as true', () => {
+      beforeEach(() => {
+        cy.visit('/')
+        cy.get(".app-js-only > [data-cy='cookie_settings']").click()
+        cy.setCookie('cookies_preferences_set', 'true')
+        cy.setCookie('analytics_cookies_set', 'true')
+      })
+
+      it('can change cookie settings', () => {
+        cy.get('input#cookie-analytics-false-field').should('have.value', 'false')
+        cy.get('input#cookie-analytics-false-field').check()
+        cy.get("[data-cy='submit-cookies']").click()
+        cy.get('.govuk-notification-banner__heading').should('contain', successfullySetCookies)
+        cy.checkCookieValue('cookies_preferences_set', 'true')
+        cy.checkCookieValue('analytics_cookies_set', 'false')
+      })
+    })
+  })
+})

--- a/cypress/integration/index/cookie_settings.spec.js
+++ b/cypress/integration/index/cookie_settings.spec.js
@@ -1,4 +1,7 @@
+
 describe('Cookie settings page', () => {
+  const successfullySetCookies = "You've set your cookie preferences."
+
   context('not logged in and javascript enabled', () => {
     beforeEach(() => {
       cy.visit('/')
@@ -8,8 +11,6 @@ describe('Cookie settings page', () => {
 
       cy.get("[data-cy='cookie_settings']").click()
     })
-
-    const successfullySetCookies = "You've set your cookie preferences."
 
     context('Cookies storing is set as false', () => {
       beforeEach(() => {

--- a/cypress/integration/index/cookies.spec.js
+++ b/cypress/integration/index/cookies.spec.js
@@ -1,0 +1,85 @@
+describe("Cookie banner", () => {
+    before(() => {
+      cy.visit("/");
+      cy.checkBanner();
+    });
+
+    context('logged in with javascript enabled', () => {
+      beforeEach(() => {
+				cy.visit("/");
+				cy.fixture("users").then((users) => {
+					cy.login(users[0].username, users[0].password);
+				});
+      });
+
+      it('displays search filters page', () => {
+        cy.get(".govuk-fieldset__legend").should(
+            "contain",
+            "Search for"
+        );
+      });
+
+      it('can accept cookie preferences', () => {
+        cy.get('[data-accept-cookies="true"]')
+						.should("contain", "Accept analytics cookies")
+            .should('have.attr', 'href').and('include', "analytics_cookies_set=true&show_confirm_banner=true");
+
+        cy.get('[data-accept-cookies="true"]').click();
+        cy.get('.govuk-cookie-banner__content > p').should(
+            "contain",
+            "You've accepted additional cookies."
+        );
+      });
+
+      it('can reject cookie preferences', () => {
+        cy.get('[data-reject-cookies="true"]')
+						.should("contain", "Reject analytics cookies")
+            .should('have.attr', 'href').and('include', "analytics_cookies_set=false&show_confirm_banner=true");
+
+        cy.get('.app-js-only > [data-reject-cookies="true"]').click();
+        cy.get('.govuk-cookie-banner__content > p').should(
+            "contain",
+            "You've rejected additional cookies."
+        );
+      });
+
+			it('can go to cookie settings', () => {
+				cy.get('.govuk-link')
+				.should("contain", "Cookie settings")
+				.should('have.attr', 'href').and('include', "/cookies/settings");
+
+				cy.get('.app-js-only > .govuk-link').click();
+        cy.get('.govuk-heading-xl').should(
+            "contain",
+            "Change your cookie settings"
+        );
+			});
+  });
+});
+
+describe("Cookie settings", () => {
+	before(() => {
+		cy.visit("/");
+		cy.get('.govuk-link')
+		.should("contain", "Cookie settings")
+		.should('have.attr', 'href').and('include', "/cookies/settings");
+
+		cy.get('.app-js-only > .govuk-link').click();
+	});
+
+
+	it('can update cookie settings', () => {
+		cy.get('input#cookie-analytics-true-field')
+		.should("have.value", "true");
+
+		cy.get('input#cookie-analytics-true-field').check();
+		Cypress.on('uncaught:exception', (err, runnable) => {
+			// returning false here prevents Cypress from
+			// failing the test due to TypeError: Illegal Invocation in Rails ujs nodemodule
+			return false
+		});
+	
+		cy.get('form.app-js-only#new_cookie').submit();
+		
+	});
+});

--- a/cypress/integration/index/cookies.spec.js
+++ b/cypress/integration/index/cookies.spec.js
@@ -1,85 +1,82 @@
-describe("Cookie banner", () => {
-    before(() => {
-      cy.visit("/");
-      cy.checkBanner();
-    });
+describe('Cookie banner', () => {
+  before(() => {
+    cy.visit('/')
+    cy.checkBanner()
+  })
 
-    context('logged in with javascript enabled', () => {
-      beforeEach(() => {
-				cy.visit("/");
-				cy.fixture("users").then((users) => {
-					cy.login(users[0].username, users[0].password);
-				});
-      });
+  context('logged in with javascript enabled', () => {
+    beforeEach(() => {
+      cy.visit('/')
+      cy.fixture('users').then((users) => {
+        cy.login(users[0].username, users[0].password)
+      })
+    })
 
-      it('displays search filters page', () => {
-        cy.get(".govuk-fieldset__legend").should(
-            "contain",
-            "Search for"
-        );
-      });
+    it('displays search filters page', () => {
+      cy.get('.govuk-fieldset__legend').should(
+        'contain',
+        'Search for'
+      )
+    })
 
-      it('can accept cookie preferences', () => {
-        cy.get('[data-accept-cookies="true"]')
-						.should("contain", "Accept analytics cookies")
-            .should('have.attr', 'href').and('include', "analytics_cookies_set=true&show_confirm_banner=true");
+    it('can accept cookie preferences', () => {
+      cy.get('[data-accept-cookies="true"]')
+        .should('contain', 'Accept analytics cookies')
+        .should('have.attr', 'href').and('include', 'analytics_cookies_set=true&show_confirm_banner=true')
 
-        cy.get('[data-accept-cookies="true"]').click();
-        cy.get('.govuk-cookie-banner__content > p').should(
-            "contain",
-            "You've accepted additional cookies."
-        );
-      });
+      cy.get('[data-accept-cookies="true"]').click()
+      cy.get('.govuk-cookie-banner__content > p').should(
+        'contain',
+        "You've accepted additional cookies."
+      )
+    })
 
-      it('can reject cookie preferences', () => {
-        cy.get('[data-reject-cookies="true"]')
-						.should("contain", "Reject analytics cookies")
-            .should('have.attr', 'href').and('include', "analytics_cookies_set=false&show_confirm_banner=true");
+    it('can reject cookie preferences', () => {
+      cy.get('[data-reject-cookies="true"]')
+        .should('contain', 'Reject analytics cookies')
+        .should('have.attr', 'href').and('include', 'analytics_cookies_set=false&show_confirm_banner=true')
 
-        cy.get('.app-js-only > [data-reject-cookies="true"]').click();
-        cy.get('.govuk-cookie-banner__content > p').should(
-            "contain",
-            "You've rejected additional cookies."
-        );
-      });
+      cy.get('.app-js-only > [data-reject-cookies="true"]').click()
+      cy.get('.govuk-cookie-banner__content > p').should(
+        'contain',
+        "You've rejected additional cookies."
+      )
+    })
 
-			it('can go to cookie settings', () => {
-				cy.get('.govuk-link')
-				.should("contain", "Cookie settings")
-				.should('have.attr', 'href').and('include', "/cookies/settings");
+    it('can go to cookie settings', () => {
+      cy.get('.govuk-link')
+        .should('contain', 'Cookie settings')
+        .should('have.attr', 'href').and('include', '/cookies/settings')
 
-				cy.get('.app-js-only > .govuk-link').click();
-        cy.get('.govuk-heading-xl').should(
-            "contain",
-            "Change your cookie settings"
-        );
-			});
-  });
-});
+      cy.get('.app-js-only > .govuk-link').click()
+      cy.get('.govuk-heading-xl').should(
+        'contain',
+        'Change your cookie settings'
+      )
+    })
+  })
+})
 
-describe("Cookie settings", () => {
-	before(() => {
-		cy.visit("/");
-		cy.get('.govuk-link')
-		.should("contain", "Cookie settings")
-		.should('have.attr', 'href').and('include', "/cookies/settings");
+describe('Cookie settings', () => {
+  before(() => {
+    cy.visit('/')
+    cy.get('.govuk-link')
+      .should('contain', 'Cookie settings')
+      .should('have.attr', 'href').and('include', '/cookies/settings')
 
-		cy.get('.app-js-only > .govuk-link').click();
-	});
+    cy.get('.app-js-only > .govuk-link').click()
+  })
 
+  it('can update cookie settings', () => {
+    cy.get('input#cookie-analytics-true-field').should('have.value', 'true')
+    cy.get('input#cookie-analytics-true-field').check()
 
-	it('can update cookie settings', () => {
-		cy.get('input#cookie-analytics-true-field')
-		.should("have.value", "true");
-
-		cy.get('input#cookie-analytics-true-field').check();
-		Cypress.on('uncaught:exception', (err, runnable) => {
-			// returning false here prevents Cypress from
-			// failing the test due to TypeError: Illegal Invocation in Rails ujs nodemodule
-			return false
-		});
-	
-		cy.get('form.app-js-only#new_cookie').submit();
-		
-	});
-});
+    Cypress.on('uncaught:exception', (_err, runnable) => {
+      // returning false here prevents Cypress from
+      // failing the test due to TypeError: Illegal Invocation in Rails ujs nodemodule
+      return false
+    })
+    cy.get('input#cookie-analytics-true-field').check()
+    cy.get('form.app-js-only#new_cookie').submit()
+  })
+})

--- a/cypress/integration/index/cookies.spec.js
+++ b/cypress/integration/index/cookies.spec.js
@@ -31,6 +31,37 @@ describe('Cookie banner', () => {
       )
     })
 
+    context('cookies accepted', () => {
+      beforeEach(() => {
+        cy.get("[data-cy='accept_cookies']")
+          .should('contain', 'Accept analytics cookies')
+          .should('have.attr', 'href').and('include', 'analytics_cookies_set=true&show_confirm_banner=true')
+
+        cy.get("[data-cy='accept_cookies']").click()
+      })
+      const bannerMessageElement = '.govuk-cookie-banner__content > p'
+      const hideMessageElement = "[data-cy='hide_message']"
+
+      it('can hide confirmation message', () => {
+        cy.get(`${bannerMessageElement}`)
+          .should('contain', "You've accepted additional cookies")
+        cy.get(`${hideMessageElement}`)
+          .should('contain', 'Hide this message')
+          .should('have.attr', 'href').and('include', '?')
+
+        cy.get(`${hideMessageElement}`).click()
+        cy.get(`${hideMessageElement}`).should('not.exist')
+      })
+
+      it('can go to cookie settings from cookie banner', () => {
+        cy.get(`${bannerMessageElement} > a`)
+          .should('contain', 'change your cookie settings')
+          .should('have.attr', 'href').and('include', '/cookies/settings')
+        cy.get(`${bannerMessageElement} > a`).click()
+        cy.get('.govuk-heading-xl').should('contain', 'Change your cookie settings')
+      })
+    })
+
     it('can reject cookie preferences', () => {
       cy.get("[data-cy='reject_cookies']")
         .should('contain', 'Reject analytics cookies')
@@ -72,5 +103,6 @@ describe('Cookie settings', () => {
     cy.get('input#cookie-analytics-true-field').check()
 
     cy.get("[data-cy='submit-cookies']").click()
+    cy.get('.govuk-notification-banner__heading').should('contain', "You've set your cookie preferences.")
   })
 })

--- a/cypress/integration/index/cookies.spec.js
+++ b/cypress/integration/index/cookies.spec.js
@@ -12,6 +12,8 @@ describe('Cookie banner', () => {
       })
     })
 
+    const changeCookingSettings = 'Change your cookie settings'
+
     it('displays search filters page', () => {
       cy.get('.govuk-fieldset__legend').should(
         'contain',
@@ -74,10 +76,10 @@ describe('Cookie banner', () => {
 
       it('can go to cookie settings from cookie banner', () => {
         cy.get(`${bannerMessageElement} > a`)
-          .should('contain', 'change your cookie settings')
+          .contains(changeCookingSettings, { matchCase: false })
           .should('have.attr', 'href').and('include', '/cookies/settings')
         cy.get(`${bannerMessageElement} > a`).click()
-        cy.get('.govuk-heading-xl').should('contain', 'Change your cookie settings')
+        cy.get('.govuk-heading-xl').should('contain', changeCookingSettings)
       })
     })
 
@@ -105,10 +107,10 @@ describe('Cookie banner', () => {
 
       it('can go to cookie settings from cookie banner', () => {
         cy.get(`${bannerMessageElement} > a`)
-          .should('contain', 'change your cookie settings')
+          .contains(changeCookingSettings, { matchCase: false })
           .should('have.attr', 'href').and('include', '/cookies/settings')
         cy.get(`${bannerMessageElement} > a`).click()
-        cy.get('.govuk-heading-xl').should('contain', 'Change your cookie settings')
+        cy.get('.govuk-heading-xl').should('contain', changeCookingSettings)
       })
     })
 
@@ -120,7 +122,7 @@ describe('Cookie banner', () => {
       cy.get(".app-js-only > [data-cy='cookie_settings']").click()
       cy.get('.govuk-heading-xl').should(
         'contain',
-        'Change your cookie settings'
+        changeCookingSettings
       )
     })
   })
@@ -136,6 +138,8 @@ describe('Cookie settings', () => {
     cy.get(".app-js-only > [data-cy='cookie_settings']").click()
   })
 
+  const successfullySetCookies = "You've set your cookie preferences."
+
   context('Cookies storing is set as false', () => {
     beforeEach(() => {
       cy.getCookie('cookies_preferences_set').should('not.exist')
@@ -148,7 +152,7 @@ describe('Cookie settings', () => {
       cy.get('input#cookie-analytics-true-field').should('have.value', 'true')
       cy.get('input#cookie-analytics-true-field').check()
       cy.get("[data-cy='submit-cookies']").click()
-      cy.get('.govuk-notification-banner__heading').should('contain', "You've set your cookie preferences.")
+      cy.get('.govuk-notification-banner__heading').should('contain', successfullySetCookies)
       cy.checkCookieValue('cookies_preferences_set', 'true')
       cy.checkCookieValue('analytics_cookies_set', 'true')
     })
@@ -166,7 +170,7 @@ describe('Cookie settings', () => {
       cy.get('input#cookie-analytics-false-field').should('have.value', 'false')
       cy.get('input#cookie-analytics-false-field').check()
       cy.get("[data-cy='submit-cookies']").click()
-      cy.get('.govuk-notification-banner__heading').should('contain', "You've set your cookie preferences.")
+      cy.get('.govuk-notification-banner__heading').should('contain', successfullySetCookies)
       cy.checkCookieValue('cookies_preferences_set', 'true')
       cy.checkCookieValue('analytics_cookies_set', 'false')
     })

--- a/cypress/integration/index/cookies.spec.js
+++ b/cypress/integration/index/cookies.spec.js
@@ -20,6 +20,7 @@ describe('Cookie banner', () => {
     })
 
     it('can reject cookie preferences', () => {
+      cy.getCookie('cookies_preferences_set').should('not.exist')
       cy.checkCookieValue('analytics_cookies_set', 'false')
       cy.get("[data-cy='reject_cookies']")
         .should('contain', 'Reject analytics cookies')
@@ -30,12 +31,12 @@ describe('Cookie banner', () => {
         'contain',
         "You've rejected additional cookies."
       )
-      cy.getCookie('cookes_prefernces_set').should('not.exist')
+      cy.checkCookieValue('cookies_preferences_set', 'true')
       cy.checkCookieValue('analytics_cookies_set', 'false')
     })
 
     it('can accept cookie preferences', () => {
-      cy.getCookie('cookes_prefernces_set').should('not.exist')
+      cy.getCookie('cookies_preferences_set').should('not.exist')
       cy.checkCookieValue('analytics_cookies_set', 'false')
       cy.get("[data-cy='accept_cookies']")
         .should('contain', 'Accept analytics cookies')
@@ -136,11 +137,11 @@ describe('Cookie settings', () => {
   })
 
   context('Cookies storing is set as false', () => {
-
     beforeEach(() => {
+      cy.getCookie('cookies_preferences_set').should('not.exist')
+      cy.checkCookieValue('analytics_cookies_set', 'false')
+
       cy.get(".app-js-only > [data-cy='cookie_settings']").click()
-      cy.setCookie('cookies_preferences_set', 'false')
-      cy.setCookie('analytics_cookies_set', 'false')
     })
 
     it('can change cookie settings', () => {

--- a/cypress/integration/index/cookies.spec.js
+++ b/cypress/integration/index/cookies.spec.js
@@ -20,11 +20,11 @@ describe('Cookie banner', () => {
     })
 
     it('can accept cookie preferences', () => {
-      cy.get('[data-accept-cookies="true"]')
+      cy.get("[data-cy='accept_cookies']")
         .should('contain', 'Accept analytics cookies')
         .should('have.attr', 'href').and('include', 'analytics_cookies_set=true&show_confirm_banner=true')
 
-      cy.get('[data-accept-cookies="true"]').click()
+      cy.get("[data-cy='accept_cookies']").click()
       cy.get('.govuk-cookie-banner__content > p').should(
         'contain',
         "You've accepted additional cookies."
@@ -32,11 +32,11 @@ describe('Cookie banner', () => {
     })
 
     it('can reject cookie preferences', () => {
-      cy.get('[data-reject-cookies="true"]')
+      cy.get("[data-cy='reject_cookies']")
         .should('contain', 'Reject analytics cookies')
         .should('have.attr', 'href').and('include', 'analytics_cookies_set=false&show_confirm_banner=true')
 
-      cy.get('.app-js-only > [data-reject-cookies="true"]').click()
+      cy.get(".app-js-only > [data-cy='reject_cookies']").click()
       cy.get('.govuk-cookie-banner__content > p').should(
         'contain',
         "You've rejected additional cookies."
@@ -44,11 +44,11 @@ describe('Cookie banner', () => {
     })
 
     it('can go to cookie settings', () => {
-      cy.get('.govuk-link')
+      cy.get("[data-cy='cookie_settings']")
         .should('contain', 'Cookie settings')
         .should('have.attr', 'href').and('include', '/cookies/settings')
 
-      cy.get('.app-js-only > .govuk-link').click()
+      cy.get(".app-js-only > [data-cy='cookie_settings']").click()
       cy.get('.govuk-heading-xl').should(
         'contain',
         'Change your cookie settings'
@@ -60,23 +60,17 @@ describe('Cookie banner', () => {
 describe('Cookie settings', () => {
   before(() => {
     cy.visit('/')
-    cy.get('.govuk-link')
+    cy.get("[data-cy='cookie_settings']")
       .should('contain', 'Cookie settings')
       .should('have.attr', 'href').and('include', '/cookies/settings')
 
-    cy.get('.app-js-only > .govuk-link').click()
+    cy.get(".app-js-only > [data-cy='cookie_settings']").click()
   })
 
-  it('can update cookie settings', () => {
+  it('can submit updated cookie settings', () => {
     cy.get('input#cookie-analytics-true-field').should('have.value', 'true')
     cy.get('input#cookie-analytics-true-field').check()
 
-    Cypress.on('uncaught:exception', (_err, runnable) => {
-      // returning false here prevents Cypress from
-      // failing the test due to TypeError: Illegal Invocation in Rails ujs nodemodule
-      return false
-    })
-    cy.get('input#cookie-analytics-true-field').check()
-    cy.get('form.app-js-only#new_cookie').submit()
+    cy.get("[data-cy='submit-cookies']").click()
   })
 })

--- a/cypress/integration/index/cookies.spec.js
+++ b/cypress/integration/index/cookies.spec.js
@@ -19,7 +19,24 @@ describe('Cookie banner', () => {
       )
     })
 
+    it('can reject cookie preferences', () => {
+      cy.checkCookieValue('analytics_cookies_set', 'false')
+      cy.get("[data-cy='reject_cookies']")
+        .should('contain', 'Reject analytics cookies')
+        .should('have.attr', 'href').and('include', 'analytics_cookies_set=false&show_confirm_banner=true')
+
+      cy.get(".app-js-only > [data-cy='reject_cookies']").click()
+      cy.get('.govuk-cookie-banner__content > p').should(
+        'contain',
+        "You've rejected additional cookies."
+      )
+      cy.getCookie('cookes_prefernces_set').should('not.exist')
+      cy.checkCookieValue('analytics_cookies_set', 'false')
+    })
+
     it('can accept cookie preferences', () => {
+      cy.getCookie('cookes_prefernces_set').should('not.exist')
+      cy.checkCookieValue('analytics_cookies_set', 'false')
       cy.get("[data-cy='accept_cookies']")
         .should('contain', 'Accept analytics cookies')
         .should('have.attr', 'href').and('include', 'analytics_cookies_set=true&show_confirm_banner=true')
@@ -29,6 +46,8 @@ describe('Cookie banner', () => {
         'contain',
         "You've accepted additional cookies."
       )
+      cy.checkCookieValue('cookies_preferences_set', 'true')
+      cy.checkCookieValue('analytics_cookies_set', 'true')
     })
 
     context('cookies accepted', () => {
@@ -36,7 +55,6 @@ describe('Cookie banner', () => {
         cy.get("[data-cy='accept_cookies']")
           .should('contain', 'Accept analytics cookies')
           .should('have.attr', 'href').and('include', 'analytics_cookies_set=true&show_confirm_banner=true')
-
         cy.get("[data-cy='accept_cookies']").click()
       })
       const bannerMessageElement = '.govuk-cookie-banner__content > p'
@@ -62,16 +80,35 @@ describe('Cookie banner', () => {
       })
     })
 
-    it('can reject cookie preferences', () => {
-      cy.get("[data-cy='reject_cookies']")
-        .should('contain', 'Reject analytics cookies')
-        .should('have.attr', 'href').and('include', 'analytics_cookies_set=false&show_confirm_banner=true')
+    context('cookies rejected', () => {
+      beforeEach(() => {
+        cy.get("[data-cy='reject_cookies']")
+          .should('contain', 'Reject analytics cookies')
+          .should('have.attr', 'href').and('include', 'analytics_cookies_set=false&show_confirm_banner=true')
 
-      cy.get(".app-js-only > [data-cy='reject_cookies']").click()
-      cy.get('.govuk-cookie-banner__content > p').should(
-        'contain',
-        "You've rejected additional cookies."
-      )
+        cy.get("[data-cy='reject_cookies']").click()
+      })
+      const bannerMessageElement = '.govuk-cookie-banner__content > p'
+      const hideMessageElement = "[data-cy='hide_message']"
+
+      it('can hide confirmation message', () => {
+        cy.get(`${bannerMessageElement}`)
+          .should('contain', "You've rejected additional cookies")
+        cy.get(`${hideMessageElement}`)
+          .should('contain', 'Hide this message')
+          .should('have.attr', 'href').and('include', '?')
+
+        cy.get(`${hideMessageElement}`).click()
+        cy.get(`${hideMessageElement}`).should('not.exist')
+      })
+
+      it('can go to cookie settings from cookie banner', () => {
+        cy.get(`${bannerMessageElement} > a`)
+          .should('contain', 'change your cookie settings')
+          .should('have.attr', 'href').and('include', '/cookies/settings')
+        cy.get(`${bannerMessageElement} > a`).click()
+        cy.get('.govuk-heading-xl').should('contain', 'Change your cookie settings')
+      })
     })
 
     it('can go to cookie settings', () => {
@@ -89,7 +126,7 @@ describe('Cookie banner', () => {
 })
 
 describe('Cookie settings', () => {
-  before(() => {
+  beforeEach(() => {
     cy.visit('/')
     cy.get("[data-cy='cookie_settings']")
       .should('contain', 'Cookie settings')
@@ -98,11 +135,39 @@ describe('Cookie settings', () => {
     cy.get(".app-js-only > [data-cy='cookie_settings']").click()
   })
 
-  it('can submit updated cookie settings', () => {
-    cy.get('input#cookie-analytics-true-field').should('have.value', 'true')
-    cy.get('input#cookie-analytics-true-field').check()
+  context('Cookies storing is set as false', () => {
 
-    cy.get("[data-cy='submit-cookies']").click()
-    cy.get('.govuk-notification-banner__heading').should('contain', "You've set your cookie preferences.")
+    beforeEach(() => {
+      cy.get(".app-js-only > [data-cy='cookie_settings']").click()
+      cy.setCookie('cookies_preferences_set', 'false')
+      cy.setCookie('analytics_cookies_set', 'false')
+    })
+
+    it('can change cookie settings', () => {
+      cy.get('input#cookie-analytics-true-field').should('have.value', 'true')
+      cy.get('input#cookie-analytics-true-field').check()
+      cy.get("[data-cy='submit-cookies']").click()
+      cy.get('.govuk-notification-banner__heading').should('contain', "You've set your cookie preferences.")
+      cy.checkCookieValue('cookies_preferences_set', 'true')
+      cy.checkCookieValue('analytics_cookies_set', 'true')
+    })
+  })
+
+  context('Cookies storing is set as true', () => {
+    beforeEach(() => {
+      cy.visit('/')
+      cy.get(".app-js-only > [data-cy='cookie_settings']").click()
+      cy.setCookie('cookies_preferences_set', 'true')
+      cy.setCookie('analytics_cookies_set', 'true')
+    })
+
+    it('can change cookie settings', () => {
+      cy.get('input#cookie-analytics-false-field').should('have.value', 'false')
+      cy.get('input#cookie-analytics-false-field').check()
+      cy.get("[data-cy='submit-cookies']").click()
+      cy.get('.govuk-notification-banner__heading').should('contain', "You've set your cookie preferences.")
+      cy.checkCookieValue('cookies_preferences_set', 'true')
+      cy.checkCookieValue('analytics_cookies_set', 'false')
+    })
   })
 })

--- a/cypress/integration/index/sign_in.spec.js
+++ b/cypress/integration/index/sign_in.spec.js
@@ -1,7 +1,7 @@
 describe('User Login Page', () => {
   before(() => {
     cy.visit('/')
-    cy.checkBanner()
+    cy.checkEnvBanner()
   })
 
   beforeEach(() => {

--- a/cypress/integration/index/sign_in.spec.js
+++ b/cypress/integration/index/sign_in.spec.js
@@ -36,7 +36,7 @@ describe("User Login Page", () => {
   });
 
   it("can log in with valid credentials after an invalid attempt", () => {
-    cy.login("someone", "some-password");
+    cy.login("invalid-username", "invalid-password");
     cy.get(".govuk-error-summary__title").should(
       "contain",
       "Invalid username or password."
@@ -47,6 +47,31 @@ describe("User Login Page", () => {
         "contain",
         "Signed in successfully."
       );
+    });
+  });
+
+  context('logged in', () => {
+    beforeEach(() => {
+      cy.visit("/");
+      cy.fixture("users").then((users) => {
+        cy.login(users[0].username, users[0].password);
+      });
+    });
+
+    it('displays search filters page', () => {
+      cy.get(".govuk-fieldset__legend").should(
+        "contain",
+        "Search for"
+      );
+    });
+
+    it('can log out', () => {
+      cy.get("[data-method='delete']")
+      .should("have.text", "Sign out")
+      .should('have.attr', 'href').and('include', "/users/sign_out");
+  
+      cy.get("[data-method='delete']").click();
+      cy.get('.govuk-error-summary__title').should('contain', 'Signed out successfully.');
     });
   });
 });

--- a/cypress/integration/index/sign_in.spec.js
+++ b/cypress/integration/index/sign_in.spec.js
@@ -1,77 +1,77 @@
-describe("User Login Page", () => {
+describe('User Login Page', () => {
   before(() => {
-    cy.visit("/");
-    cy.checkBanner();
-  });
+    cy.visit('/')
+    cy.checkBanner()
+  })
 
   beforeEach(() => {
-    cy.visit("/");
-  });
+    cy.visit('/')
+  })
 
-  it("displays the login page", () => {
-    cy.get(".govuk-heading-xl").should("have.text", "Sign in");
-    cy.get("#new_user")
-      .should("contain", "Username or email")
-      .and("contain", "Password");
-    cy.get("input#user-login-field").should("exist");
-    cy.get("input#user-password-field").should("exist");
-  });
+  it('displays the login page', () => {
+    cy.get('.govuk-heading-xl').should('have.text', 'Sign in')
+    cy.get('#new_user')
+      .should('contain', 'Username or email')
+      .and('contain', 'Password')
+    cy.get('input#user-login-field').should('exist')
+    cy.get('input#user-password-field').should('exist')
+  })
 
-  it("can log in with correct credentials", () => {
-    cy.fixture("users").then((users) => {
-      cy.login(users[0].username, users[0].password);
-      cy.get(".govuk-error-summary__title").should(
-        "contain",
-        "Signed in successfully."
-      );
-    });
-  });
+  it('can log in with correct credentials', () => {
+    cy.fixture('users').then((users) => {
+      cy.login(users[0].username, users[0].password)
+      cy.get('.govuk-error-summary__title').should(
+        'contain',
+        'Signed in successfully.'
+      )
+    })
+  })
 
-  it("cannot log in with incorrect credentials", () => {
-    cy.login("someone", "some-password");
-    cy.get(".govuk-error-summary__title").should(
-      "contain",
-      "Invalid username or password."
-    );
-  });
+  it('cannot log in with incorrect credentials', () => {
+    cy.login('someone', 'some-password')
+    cy.get('.govuk-error-summary__title').should(
+      'contain',
+      'Invalid username or password.'
+    )
+  })
 
-  it("can log in with valid credentials after an invalid attempt", () => {
-    cy.login("invalid-username", "invalid-password");
-    cy.get(".govuk-error-summary__title").should(
-      "contain",
-      "Invalid username or password."
-    );
-    cy.fixture("users").then((users) => {
-      cy.login(users[0].username, users[0].password);
-      cy.get(".govuk-error-summary__title").should(
-        "contain",
-        "Signed in successfully."
-      );
-    });
-  });
+  it('can log in with valid credentials after an invalid attempt', () => {
+    cy.login('invalid-username', 'invalid-password')
+    cy.get('.govuk-error-summary__title').should(
+      'contain',
+      'Invalid username or password.'
+    )
+    cy.fixture('users').then((users) => {
+      cy.login(users[0].username, users[0].password)
+      cy.get('.govuk-error-summary__title').should(
+        'contain',
+        'Signed in successfully.'
+      )
+    })
+  })
 
   context('logged in', () => {
     beforeEach(() => {
-      cy.visit("/");
-      cy.fixture("users").then((users) => {
-        cy.login(users[0].username, users[0].password);
-      });
-    });
+      cy.visit('/')
+      cy.fixture('users').then((users) => {
+        cy.login(users[0].username, users[0].password)
+      })
+    })
 
     it('displays search filters page', () => {
-      cy.get(".govuk-fieldset__legend").should(
-        "contain",
-        "Search for"
-      );
-    });
+      cy.get('.govuk-fieldset__legend').should(
+        'contain',
+        'Search for'
+      )
+    })
 
     it('can log out', () => {
       cy.get("[data-method='delete']")
-      .should("have.text", "Sign out")
-      .should('have.attr', 'href').and('include', "/users/sign_out");
-  
-      cy.get("[data-method='delete']").click();
-      cy.get('.govuk-error-summary__title').should('contain', 'Signed out successfully.');
-    });
-  });
-});
+        .should('have.text', 'Sign out')
+        .should('have.attr', 'href').and('include', '/users/sign_out')
+
+      cy.get("[data-method='delete']").click()
+      cy.get('.govuk-error-summary__title').should('contain', 'Signed out successfully.')
+    })
+  })
+})

--- a/cypress/integration/index/sign_in.spec.js
+++ b/cypress/integration/index/sign_in.spec.js
@@ -74,4 +74,13 @@ describe('User Login Page', () => {
       cy.get('.govuk-error-summary__title').should('contain', 'Signed out successfully.')
     })
   })
+
+  context('logged out', () => {
+    it('can not see search filters', () => {
+      cy.get('#main-content').not(
+        'contain',
+        'Search for'
+      )
+    })
+  })
 })

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -11,7 +11,7 @@ Cypress.Commands.add('login', (username, password) => {
 })
 
 // checks whether appropriate banner is at the top of the site
-Cypress.Commands.add('checkBanner', () => {
+Cypress.Commands.add('checkEnvBanner', () => {
   it('displays the dev banner', () => {
     cy.get('.govuk-phase-banner__content').should('contain', Cypress.env('environment'))
   })

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -16,3 +16,7 @@ Cypress.Commands.add('checkBanner', () => {
     cy.get('.govuk-phase-banner__content').should('contain', Cypress.env('environment'))
   })
 })
+
+Cypress.Commands.add('checkCookieValue', (name, value) => {
+  cy.getCookie(name).should('have.property', 'value', value)
+})

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   },
   "devDependencies": {
     "@webpack-cli/serve": "^1.6.0",
-    "standard": "^16.0.4",
     "cypress": "^8.7.0",
+    "standard": "^16.0.4",
     "stylelint": "^13.13.1",
     "stylelint-config-gds": "^0.1.0",
     "stylelint-order": "^4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2374,15 +2374,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001219:
-  version "1.0.30001236"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001236.tgz#0a80de4cdf62e1770bb46a30d884fc8d633e3958"
-  integrity sha512-o0PRQSrSCGJKCPZcgMzl5fUaj5xHe8qA2m4QRvnyY4e1lITqoNkr7q/Oh1NcpGSy0Th97UZ35yoKcINPoq7YOQ==
-
-caniuse-lite@^1.0.30001254:
-  version "1.0.30001255"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001255.tgz#f3b09b59ab52e39e751a569523618f47c4298ca0"
-  integrity sha512-F+A3N9jTZL882f/fg/WWVnKSu6IOo3ueLz4zwaOPbPYHNmM/ZaDUyzyJwS1mZhX7Ex5jqTyW599Gdelh5PDYLQ==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001219, caniuse-lite@^1.0.30001254:
+  version "1.0.30001298"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001298.tgz"
+  integrity sha512-AcKqikjMLlvghZL/vfTHorlQsLDhGRalYf1+GmWCf5SCMziSGjRYQW/JEksj14NaYHIR6KIhrFAy0HV5C25UzQ==
 
 case-sensitive-paths-webpack-plugin@^2.4.0:
   version "2.4.0"


### PR DESCRIPTION
#### What

Add Cypress tests for Cookies (banner and settings page) and more Login/Logout tests

#### Ticket

[AAC-162](https://dsdmoj.atlassian.net/browse/AAC-162?atlOrigin=eyJpIjoiNWRjOTdhOTFlYzJkNDQ1ZTllOTc4MmIzZGExNzliYTIiLCJwIjoiaiJ9)

#### Why

- To test and ensure rigidity of the cookies feature
- To not pollute genuine data in Google Analytics
- Add customised data attributes for cypress testing to meet best practices [here](https://docs.cypress.io/guides/references/best-practices#Selecting-Elements)

#### How

- Add cypress tests to accept and reject cookies
- Add cypress tests to adjust cookie settings
- Add cypress testing to check for the change in two cookies: cookies_preferences_set and analytics_cookies_set
- Add cypress tests to test the logout procedure
- Update cypress configuration on all environments to block calls to Google Analytics.
- Add data attributes to buttons/links (accept, reject, settings and form submit)


**TO NOTE:**

Cypress tests run faster for the cookie banner and cookie settings page when the user is not logged in hence i just tested with 'not logged in'. I have tried looking into storing a session for login but its an experimental cypress feature.

This tests cookies whilst not logged in because it's a feature that doesn't currently require authentication


**EDIT:**

These tests only work with JS enabled and doesn't test for the non-js version. This is because cypress requires javascript to work and the current solutions are [workaround / hacks ](https://github.com/cypress-io/cypress/issues/1611#issuecomment-749406961) . If we were to do it, I would suggest a separate ticket / feature.