### PR TITLE
AAC-606 - Add hearing events from V2 if flag enabled

### DIFF
--- a/app/controllers/hearings_controller.rb
+++ b/app/controllers/hearings_controller.rb
@@ -5,7 +5,8 @@ require_dependency 'court_data_adaptor'
 class HearingsController < ApplicationController
   before_action :load_and_authorize_search,
                 :set_hearing,
-                :set_hearing_day
+                :set_hearing_day,
+                :set_hearing_events
 
   add_breadcrumb :search_filter_breadcrumb_name, :new_search_filter_path
   add_breadcrumb :search_breadcrumb_name, :search_breadcrumb_path
@@ -47,6 +48,10 @@ class HearingsController < ApplicationController
     hearing_day
   end
 
+  def set_hearing_events
+    hearing_events if Feature.enabled?(:hearing_events)
+  end
+
   def hearing
     @hearing ||= helpers.decorate(prosecution_case.hearings.find { |hearing| hearing.id == params[:id] })
   end
@@ -62,6 +67,13 @@ class HearingsController < ApplicationController
 
   def prosecution_case
     @prosecution_case ||= helpers.decorate(@prosecution_case_search.execute.first)
+  end
+
+  def hearing_events
+    @hearing_events ||= CdApi::HearingEvents.find(params[:id],
+                                                  params: {
+                                                    date: paginator.current_item.hearing_date.strftime('%F')
+                                                  })
   end
 
   def page

--- a/app/models/cd_api/hearing_events.rb
+++ b/app/models/cd_api/hearing_events.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module CdApi
+  class HearingEvents < BaseModel
+  end
+end

--- a/app/views/hearings/_hearing_events_v2.html.haml
+++ b/app/views/hearings/_hearing_events_v2.html.haml
@@ -1,0 +1,19 @@
+.govuk-heading-l
+  = t('hearings.show.events.title')
+%table.govuk-table{:class => "govuk-!-margin-bottom-9"}
+  %caption.govuk-table__caption.govuk-visually-hidden
+    = t('hearings.show.events.caption')
+  %thead.govuk-table__head
+    %tr.govuk-table__row
+      %th.govuk-table__header{ scope: 'col' }= t('hearings.show.events.time')
+      %th.govuk-table__header{ scope: 'col' }= t('hearings.show.events.event')
+  %tbody.govuk-table__body
+    - hearing_events.events.each do |event|
+      %tr.govuk-table__row
+        %td.govuk-table__cell
+          = event.event_time.to_datetime.strftime('%H:%M')
+        %td.govuk-table__cell.hearing-events-table__cell--overflow-wrap
+          = event.recorded_label
+          - if event&.note.present?
+            %div{ class: 'govuk-!-padding-top-1' }
+              = transform_and_sanitize(event.note)

--- a/app/views/hearings/show.html.haml
+++ b/app/views/hearings/show.html.haml
@@ -11,12 +11,16 @@
     = render partial: 'attendees', locals: { hearing: @hearing }
 
   .govuk-grid-column-two-thirds
-    - if @hearing.hearing_events
-      = render partial: 'hearing_events', locals: { hearing: @hearing, hearing_day: @hearing_day }
-    
+    - unless Feature.enabled?(:hearing_events)
+      - if @hearing.hearing_events
+        = render partial: 'hearing_events', locals: { hearing: @hearing, hearing_day: @hearing_day }
+    - else
+      - if @hearing_events
+        = render partial: 'hearing_events_v2', locals: { hearing_events: @hearing_events, hearing_day: @hearing_day }
+
     - if @hearing.cracked_ineffective_trial
       = render partial: 'hearing_result', locals: { hearing: @hearing }
-    
+
     = render partial: 'court_applications', locals: { hearing: @hearing }
 
 - if Rails.configuration.x.display_raw_responses

--- a/spec/fixtures/stubs/cd_api/hearing_events_empty_response.json
+++ b/spec/fixtures/stubs/cd_api/hearing_events_empty_response.json
@@ -1,0 +1,5 @@
+{
+  "hearing_id": "944a6542-ffcb-4cd0-94ce-fda3ffc3081b",
+  "has_active_hearing": false,
+  "events": []
+}

--- a/spec/fixtures/stubs/cd_api/hearing_events_response.json
+++ b/spec/fixtures/stubs/cd_api/hearing_events_response.json
@@ -1,0 +1,56 @@
+{
+  "hearing_id": "844a6542-ffcb-4cd0-94ce-fda3ffc3081b",
+  "has_active_hearing": true,
+  "events": [
+    {
+      "id": "ce632946-994f-4201-8a35-6438770fb9b9",
+      "definition_id": "cbe94a12-0c0c-4b04-8585-789dbd23a913",
+      "defence_counsel_id": null,
+      "recorded_label": "Hearing event 0",
+      "event_time": "2019-10-23T08:30:00+00:00",
+      "last_modified_time": "2021-02-09T10:24:41.848000+00:00",
+      "alterable": false,
+      "note": "Hearing note 0"
+    },
+    {
+      "id": "5e26ad45-7730-4a9e-9a81-83d5f4dd913e",
+      "definition_id": "f1ffcd77-648d-46d6-bdf6-edc2f8f31543",
+      "defence_counsel_id": null,
+      "recorded_label": "Hearing event 1",
+      "event_time": "2019-10-23T09:30:00+00:00",
+      "last_modified_time": "2021-02-09T10:24:41.870000+00:00",
+      "alterable": false,
+      "note": null
+    },
+    {
+      "id": "63f7cb8f-a95d-49cc-8d44-7ecd51ecdd08",
+      "definition_id": "7d10db9a-2e60-4879-8c93-964372bd14f6",
+      "defence_counsel_id": null,
+      "recorded_label": "Hearing event 2",
+      "event_time": "2019-10-23T10:30:00+00:00",
+      "last_modified_time": "2021-02-09T10:24:41.895000+00:00",
+      "alterable": false,
+      "note": "!\\\"#£%&()*,-./Æ½ŵ€"
+    },
+    {
+      "id": "a159016f-e852-4caf-b4a6-fa4d458702de",
+      "definition_id": "75447148-bae9-4381-870b-3a4d84068015",
+      "defence_counsel_id": null,
+      "recorded_label": "Hearing event 3",
+      "event_time": "2019-10-23T11:30:00+00:00",
+      "last_modified_time": "2021-02-09T10:24:41.919000+00:00",
+      "alterable": false,
+      "note": "<b>a comment</b> <script>and (this is another example)</script>"
+    },
+    {
+      "id": "82ea36e8-6b91-4dbe-9d49-ff96c3d20ece",
+      "definition_id": "63231346-56de-497c-bb38-06b953f02bad",
+      "defence_counsel_id": null,
+      "recorded_label": "Hearing event 4",
+      "event_time": "2019-10-23T12:30:00+00:00",
+      "last_modified_time": "2021-02-09T10:24:41.939000+00:00",
+      "alterable": false,
+      "note": "\ntext\r\nmore details\rother information"
+    }
+  ]
+}

--- a/spec/requests/hearings_spec.rb
+++ b/spec/requests/hearings_spec.rb
@@ -50,4 +50,17 @@ RSpec.describe 'hearings', type: :request do
       expect(flash.now[:notice]).to match(/No hearing details available/)
     end
   end
+
+  context 'when v2 is enabled', stub_v2_hearing_events: true, stub_case_search: true do
+    before do
+      allow(Feature).to receive(:enabled?).with(:defendants_search).and_return(false)
+      allow(Feature).to receive(:enabled?).with(:hearing_events).and_return(true)
+      sign_in user
+      get "/hearings/#{hearing_id_from_fixture}?page=0&urn=#{case_reference}"
+    end
+
+    it 'shows v2 hearing table' do
+      expect(response).to render_template(:_hearing_events_v2)
+    end
+  end
 end

--- a/spec/support/webmock/court_data_api/webmock.rb
+++ b/spec/support/webmock/court_data_api/webmock.rb
@@ -157,4 +157,28 @@ RSpec.configure do |config|
       body: ''
     )
   end
+
+  config.before(:each, stub_v2_hearing_events: true) do
+    stub_request(
+      :get, %r{/v2/hearing_events/844a6542-ffcb-4cd0-94ce-fda3ffc3081b}
+    ).with(
+      query: { :date => '2021-01-17' }
+    ).to_return(
+      status: 200,
+      headers: { 'Content-Type' => 'application/json' },
+      body: load_json_stub('cd_api/hearing_events_response.json')
+    )
+  end
+
+  config.before(:each, stub_v2_hearing_events_empty: true) do
+    stub_request(
+      :get, %r{/v2/hearing_events/844a6542-ffcb-4cd0-94ce-fda3ffc3081b}
+    ).with(
+      query: { :date => '2021-01-17' }
+    ).to_return(
+      status: 200,
+      headers: { 'Content-Type' => 'application/json' },
+      body: load_json_stub('cd_api/hearing_events_empty_response.json')
+    )
+  end
 end

--- a/spec/support/webmock/court_data_api/webmock.rb
+++ b/spec/support/webmock/court_data_api/webmock.rb
@@ -162,7 +162,7 @@ RSpec.configure do |config|
     stub_request(
       :get, %r{/v2/hearing_events/844a6542-ffcb-4cd0-94ce-fda3ffc3081b}
     ).with(
-      query: { :date => '2021-01-17' }
+      query: { date: '2021-01-17' }
     ).to_return(
       status: 200,
       headers: { 'Content-Type' => 'application/json' },
@@ -174,7 +174,7 @@ RSpec.configure do |config|
     stub_request(
       :get, %r{/v2/hearing_events/844a6542-ffcb-4cd0-94ce-fda3ffc3081b}
     ).with(
-      query: { :date => '2021-01-17' }
+      query: { date: '2021-01-17' }
     ).to_return(
       status: 200,
       headers: { 'Content-Type' => 'application/json' },

--- a/spec/support/webmock/court_data_api/webmock.rb
+++ b/spec/support/webmock/court_data_api/webmock.rb
@@ -160,9 +160,9 @@ RSpec.configure do |config|
 
   config.before(:each, stub_v2_hearing_events: true) do
     stub_request(
-      :get, %r{/v2/hearing_events/844a6542-ffcb-4cd0-94ce-fda3ffc3081b}
+      :get, %r{/v2/hearing_events/*}
     ).with(
-      query: { date: '2021-01-17' }
+      query: { date: '2019-10-23' }
     ).to_return(
       status: 200,
       headers: { 'Content-Type' => 'application/json' },
@@ -172,9 +172,9 @@ RSpec.configure do |config|
 
   config.before(:each, stub_v2_hearing_events_empty: true) do
     stub_request(
-      :get, %r{/v2/hearing_events/844a6542-ffcb-4cd0-94ce-fda3ffc3081b}
+      :get, %r{/v2/hearing_events/*}
     ).with(
-      query: { date: '2021-01-17' }
+      query: { date: '2019-10-23' }
     ).to_return(
       status: 200,
       headers: { 'Content-Type' => 'application/json' },

--- a/spec/views/hearings/_hearing_events_v2.html.haml_spec.rb
+++ b/spec/views/hearings/_hearing_events_v2.html.haml_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'hearings/_hearing_events_v2.html.haml', type: :view do
     render partial: 'hearing_events_v2', locals: { hearing_events:, hearing_day: }
   end
 
-  let(:hearing_day) { Date.parse('2021-01-17T10:30:00.000Z') }
+  let(:hearing_day) { Date.parse('2019-10-23T10:30:00.000Z') }
   let(:hearing_events) do
     CdApi::HearingEvents.find('844a6542-ffcb-4cd0-94ce-fda3ffc3081b',
                               params: { date: hearing_day.strftime('%F') })

--- a/spec/views/hearings/_hearing_events_v2.html.haml_spec.rb
+++ b/spec/views/hearings/_hearing_events_v2.html.haml_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+RSpec.describe 'hearings/_hearing_events_v2.html.haml', type: :view do
+  subject(:render_partial) do
+    render partial: 'hearing_events_v2', locals: { hearing_events:, hearing_day: }
+  end
+
+  let(:hearing_day) { Date.parse('2021-01-17T10:30:00.000Z') }
+  let(:hearing_events) do
+    CdApi::HearingEvents.find('844a6542-ffcb-4cd0-94ce-fda3ffc3081b',
+                              params: { date: hearing_day.strftime('%F') })
+  end
+
+  context 'without hearing_events', stub_v2_hearing_events_empty: true do
+    it 'renders template without error' do
+      is_expected.to render_template(:_hearing_events_v2)
+    end
+  end
+
+  context 'with hearing events', stub_v2_hearing_events: true do
+    it 'displays hearing event row columns' do
+      is_expected
+        .to have_selector('thead th', text: 'Time')
+        .and have_selector('thead th', text: 'Event')
+    end
+
+    context 'with hearing_events notes' do
+      it 'displays the notes' do
+        is_expected
+          .to have_content('Hearing event 0')
+          .and have_content('Hearing note 0')
+      end
+    end
+
+    context 'with no hearing_events notes' do
+      it 'displays the row' do
+        is_expected
+          .to have_content('Hearing event 1')
+      end
+    end
+
+    context 'with notes containing html, unicode and crlf_escape_sequences' do
+      it 'renders unicode characters correctly' do
+        is_expected.to have_content('!\"#£%&()*,-./Æ½ŵ€')
+      end
+
+      it 'does not render unpermitted html' do
+        is_expected.to have_content('a comment and (this is another example)')
+      end
+
+      it 'renders crlf escape sequences correctly' do
+        is_expected.to have_content("text\nmore details\nother information\n")
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What

Add Hearing Events to come from V2 if hearing_events env var is enabled. 

#### Ticket

[Integrate CDAPI Hearing Events to the Hearing Page events table](https://dsdmoj.atlassian.net/browse/AAC-606)

#### Why

Migration to V2 for View Court Data

#### How

- Create new v2 hearing_events partial as we no longer need a decorator to sort through the prosecution_cases response
- Add model to hit hearing_events endpoint
- Add logic into hearings controller to call hearing_events if V2 enabled
- Add logic in hearing page to show correct table based on V2 flag
