### PR TITLE
AAC-584 - Update to set env_var to true

### DIFF
--- a/.k8s/live/production/deployment.yaml
+++ b/.k8s/live/production/deployment.yaml
@@ -61,6 +61,8 @@ spec:
               value: enabled
             - name: GA_TRACKING_ID
               value: 'UA-131160087-15'
+            - name: LAA_REFERENCES
+              value: 'true'
             - name: RAILS_LOG_TO_STDOUT
               value: enabled
             - name: COURT_DATA_ADAPTOR_API_UID


### PR DESCRIPTION
#### What

Add LAA_REFERENCES env var to prod and set to true for V2 release of MAAT linking and unlinking

#### Ticket

[CDUI - Enable MAAT Linking/ Unlinking in V2](https://dsdmoj.atlassian.net/browse/AAC-584)

#### Why

V2 Migration
