### PR TITLE
AAC-625 - Put feedback form behind auth

### DIFF
--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 class FeedbackController < ApplicationController
-  skip_before_action :authenticate_user!
-  skip_authorization_check
+  load_and_authorize_resource
 
   def new
     @feedback = Feedback.new

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -49,6 +49,7 @@ class Ability
     can_query_cdapi
     can_manage_links
     can_manage_self
+    can_feedback
   end
 
   def manager_abilities
@@ -56,6 +57,7 @@ class Ability
     can_query_cdapi
     can_manage_links
     can :manage, User
+    can_feedback
   end
 
   def admin_abilities
@@ -80,5 +82,9 @@ class Ability
 
   def can_manage_self
     can %i[show manage_password], User, id: user.id
+  end
+
+  def can_feedback
+    can %i[new create], Feedback
   end
 end

--- a/spec/features/feedback_spec.rb
+++ b/spec/features/feedback_spec.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 RSpec.feature 'Feedback', type: :feature do
-  scenario 'user clicks feedback link' do
+  let(:user) { create(:user) }
+
+  scenario 'user clicks feedback link signed in' do
+    sign_in user
     visit new_feedback_path
 
     expect(page).to have_govuk_page_title(text: 'Help us improve this service')
@@ -24,5 +27,12 @@ RSpec.feature 'Feedback', type: :feature do
 
     expect(page).to have_govuk_flash(:notice, text: 'Your feedback has been submitted')
     expect(page).to have_current_path(authenticated_root_path)
+  end
+
+  scenario 'user clicks feedback link unauthenticated' do
+    visit new_feedback_path
+
+    expect(page).to have_current_path('/users/sign_in')
+    expect(page).to have_govuk_flash(:alert, text: 'You need to sign in before continuing.')
   end
 end

--- a/spec/requests/feedback_spec.rb
+++ b/spec/requests/feedback_spec.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
 RSpec.describe 'feedback', type: :request do
+  let(:user) { create(:user) }
   let(:message_delivery) { instance_double(FeedbackMailer::MessageDelivery) }
+
+  before do
+    sign_in user
+  end
 
   context 'when clicking the feedback link', type: :request do
     before { get '/feedback/new' }


### PR DESCRIPTION
#### What

Put feedback form behind auth to prevent unwanted bot attacks.

#### Ticket

[Move Court Data Feedback form behind an authorisation wall](https://dsdmoj.atlassian.net/browse/AAC-625)

#### Why

Bot attacks focus this form due to its un-authenticated nature. 