### PR TITLE
AAC-498 - Ruby31 cleanup

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -25,7 +25,7 @@ plugins:
             - "(call _ expose ___)" # exlude expose methods
   rubocop:
     enabled: true
-    channel: rubocop-1-23-0
+    channel: beta
     config:
       file: .rubocop.yml
   brakeman:

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -25,7 +25,7 @@ plugins:
             - "(call _ expose ___)" # exlude expose methods
   rubocop:
     enabled: true
-    channel: rubocop-1-9-1
+    channel: rubocop-1-23-0
     config:
       file: .rubocop.yml
   brakeman:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,7 +6,7 @@ require:
 AllCops:
   NewCops: enable
   DisplayCopNames: true
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.1
   TargetRailsVersion: 6
   Exclude:
     - tmp/**/*

--- a/app/controllers/concerns/cookie_concern.rb
+++ b/app/controllers/concerns/cookie_concern.rb
@@ -19,7 +19,7 @@ module CookieConcern
 
   def set_cookie(type, value: false)
     cookies[type] = {
-      value: value,
+      value:,
       domain: request.host,
       expires: 1.year.from_now,
       secure: !Rails.env.test?

--- a/app/controllers/defendants_controller.rb
+++ b/app/controllers/defendants_controller.rb
@@ -93,7 +93,7 @@ class DefendantsController < ApplicationController
 
   def adaptor_error_handler(exception)
     @errors = exception.errors
-    flash.now[:alert] = I18n.t('defendants.unlink.failure', error_messages: error_messages)
+    flash.now[:alert] = I18n.t('defendants.unlink.failure', error_messages:)
     render 'edit'
   end
 end

--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -25,7 +25,7 @@ class FeedbackController < ApplicationController
       email: feedback_params[:email],
       rating: feedback_params[:rating],
       comment: feedback_params[:comment],
-      environment: environment
+      environment:
     ).deliver_later!
   end
 

--- a/app/controllers/hearings_controller.rb
+++ b/app/controllers/hearings_controller.rb
@@ -56,8 +56,8 @@ class HearingsController < ApplicationController
   end
 
   def paginator
-    @paginator ||= helpers.paginator(prosecution_case, column: column,
-                                                       direction: direction, page: page)
+    @paginator ||= helpers.paginator(prosecution_case, column:,
+                                                       direction:, page:)
   end
 
   def prosecution_case

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -12,7 +12,7 @@ class SearchesController < ApplicationController
   end
 
   def create
-    @search = Search.new(filter: filter, term: term, dob: dob)
+    @search = Search.new(filter:, term:, dob:)
     authorize! :create, @search
 
     @results = @search.execute if @search.valid?

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -21,9 +21,9 @@ module ApplicationHelper
     decorator
   end
 
-  def decorate_all(objects, decorator_class = nil, &block)
+  def decorate_all(objects, decorator_class = nil, &)
     objects.map do |object|
-      decorate(object, decorator_class, &block)
+      decorate(object, decorator_class, &)
     end
   end
   alias decorate_each decorate_all
@@ -32,7 +32,7 @@ module ApplicationHelper
     title ||= prosecution_case.column_title(column)
     title = "#{title} " + prosecution_case.column_sort_icon if column == prosecution_case.hearings_sort_column
     direction = prosecution_case.hearings_sort_direction == 'asc' ? 'desc' : 'asc'
-    link_to(title, prosecution_case_path(id: prosecution_case.prosecution_case_reference, column: column, direction: direction, anchor: column), class: 'govuk-link govuk-link--no-visited-state', id: column, 'aria-label': "Sort #{column} #{direction}")
+    link_to(title, prosecution_case_path(id: prosecution_case.prosecution_case_reference, column:, direction:, anchor: column), class: 'govuk-link govuk-link--no-visited-state', id: column, 'aria-label': "Sort #{column} #{direction}")
   end
 
   def app_environment

--- a/app/helpers/govuk_design_system_helper.rb
+++ b/app/helpers/govuk_design_system_helper.rb
@@ -22,12 +22,12 @@ module GovukDesignSystemHelper
     GdsDesignSystemBreadcrumbBuilder
   end
 
-  def govuk_detail(summary_text = nil, tag_options = {}, &block)
+  def govuk_detail(summary_text = nil, tag_options = {}, &)
     tag_options = prepend_classes('govuk-details', tag_options)
     tag_options[:data] = { module: 'govuk-details' }
 
     summary = tag.span(summary_text, class: 'govuk-details__summary-text')
-    content = capture(&block)
+    content = capture(&)
     tag.details(**tag_options) do
       concat tag.summary(summary, class: 'govuk-details__summary')
       concat tag.div(content, class: 'govuk-details__text')

--- a/app/mailers/feedback_mailer.rb
+++ b/app/mailers/feedback_mailer.rb
@@ -4,10 +4,10 @@ class FeedbackMailer < GovukNotifyRails::Mailer
   def notify(email:, rating:, environment:, comment: nil)
     set_template('5fcd84b1-8d05-4b6c-86a8-9fc391efa754')
     set_personalisation(
-      email: email,
-      rating: rating,
-      comment: comment,
-      environment: environment
+      email:,
+      rating:,
+      comment:,
+      environment:
     )
     mail(to: support_email_address)
   end

--- a/app/models/link_attempt.rb
+++ b/app/models/link_attempt.rb
@@ -12,8 +12,8 @@ class LinkAttempt
             format: { with: /\A[0-9]{7}\z/, unless: :no_maat_id? }
 
   def to_link_attributes
-    { defendant_id: defendant_id, user_name: username }.tap do |attrs|
-      attrs.merge!(maat_reference: maat_reference) unless no_maat_id?
+    { defendant_id:, user_name: username }.tap do |attrs|
+      attrs.merge!(maat_reference:) unless no_maat_id?
     end
   end
 end

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -61,6 +61,6 @@ class Search
   end
 
   def defendant_name_query
-    CourtDataAdaptor::Query::Defendant::ByName.new(term, dob: dob)
+    CourtDataAdaptor::Query::Defendant::ByName.new(term, dob:)
   end
 end

--- a/db/seed_helper.rb
+++ b/db/seed_helper.rb
@@ -6,7 +6,7 @@ module SeedHelper
   # find_or_create_by does not work with devise user model
   def self.find_or_create_user(attributes)
     email = attributes[:email].downcase
-    user = User.find_by(email: email)
+    user = User.find_by(email:)
     if user.blank?
       attributes[:email_confirmation] = email
       user = User.create(attributes) if user.blank?

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,7 +2,7 @@
 
 ## System dependencies
 - postgres
-- ruby 2.7+
+- ruby 3.1
 - rails 6+
 - nvm
 - node 12.4.1+

--- a/lib/court_data_adaptor/query/defendant/by_name.rb
+++ b/lib/court_data_adaptor/query/defendant/by_name.rb
@@ -13,7 +13,7 @@ module CourtDataAdaptor
                   .includes(:defendants)
                   .where(
                     name: term,
-                    date_of_birth: date_of_birth
+                    date_of_birth:
                   )
                   .all
 

--- a/lib/court_data_adaptor/query/defendant/reference_parser.rb
+++ b/lib/court_data_adaptor/query/defendant/reference_parser.rb
@@ -5,7 +5,7 @@ module CourtDataAdaptor
     module Defendant
       class ReferenceParser
         # rubocop:disable Layout/LineLength
-        NINO_REGEXP = /^(?!BG)(?!GB)(?!NK)(?!KN)(?!TN)(?!NT)(?!ZZ)(?:[A-CEGHJ-PR-TW-Z][A-CEGHJ-NPR-TW-Z])[0-9]{6}[A-D]{1}$/.freeze
+        NINO_REGEXP = /^(?!BG)(?!GB)(?!NK)(?!KN)(?!TN)(?!NT)(?!ZZ)(?:[A-CEGHJ-PR-TW-Z][A-CEGHJ-NPR-TW-Z])[0-9]{6}[A-D]{1}$/
         # rubocop:enable Layout/LineLength
 
         def initialize(term)

--- a/spec/decorators/court_application_decorator_spec.rb
+++ b/spec/decorators/court_application_decorator_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe CourtApplicationDecorator, type: :decorator do
   describe '#respondent_list' do
     subject(:call) { decorator.respondent_list }
 
-    before { allow(court_application).to receive_messages(respondents: respondents) }
+    before { allow(court_application).to receive_messages(respondents:) }
 
     context 'with multiple respondents' do
       let(:respondents) { [respondent1, respondent2] }

--- a/spec/decorators/cracked_ineffective_trial_decorator_spec.rb
+++ b/spec/decorators/cracked_ineffective_trial_decorator_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe CrackedIneffectiveTrialDecorator, type: :decorator do
     subject(:call) { decorator.cracked? }
 
     before do
-      allow(cracked_ineffective_trial).to receive_messages(type: type, code: code)
+      allow(cracked_ineffective_trial).to receive_messages(type:, code:)
     end
 
     context 'when type is cracked' do
@@ -80,7 +80,7 @@ RSpec.describe CrackedIneffectiveTrialDecorator, type: :decorator do
     end
 
     before do
-      allow(cracked_ineffective_trial).to receive_messages(type: type)
+      allow(cracked_ineffective_trial).to receive_messages(type:)
     end
 
     context 'when type is cracked' do

--- a/spec/decorators/hearing_decorator_spec.rb
+++ b/spec/decorators/hearing_decorator_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe HearingDecorator, type: :decorator do
   describe '#provider_list' do
     subject(:call) { decorator.provider_list }
 
-    before { allow(hearing).to receive_messages(providers: providers) }
+    before { allow(hearing).to receive_messages(providers:) }
 
     context 'with multiple providers' do
       let(:providers) { [provider1, provider2] }
@@ -54,7 +54,7 @@ RSpec.describe HearingDecorator, type: :decorator do
   describe '#defendant_name_list' do
     subject(:call) { decorator.defendant_name_list }
 
-    before { allow(hearing).to receive_messages(defendant_names: defendant_names) }
+    before { allow(hearing).to receive_messages(defendant_names:) }
 
     context 'with nil defendant_names' do
       let(:defendant_names) { nil }
@@ -84,7 +84,7 @@ RSpec.describe HearingDecorator, type: :decorator do
   describe '#prosecution_advocate_name_list' do
     subject(:call) { decorator.prosecution_advocate_name_list }
 
-    before { allow(hearing).to receive_messages(prosecution_advocate_names: prosecution_advocate_names) }
+    before { allow(hearing).to receive_messages(prosecution_advocate_names:) }
 
     context 'with nil prosecution_advocate_names' do
       let(:prosecution_advocate_names) { nil }
@@ -114,7 +114,7 @@ RSpec.describe HearingDecorator, type: :decorator do
   describe '#judge_name_list' do
     subject(:call) { decorator.judge_name_list }
 
-    before { allow(hearing).to receive_messages(judge_names: judge_names) }
+    before { allow(hearing).to receive_messages(judge_names:) }
 
     context 'with nil prosecution_advocate_names' do
       let(:judge_names) { nil }
@@ -144,7 +144,7 @@ RSpec.describe HearingDecorator, type: :decorator do
   describe '#cracked_ineffective_trial' do
     subject(:call) { decorator.cracked_ineffective_trial }
 
-    before { allow(hearing).to receive_messages(cracked_ineffective_trial: cracked_ineffective_trial) }
+    before { allow(hearing).to receive_messages(cracked_ineffective_trial:) }
 
     context 'with nil cracked_ineffective_trial' do
       let(:cracked_ineffective_trial) { nil }
@@ -179,7 +179,7 @@ RSpec.describe HearingDecorator, type: :decorator do
 
     let(:hearing_event_class) { CourtDataAdaptor::Resource::HearingEvent }
 
-    before { allow(hearing).to receive_messages(hearing_events: hearing_events) }
+    before { allow(hearing).to receive_messages(hearing_events:) }
 
     it 'filters events by day' do
       is_expected.to match_array([hearing_event1, hearing_event2])

--- a/spec/decorators/offence_decorator_spec.rb
+++ b/spec/decorators/offence_decorator_spec.rb
@@ -201,7 +201,7 @@ RSpec.describe OffenceDecorator, type: :decorator do
       [1, 2, 6].each do |code|
         context "when exactly one reason exists, with code #{code}" do
           let(:mode_of_trial_reason_array) do
-            [{ code: code,
+            [{ code:,
                description: 'description to be hidden' }]
           end
 

--- a/spec/decorators/prosecution_case_decorator_spec.rb
+++ b/spec/decorators/prosecution_case_decorator_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe ProsecutionCaseDecorator, type: :decorator do
   describe '#hearings' do
     subject(:call) { decorator.hearings }
 
-    before { allow(prosecution_case).to receive_messages(hearings: hearings) }
+    before { allow(prosecution_case).to receive_messages(hearings:) }
 
     context 'with multiple hearings' do
       let(:hearings) { [hearing1, hearing2] }
@@ -153,7 +153,7 @@ RSpec.describe ProsecutionCaseDecorator, type: :decorator do
   describe '#cracked?' do
     subject(:call) { decorator.cracked? }
 
-    before { allow(prosecution_case).to receive_messages(hearings: hearings) }
+    before { allow(prosecution_case).to receive_messages(hearings:) }
 
     context 'with no hearings' do
       let(:hearings) { [] }

--- a/spec/features/unlinking_a_defendant_from_maat_spec.rb
+++ b/spec/features/unlinking_a_defendant_from_maat_spec.rb
@@ -23,8 +23,8 @@ RSpec.feature 'Unlinking a defendant from MAAT', type: :feature do
     json_api_header = { 'Content-Type' => 'application/vnd.api+json' }
 
     stub_request(:get, "#{api_url}/prosecution_cases")
-      .with(query: query)
-      .to_return(body: body, headers: json_api_header)
+      .with(query:)
+      .to_return(body:, headers: json_api_header)
 
     stub_request(:get, "#{api_url}/defendants/#{defendant_id_from_fixture}?include=offences")
       .to_return(body: defendant_body, headers: json_api_header)

--- a/spec/helpers/hearing_paginator_spec.rb
+++ b/spec/helpers/hearing_paginator_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe HearingPaginator, type: :helper do
 
   let(:prosecution_case) do
     instance_double(CourtDataAdaptor::Resource::ProsecutionCase,
-                    hearings: hearings,
+                    hearings:,
                     prosecution_case_reference: 'ACASEURN')
   end
 

--- a/spec/lib/court_data_adaptor/query/defendant/by_name_spec.rb
+++ b/spec/lib/court_data_adaptor/query/defendant/by_name_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe CourtDataAdaptor::Query::Defendant::ByName do
   describe '#call' do
     subject(:call) { instance.call }
 
-    let(:instance) { described_class.new(term, dob: dob) }
+    let(:instance) { described_class.new(term, dob:) }
 
     context 'with mocking' do
       let(:resource) { self.class.resource }

--- a/spec/mailers/feedback_mailer_spec.rb
+++ b/spec/mailers/feedback_mailer_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe FeedbackMailer, type: :mailer do
   describe '#notify' do
     subject(:mail) { described_class.notify(**args) }
 
-    let(:args) { { email: email, rating: rating, comment: comment, environment: environment } }
+    let(:args) { { email:, rating:, comment:, environment: } }
 
     it 'is a govuk_notify delivery' do
       expect(mail.delivery_method).to be_a(GovukNotifyRails::Delivery)
@@ -32,16 +32,16 @@ RSpec.describe FeedbackMailer, type: :mailer do
       it 'sets personalisation from args' do
         expect(
           mail.govuk_notify_personalisation
-        ).to include(comment: comment, email: email, rating: rating, environment: environment)
+        ).to include(comment:, email:, rating:, environment:)
       end
 
       context 'when no comment' do
-        let(:args) { { email: email, rating: rating, environment: environment } }
+        let(:args) { { email:, rating:, environment: } }
 
         it 'sets comment to nil' do
           expect(
             mail.govuk_notify_personalisation
-          ).to include(comment: nil, email: email, rating: rating, environment: environment)
+          ).to include(comment: nil, email:, rating:, environment:)
         end
       end
     end

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Search, type: :model do
     end
 
     context 'when searching by case reference', stub_no_results: true do
-      subject(:search_instance) { described_class.new(filter: filter, term: term) }
+      subject(:search_instance) { described_class.new(filter:, term:) }
 
       let(:filter) { 'case_reference' }
       let(:term) { 'case-urn' }
@@ -59,7 +59,7 @@ RSpec.describe Search, type: :model do
     end
 
     context 'when searching by defendant name', stub_no_results: true do
-      subject(:search_instance) { described_class.new(filter: filter, term: term, dob: dob) }
+      subject(:search_instance) { described_class.new(filter:, term:, dob:) }
 
       let(:filter) { 'defendant_name' }
       let(:term) { 'defendant-name' }
@@ -69,7 +69,7 @@ RSpec.describe Search, type: :model do
       let(:query_instance) { instance_double(query_class) }
 
       it 'sends term and dob to defandant query object' do
-        expect(query_class).to have_received(:new).with(term, dob: dob)
+        expect(query_class).to have_received(:new).with(term, dob:)
       end
 
       it 'calls defendant query object' do
@@ -78,7 +78,7 @@ RSpec.describe Search, type: :model do
     end
 
     context 'when searching by defendant reference', stub_no_results: true do
-      subject(:search_instance) { described_class.new(filter: filter, term: term) }
+      subject(:search_instance) { described_class.new(filter:, term:) }
 
       let(:filter) { 'defendant_reference' }
       let(:term) { 'defendant-ni-number' }
@@ -97,7 +97,7 @@ RSpec.describe Search, type: :model do
   end
 
   context 'when validating' do
-    subject(:search) { described_class.new(filter: filter, term: term, dob: dob) }
+    subject(:search) { described_class.new(filter:, term:, dob:) }
 
     context 'with case reference search' do
       let(:filter) { 'case_reference' }

--- a/spec/requests/linking/link_defendant_maat_reference_spec.rb
+++ b/spec/requests/linking/link_defendant_maat_reference_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe 'link defendant maat reference', type: :request, stub_unlinked: t
   let(:params) do
     { urn: case_urn,
       link_attempt:
-        { defendant_id: defendant_id,
-          maat_reference: maat_reference } }
+        { defendant_id:,
+          maat_reference: } }
   end
 
   let(:adaptor_request_path) { %r{.*/laa_references} }
@@ -23,9 +23,9 @@ RSpec.describe 'link defendant maat reference', type: :request, stub_unlinked: t
     { data:
       { type: 'laa_references',
         attributes:
-          { defendant_id: defendant_id,
+          { defendant_id:,
             user_name: user.username,
-            maat_reference: maat_reference } } }
+            maat_reference: } } }
   end
 
   context 'when authenticated' do
@@ -39,7 +39,7 @@ RSpec.describe 'link defendant maat reference', type: :request, stub_unlinked: t
 
     before do
       sign_in user
-      post '/laa_references', params: params
+      post '/laa_references', params:
     end
 
     context 'with valid params', stub_link_success: true do
@@ -105,7 +105,7 @@ RSpec.describe 'link defendant maat reference', type: :request, stub_unlinked: t
 
   context 'when not authenticated' do
     context 'when creating a reference' do
-      before { post '/laa_references', params: params }
+      before { post '/laa_references', params: }
 
       it_behaves_like 'unauthenticated request'
     end
@@ -120,7 +120,7 @@ RSpec.describe 'link defendant maat reference', type: :request, stub_unlinked: t
       allow(config).to receive(:test_mode?).and_return false
       allow_any_instance_of(OAuth2::AccessToken).to receive(:expired?).and_return true
 
-      post '/laa_references', params: params
+      post '/laa_references', params:
     end
 
     it 'sends token request' do

--- a/spec/requests/linking/link_defendant_no_maat_id_spec.rb
+++ b/spec/requests/linking/link_defendant_no_maat_id_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe 'link defendant with no maat id', type: :request, stub_unlinked: 
   let(:commit) { 'Create link without MAAT ID' }
 
   let(:params) do
-    { commit: commit,
+    { commit:,
       urn: case_urn,
-      link_attempt: { defendant_id: defendant_id } }
+      link_attempt: { defendant_id: } }
   end
 
   let(:adaptor_request_path) { %r{.*/laa_references} }
@@ -22,7 +22,7 @@ RSpec.describe 'link defendant with no maat id', type: :request, stub_unlinked: 
     { data:
       { type: 'laa_references',
         attributes:
-          { defendant_id: defendant_id,
+          { defendant_id:,
             user_name: user.username } } }
   end
 
@@ -37,7 +37,7 @@ RSpec.describe 'link defendant with no maat id', type: :request, stub_unlinked: 
 
     before do
       sign_in user
-      post '/laa_references', params: params
+      post '/laa_references', params:
     end
 
     context 'with valid params', stub_link_success: true do
@@ -77,7 +77,7 @@ RSpec.describe 'link defendant with no maat id', type: :request, stub_unlinked: 
 
   context 'when not authenticated' do
     context 'when creating a reference' do
-      before { post '/laa_references', params: params }
+      before { post '/laa_references', params: }
 
       it_behaves_like 'unauthenticated request'
     end

--- a/spec/requests/linking/unlink_defendant_maat_reference_spec.rb
+++ b/spec/requests/linking/unlink_defendant_maat_reference_spec.rb
@@ -5,7 +5,7 @@ require 'court_data_adaptor'
 RSpec.shared_examples 'invalid unlink_attempt request' do
   before do
     patch "/defendants/#{defendant_id_from_fixture}?urn=#{prosecution_case_reference_from_fixture}",
-          params: params
+          params:
   end
 
   it 'does NOT send an unlink request to the adapter' do
@@ -74,7 +74,7 @@ RSpec.describe 'unlink defendant maat reference', type: :request do
       sign_in user
 
       stub_request(:get, "#{api_url}/prosecution_cases")
-        .with(query: query)
+        .with(query:)
         .to_return(body: defendant_fixture, headers: json_api_content)
 
       stub_request(:get, "#{api_url}/defendants/#{defendant_id_from_fixture}?include=offences")
@@ -89,7 +89,7 @@ RSpec.describe 'unlink defendant maat reference', type: :request do
           .to_return(status: 202, body: '', headers: plain_content)
 
         patch "/defendants/#{defendant_id_from_fixture}?urn=#{prosecution_case_reference_from_fixture}",
-              params: params
+              params:
       end
 
       it 'sends an unlink request to the adapter' do
@@ -124,7 +124,7 @@ RSpec.describe 'unlink defendant maat reference', type: :request do
           )
 
         patch "/defendants/#{defendant_id_from_fixture}?urn=#{prosecution_case_reference_from_fixture}",
-              params: params
+              params:
       end
 
       it 'flashes alert' do
@@ -148,7 +148,7 @@ RSpec.describe 'unlink defendant maat reference', type: :request do
         stub_request(:patch, adaptor_request_path)
           .to_return(status: 202, body: '', headers: plain_content)
 
-        patch "/defendants/#{defendant_id_from_fixture}", params: params
+        patch "/defendants/#{defendant_id_from_fixture}", params:
       end
 
       it 'sends an unlink request to the adapter' do
@@ -189,7 +189,7 @@ RSpec.describe 'unlink defendant maat reference', type: :request do
         stub_request(:patch, adaptor_request_path)
           .to_return(status: 202, body: '', headers: plain_content)
 
-        patch "/defendants/#{defendant_id_from_fixture}", params: params
+        patch "/defendants/#{defendant_id_from_fixture}", params:
       end
 
       it 'sends an unlink request to the adapter' do
@@ -252,7 +252,7 @@ RSpec.describe 'unlink defendant maat reference', type: :request do
         stub_request(:patch, adaptor_request_path)
           .to_return(status: 202, body: '', headers: plain_content)
 
-        patch "/defendants/#{defendant_id_from_fixture}", params: params
+        patch "/defendants/#{defendant_id_from_fixture}", params:
       end
 
       it 'sends token request' do
@@ -264,7 +264,7 @@ RSpec.describe 'unlink defendant maat reference', type: :request do
   end
 
   context 'when not authenticated' do
-    before { patch "/defendants/#{defendant_id_from_fixture}", params: params }
+    before { patch "/defendants/#{defendant_id_from_fixture}", params: }
 
     it 'redirects to sign in page' do
       expect(response).to redirect_to new_user_session_path

--- a/spec/requests/search/search_filters_spec.rb
+++ b/spec/requests/search/search_filters_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'Search filters', type: :request do
   end
 
   describe '#create' do
-    before { post '/search_filters', params: params }
+    before { post '/search_filters', params: }
 
     context 'when posting a valid search filter' do
       let(:params) { { search_filter: { id: 'whatever' } } }

--- a/spec/requests/search/searches_spec.rb
+++ b/spec/requests/search/searches_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Searches', type: :request do
   end
 
   describe '#new' do
-    before { get '/searches/new', params: params }
+    before { get '/searches/new', params: }
 
     context 'without a query' do
       let(:params) { { search: { filter: 'case_reference' } } }
@@ -35,7 +35,7 @@ RSpec.describe 'Searches', type: :request do
   end
 
   describe 'POST #create' do
-    before { post '/searches', params: params }
+    before { post '/searches', params: }
 
     context 'when POSTing a valid case search', stub_case_search: true do
       let(:params) { { search: { filter: 'case_reference', term: 'test12345' } } }
@@ -128,7 +128,7 @@ RSpec.describe 'Searches', type: :request do
   end
 
   describe 'GET #create', stub_case_search: true do
-    before { get '/searches', params: params }
+    before { get '/searches', params: }
 
     context 'when GETing a valid search' do
       let(:params) { { search: { filter: 'case_reference', term: 'test12345' } } }
@@ -149,7 +149,7 @@ RSpec.describe 'Searches', type: :request do
       allow_any_instance_of(Search)
         .to receive(:execute)
         .and_raise JsonApiClient::Errors::ConnectionError.new('connection error test')
-      get '/searches', params: params
+      get '/searches', params:
     end
 
     let(:params) { { search: { filter: 'case_reference', term: 'test12345' } } }
@@ -164,7 +164,7 @@ RSpec.describe 'Searches', type: :request do
       allow_any_instance_of(Search)
         .to receive(:execute)
         .and_raise Net::ReadTimeout.new('read timeout error test')
-      get '/searches', params: params
+      get '/searches', params:
     end
 
     let(:params) { { search: { filter: 'case_reference', term: 'test12345' } } }

--- a/spec/support/capybara_extensions.rb
+++ b/spec/support/capybara_extensions.rb
@@ -40,7 +40,7 @@ module CapybaraExtensions
       result = has_selector?(selector, **options)
 
       if href
-        actual_href = find(breadcrumb_link_selector, text: text)['href']
+        actual_href = find(breadcrumb_link_selector, text:)['href']
         result = href_match?(href, actual_href)
       end
       result
@@ -48,7 +48,7 @@ module CapybaraExtensions
 
     def has_govuk_warning?(text = nil)
       [
-        has_selector?('.govuk-warning-text strong.govuk-warning-text__text', text: text),
+        has_selector?('.govuk-warning-text strong.govuk-warning-text__text', text:),
         has_selector?('.govuk-warning-text span.govuk-warning-text__icon', text: '!'),
         has_selector?('.govuk-warning-text span.govuk-warning-text__assistive', text: 'Warning')
       ].all?
@@ -69,15 +69,15 @@ module CapybaraExtensions
     end
 
     def has_govuk_detail_summary?(text, options = {})
-      has_selector?(detail_summary_selector, **options.merge(text: text))
+      has_selector?(detail_summary_selector, **options.merge(text:))
     end
 
     def has_no_govuk_detail_summary?(text, options = {})
-      has_no_selector?(detail_summary_selector, **options.merge(text: text))
+      has_no_selector?(detail_summary_selector, **options.merge(text:))
     end
 
     def click_govuk_detail_summary(text, options = {})
-      detail_summary = find(detail_summary_selector, **options.merge(text: text))
+      detail_summary = find(detail_summary_selector, **options.merge(text:))
       detail_summary.click
     end
 

--- a/spec/views/hearings/_hearing_events.html.haml_spec.rb
+++ b/spec/views/hearings/_hearing_events.html.haml_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe 'hearings/_hearing_events.html.haml', type: :view do
   subject(:render_partial) do
-    render partial: 'hearing_events', locals: { hearing: decorated_hearing, hearing_day: hearing_day }
+    render partial: 'hearing_events', locals: { hearing: decorated_hearing, hearing_day: }
   end
 
   let(:hearing) { CourtDataAdaptor::Resource::Hearing.new }

--- a/spec/views/hearings/_listing_info.html.haml_spec.rb
+++ b/spec/views/hearings/_listing_info.html.haml_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe 'hearings/_listing_info.html.haml', type: :view do
   subject(:render_partial) do
-    render partial: 'listing_info', locals: { hearing: decorated_hearing, hearing_day: hearing_day }
+    render partial: 'listing_info', locals: { hearing: decorated_hearing, hearing_day: }
   end
 
   let(:hearing) { CourtDataAdaptor::Resource::Hearing.new }

--- a/spec/views/prosecution_cases/_defendants.html.haml_spec.rb
+++ b/spec/views/prosecution_cases/_defendants.html.haml_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe 'prosecution_cases/_defendants.html.haml', type: :view do
   subject(:render_partial) do
-    render partial: 'defendants', locals: { results: results, prosecution_case: prosecution_case }
+    render partial: 'defendants', locals: { results:, prosecution_case: }
   end
 
   let(:results) { [prosecution_case] }

--- a/spec/views/prosecution_cases/_hearing_summaries.html.haml_spec.rb
+++ b/spec/views/prosecution_cases/_hearing_summaries.html.haml_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe 'prosecution_cases/_hearing_summaries.html.haml', type: :view do
     CourtDataAdaptor::Resource::Hearing
       .new(id: 'hearing-uuid',
            hearing_type: 'First hearing',
-           hearing_days: hearing_days,
-           providers: providers)
+           hearing_days:,
+           providers:)
   end
 
   let(:hearing1) do
@@ -26,7 +26,7 @@ RSpec.describe 'prosecution_cases/_hearing_summaries.html.haml', type: :view do
       .new(id: 'hearing1-uuid',
            hearing_type: 'Trial',
            hearing_days: hearing1_days,
-           providers: providers)
+           providers:)
   end
 
   let(:hearing2) do
@@ -34,7 +34,7 @@ RSpec.describe 'prosecution_cases/_hearing_summaries.html.haml', type: :view do
       .new(id: 'hearing2-uuid',
            hearing_type: 'Sentence',
            hearing_days: hearing2_days,
-           providers: providers)
+           providers:)
   end
 
   let(:hearing_days) { ['2021-01-17T10:30:00.000Z'] }


### PR DESCRIPTION
#### What

Cleanup after 3.1 language upgrade to ensure we are linting against the latest language features

#### Ticket

[VCD - Upgrade Ruby to 3.1](https://dsdmoj.atlassian.net/browse/AAC-498)

#### Why

To ensure we dont accrue any more technical debt due to out of date definitions

#### How

- Bump language version in rubocop config
- Fix violations
