### PR TITLE
AAC-447 - Update urls for CDA

### DIFF
--- a/.k8s/live/dev/deployment-worker.yaml
+++ b/.k8s/live/dev/deployment-worker.yaml
@@ -47,7 +47,7 @@ spec:
             - name: DOMAIN_URL
               value: 'https://dev.view-court-data.service.justice.gov.uk'
             - name: COURT_DATA_ADAPTOR_API_URL
-              value: https://laa-court-data-adaptor-dev.apps.live-1.cloud-platform.service.justice.gov.uk/api/internal/v1
+              value: https://dev.court-data-adaptor.service.justice.gov.uk/api/internal/v1
             - name: RAILS_SERVE_STATIC_FILES
               value: enabled
             - name: RAILS_LOG_TO_STDOUT

--- a/.k8s/live/dev/deployment.yaml
+++ b/.k8s/live/dev/deployment.yaml
@@ -56,7 +56,7 @@ spec:
             - name: DOMAIN_URL
               value: 'https://dev.view-court-data.service.justice.gov.uk'
             - name: COURT_DATA_ADAPTOR_API_URL
-              value: https://laa-court-data-adaptor-dev.apps.live-1.cloud-platform.service.justice.gov.uk/api/internal/v1
+              value: https://dev.court-data-adaptor.service.justice.gov.uk/api/internal/v1
             - name: RAILS_SERVE_STATIC_FILES
               value: enabled
             - name: GA_TRACKING_ID

--- a/.k8s/live/production/deployment-worker.yaml
+++ b/.k8s/live/production/deployment-worker.yaml
@@ -43,7 +43,7 @@ spec:
             - name: DOMAIN_URL
               value: 'https://view-court-data.service.justice.gov.uk'
             - name: COURT_DATA_ADAPTOR_API_URL
-              value: https://laa-court-data-adaptor.apps.live-1.cloud-platform.service.justice.gov.uk/api/internal/v1
+              value: https://court-data-adaptor.service.justice.gov.uk/api/internal/v1
             - name: RAILS_SERVE_STATIC_FILES
               value: enabled
             - name: RAILS_LOG_TO_STDOUT

--- a/.k8s/live/production/deployment.yaml
+++ b/.k8s/live/production/deployment.yaml
@@ -56,7 +56,7 @@ spec:
             - name: DOMAIN_URL
               value: 'https://view-court-data.service.justice.gov.uk'
             - name: COURT_DATA_ADAPTOR_API_URL
-              value: https://laa-court-data-adaptor.apps.live-1.cloud-platform.service.justice.gov.uk/api/internal/v1
+              value: https://court-data-adaptor.service.justice.gov.uk/api/internal/v1
             - name: RAILS_SERVE_STATIC_FILES
               value: enabled
             - name: GA_TRACKING_ID

--- a/.k8s/live/staging/deployment-worker.yaml
+++ b/.k8s/live/staging/deployment-worker.yaml
@@ -47,7 +47,7 @@ spec:
             - name: DOMAIN_URL
               value: 'https://staging.view-court-data.service.justice.gov.uk'
             - name: COURT_DATA_ADAPTOR_API_URL
-              value: https://laa-court-data-adaptor-stage.apps.live-1.cloud-platform.service.justice.gov.uk/api/internal/v1
+              value: https://stage.court-data-adaptor.service.justice.gov.uk/api/internal/v1
             - name: RAILS_SERVE_STATIC_FILES
               value: enabled
             - name: RAILS_LOG_TO_STDOUT

--- a/.k8s/live/staging/deployment.yaml
+++ b/.k8s/live/staging/deployment.yaml
@@ -56,7 +56,7 @@ spec:
             - name: DOMAIN_URL
               value: 'https://staging.view-court-data.service.justice.gov.uk'
             - name: COURT_DATA_ADAPTOR_API_URL
-              value: https://laa-court-data-adaptor-stage.apps.live-1.cloud-platform.service.justice.gov.uk/api/internal/v1
+              value: https://stage.court-data-adaptor.service.justice.gov.uk/api/internal/v1
             - name: RAILS_SERVE_STATIC_FILES
               value: enabled
             - name: GA_TRACKING_ID

--- a/.k8s/live/uat/deployment-worker.yaml
+++ b/.k8s/live/uat/deployment-worker.yaml
@@ -47,7 +47,7 @@ spec:
             - name: DOMAIN_URL
               value: 'https://uat.view-court-data.service.justice.gov.uk'
             - name: COURT_DATA_ADAPTOR_API_URL
-              value: https://laa-court-data-adaptor-uat.apps.live-1.cloud-platform.service.justice.gov.uk/api/internal/v1
+              value: https://uat.court-data-adaptor.service.justice.gov.uk/api/internal/v1
             - name: RAILS_SERVE_STATIC_FILES
               value: enabled
             - name: RAILS_LOG_TO_STDOUT

--- a/.k8s/live/uat/deployment.yaml
+++ b/.k8s/live/uat/deployment.yaml
@@ -56,7 +56,7 @@ spec:
             - name: DOMAIN_URL
               value: 'https://uat.view-court-data.service.justice.gov.uk'
             - name: COURT_DATA_ADAPTOR_API_URL
-              value: https://laa-court-data-adaptor-uat.apps.live-1.cloud-platform.service.justice.gov.uk/api/internal/v1
+              value: https://uat.court-data-adaptor.service.justice.gov.uk/api/internal/v1
             - name: RAILS_SERVE_STATIC_FILES
               value: enabled
             - name: GA_TRACKING_ID

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -194,7 +194,7 @@ GEM
       haml (>= 4.0, < 6)
       nokogiri (>= 1.6.0)
       ruby_parser (~> 3.5)
-    i18n (1.9.0)
+    i18n (1.9.1)
       concurrent-ruby (~> 1.0)
     i18n-tasks (0.9.37)
       activesupport (>= 4.0.2)


### PR DESCRIPTION
#### What

Update CDA Urls so that when migration happens we dont error

#### Ticket

[Update CDA endpoints to non namespace specific URLS](https://dsdmoj.atlassian.net/browse/AAC-447)

#### Why

We are using cluster specific URLS and when migration is complete we could be left with out of date URLS
