### PR TITLE
AAC-547 - Add implementation of Feature Flag class

### DIFF
--- a/lib/feature_flag.rb
+++ b/lib/feature_flag.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class Feature
+  def self.enabled?(feature_name)
+    flag = ENV.fetch(feature_name.upcase.to_s, false)
+    ActiveModel::Type::Boolean.new.cast(flag)
+  end
+end

--- a/spec/lib/feature_flag_spec.rb
+++ b/spec/lib/feature_flag_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'feature_flag'
+
+RSpec.describe Feature do
+  context 'when environment variable is not set' do
+    before do
+      ENV['TEST_VAR'] = nil
+    end
+
+    it 'returns false' do
+      expect(described_class.enabled?(:test_var)).to be false
+    end
+  end
+
+  context 'when environment variable is set to true' do
+    before do
+      ENV['TEST_VAR'] = 'true'
+    end
+
+    it 'returns true' do
+      expect(described_class.enabled?(:test_var)).to be true
+    end
+  end
+
+  context 'when environment variable is set to false' do
+    before do
+      ENV['TEST_VAR'] = 'false'
+    end
+
+    it 'returns false' do
+      expect(described_class.enabled?(:test_var)).to be false
+    end
+  end
+end


### PR DESCRIPTION
#### What

Add feature flag class to allow us to put future work behind feature flags for speed of development. 

#### Ticket

[Add feature flag ability to CD UI](https://dsdmoj.atlassian.net/browse/AAC-547)

#### Why

Future work is going to require us to iterate on our implementation without a production release. This should allow us to do just that. 

#### How

The class will read from the Environment variable the true/false value and return the bool. If it is not the a default false will be returned. 
