### PR TITLE
Upgrade GMP to resolve security vulnerability

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript' ]
+        language: [ 'javascript', 'ruby' ]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
         # Learn more:
         # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,7 +32,8 @@ RUN apk --no-cache add --upgrade --virtual build-dependencies \
                   postgresql-dev \
                   tzdata \
                   runit \
-                  apk-tools
+                  apk-tools \
+                  gmp
 
 # add non-root user and group with alpine first available uid, 1000
 RUN addgroup -g 1000 -S appgroup \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,7 +33,7 @@ RUN apk --no-cache add --upgrade --virtual build-dependencies \
                   tzdata \
                   runit \
                   apk-tools \
-                  gmp
+                  gmp=6.2.1-r1
 
 # add non-root user and group with alpine first available uid, 1000
 RUN addgroup -g 1000 -S appgroup \


### PR DESCRIPTION
#### Why
Fixes  Integer Overflow or Wraparound vulnerability on ruby:3.1.0-alpine3.14
More details on issue can be found [here](https://security.snyk.io/vuln/SNYK-ALPINE314-GMP-2419278)

#### How
Upgrade [gmp](https://pkgs.alpinelinux.org/package/edge/main/x86/gmp) via Alpine Package Manager
