### PR TITLE
AAC-562 - Add additional error handling

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,6 +13,9 @@ class ApplicationController < ActionController::Base
   # https://apidock.com/rails/v6.0.0/ActiveSupport/Rescuable/ClassMethods/rescue_from
   rescue_from Exception, with: :unexpected_exception_handler
   rescue_from CanCan::AccessDenied, with: :access_denied
+  rescue_from ActiveResource::ForbiddenAccess, with: :active_resource_error
+  rescue_from ActiveResource::TimeoutError, with: :active_resource_error
+  rescue_from ActiveResource::ServerError, with: :active_resource_error
 
   def current_search_params=(params)
     session[:current_search_params] = params
@@ -51,5 +54,11 @@ class ApplicationController < ActionController::Base
       Sentry.capture_exception(exception)
       redirect_to controller: :errors, action: :internal_error
     end
+  end
+
+  def active_resource_error(exception)
+    Sentry.capture_exception(exception)
+    flash[:alert] = I18n.t('error.connection_error_message', it_helpdesk: I18n.t('error.it_helpdesk'))
+    redirect_to authenticated_root_path
   end
 end

--- a/spec/features/errors_spec.rb
+++ b/spec/features/errors_spec.rb
@@ -125,4 +125,76 @@ RSpec.feature 'Error page', type: :feature do
       expect(page).to have_current_path('/')
     end
   end
+
+  context 'when active resource forbidden error raised' do
+    let(:user) { create(:user) }
+
+    before do
+      sign_in user
+      allow(Rails.env).to receive(:production?).and_return true
+      allow(User).to receive(:find).and_raise(ActiveResource::ForbiddenAccess)
+    end
+
+    scenario 'returns 403' do
+      visit user_path(user.id)
+
+      within '.govuk-main-wrapper' do
+        expect(page).to have_css('.govuk-heading-xl', text: 'Sorry, something went wrong')
+        expect(page).to have_css('.govuk-body', text: 'Try again later.')
+        expect(page).to have_css('.govuk-body',
+                                 text: 'You can also browse from the homepage to find the information ')
+        expect(page).to have_css('.govuk-link', text: 'browse from the homepage')
+      end
+      click_link 'browse from the homepage'
+      expect(page).to have_current_path('/')
+    end
+  end
+
+  context 'when active resource timeout error raised' do
+    let(:user) { create(:user) }
+
+    before do
+      sign_in user
+      allow(Rails.env).to receive(:production?).and_return true
+      allow(User).to receive(:find).and_raise(ActiveResource::TimeoutError)
+    end
+
+    scenario 'returns 408' do
+      visit user_path(user.id)
+
+      within '.govuk-main-wrapper' do
+        expect(page).to have_css('.govuk-heading-xl', text: 'Sorry, something went wrong')
+        expect(page).to have_css('.govuk-body', text: 'Try again later.')
+        expect(page).to have_css('.govuk-body',
+                                 text: 'You can also browse from the homepage to find the information ')
+        expect(page).to have_css('.govuk-link', text: 'browse from the homepage')
+      end
+      click_link 'browse from the homepage'
+      expect(page).to have_current_path('/')
+    end
+  end
+
+  context 'when active resource server error raised' do
+    let(:user) { create(:user) }
+
+    before do
+      sign_in user
+      allow(Rails.env).to receive(:production?).and_return true
+      allow(User).to receive(:find).and_raise(ActiveResource::ServerError)
+    end
+
+    scenario 'returns 500' do
+      visit user_path(user.id)
+
+      within '.govuk-main-wrapper' do
+        expect(page).to have_css('.govuk-heading-xl', text: 'Sorry, something went wrong')
+        expect(page).to have_css('.govuk-body', text: 'Try again later.')
+        expect(page).to have_css('.govuk-body',
+                                 text: 'You can also browse from the homepage to find the information ')
+        expect(page).to have_css('.govuk-link', text: 'browse from the homepage')
+      end
+      click_link 'browse from the homepage'
+      expect(page).to have_current_path('/')
+    end
+  end
 end


### PR DESCRIPTION
#### What

Added additional error checking in the application controller for general Active Resource errors that may occur that we can capture

#### Ticket

[Add Application Level ActiveResource Error Handling](https://dsdmoj.atlassian.net/browse/AAC-562)

#### Why

Add resilience in our API

#### How

Capture 403, timeout and server errors at an application level to ensure that we display friendly information at the time of an error. Also log to sentry so we can know things are happening. 

