### PR TITLE
Wrap cookie-banner__content text in govuk-body instead of p tag

### DIFF
--- a/app/views/layouts/_cookie_banner.html.haml
+++ b/app/views/layouts/_cookie_banner.html.haml
@@ -31,7 +31,7 @@
       .govuk-grid-row
         .govuk-grid-column-two-thirds
           .govuk-cookie-banner__content
-            %p
+            %p.govuk-body
               = @analytics_cookies_accepted ? t('layouts.application.cookies.confirmation_accept') : t('layouts.application.cookies.confirmation_reject') 
               = t('layouts.application.cookies.confirmation_link_to_settings_html', href: cookies_settings_path).html_safe
       .govuk-button-group


### PR DESCRIPTION

#### Ticket

[VCD - Styling not applied to text on message when cookies are accepted/rejected](https://dsdmoj.atlassian.net/browse/AAC-432)

#### Why
As a user of VCD..
I want consistent styling..
So that I do not perceive problems with the service

As a user of VCD with accessibility needs...
I want assessable friendly font stylings...
So that I can easily access the information displayed

#### How

- Wrap cookie-banner__content text in govuk-body instead of p tag
- The govuk design system uses a sans serif font, so accessible

