### PR TITLE
AAC-631 - Add error handling around hearing events

### DIFF
--- a/config/initializers/logstasher.rb
+++ b/config/initializers/logstasher.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+if LogStasher.enabled?
+  LogStasher.add_custom_fields_to_request_context do |fields|
+    fields[:headers] = log_headers request.headers.env
+  end
+end
+
+def log_headers(headers)
+  headers.select { |key, _value| key.match('^HTTP.*') }
+end

--- a/config/locales/en/views/error.yml
+++ b/config/locales/en/views/error.yml
@@ -13,3 +13,4 @@ en:
     connection_error_message: There was a problem getting the information you requested. %{it_helpdesk}
     description_html: You can also <a class="govuk-link" href="/">browse from the homepage</a> to find the information you need.
     it_helpdesk: If this problem persists, please contact the IT Helpdesk on 0800 9175148.
+    refresh: Please refresh the page.

--- a/config/locales/en/views/hearings.yml
+++ b/config/locales/en/views/hearings.yml
@@ -27,6 +27,7 @@ en:
         title: Events
       flash:
         notice:
+          events_error: There was an error retrieving the hearing events from the server
           no_hearing_details: No hearing details available
           server_error: Error retrieving data from server
       hearing_type: Hearing type

--- a/spec/features/hearings_v2_spec.rb
+++ b/spec/features/hearings_v2_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.feature 'Viewing the hearings page', type: :feature, stub_case_search: true,
-                                           stub_v2_hearing_events: true, stub_v2_hearing_summary: true do
+RSpec.feature 'Viewing the hearings page', type: :feature, stub_case_search: true, stub_v2_hearing_summary: true do
   let(:user) { create(:user) }
   let(:api_url_v2) { CdApi::BaseModel.site }
   let(:api_events_path) { "#{api_url_v2}hearing_events/#{hearing_id}?date=2019-10-23" }
@@ -20,40 +19,117 @@ RSpec.feature 'Viewing the hearings page', type: :feature, stub_case_search: tru
     visit(url)
   end
 
-  context 'when user views hearing page', stub_v2_hearing_data: true do
+  context 'when user views hearing page', stub_v2_hearing_data: true, stub_v2_hearing_events: true do
     let(:url) { "hearings/#{hearing_id}?column=date&direction=asc&page=0&urn=#{case_reference}" }
 
-    it 'requests data for hearing summary' do
-      expect(a_request(:get, api_summary_path))
-        .to have_been_made.once
+    context 'with hearing events', stub_v2_hearing_events: true do
+      it 'requests data for hearing summary' do
+        expect(a_request(:get, api_summary_path))
+          .to have_been_made.once
+      end
+
+      it 'requests data for hearing events' do
+        expect(a_request(:get, api_events_path)
+                 .with(query: { date: '2019-10-23' }))
+          .to have_been_made.once
+      end
+
+      it 'requests data for hearing data' do
+        expect(a_request(:get, api_data_path)
+                 .with(query: { date: '2019-10-23' }))
+          .to have_been_made.once
+      end
+
+      it 'displays details section' do
+        expect(page).to have_css('.govuk-heading-l', text: 'Details')
+      end
+
+      it 'displays attendees section' do
+        expect(page).to have_css('.govuk-heading-l', text: 'Attendees')
+      end
+
+      it 'displays events section' do
+        expect(page).to have_css('.govuk-heading-l', text: 'Events')
+      end
+
+      it 'displays court applications section' do
+        expect(page).to have_css('.govuk-heading-l', text: 'Court Applications')
+      end
     end
 
-    it 'requests data for hearing events' do
-      expect(a_request(:get, api_events_path)
-        .with(query: { date: '2019-10-23' }))
-        .to have_been_made.once
+    context 'with no hearing events', stub_v2_hearing_events_not_found: true do
+      it 'requests data for hearing summary' do
+        expect(a_request(:get, api_summary_path))
+          .to have_been_made.once
+      end
+
+      it 'requests data for hearing events' do
+        expect(a_request(:get, api_events_path)
+                 .with(query: { date: '2019-10-23' }))
+          .to have_been_made.once
+      end
+
+      it 'requests data for hearing data' do
+        expect(a_request(:get, api_data_path)
+                 .with(query: { date: '2019-10-23' }))
+          .to have_been_made.once
+      end
+
+      it 'displays details section' do
+        expect(page).to have_css('.govuk-heading-l', text: 'Details')
+      end
+
+      it 'displays attendees section' do
+        expect(page).to have_css('.govuk-heading-l', text: 'Attendees')
+      end
+
+      it 'displays events section' do
+        expect(page).not_to have_css('.govuk-heading-l', text: 'Events')
+      end
+
+      it 'displays court applications section' do
+        expect(page).to have_css('.govuk-heading-l', text: 'Court Applications')
+      end
     end
 
-    it 'requests data for hearing data' do
-      expect(a_request(:get, api_data_path)
-        .with(query: { date: '2019-10-23' }))
-        .to have_been_made.once
-    end
+    context 'with error fetching hearing events', stub_v2_hearing_events_error: true do
+      it 'requests data for hearing summary' do
+        expect(a_request(:get, api_summary_path))
+          .to have_been_made.once
+      end
 
-    it 'displays details section' do
-      expect(page).to have_css('.govuk-heading-l', text: 'Details')
-    end
+      it 'requests data for hearing events' do
+        expect(a_request(:get, api_events_path)
+                 .with(query: { date: '2019-10-23' }))
+          .to have_been_made.once
+      end
 
-    it 'displays attendees section' do
-      expect(page).to have_css('.govuk-heading-l', text: 'Attendees')
-    end
+      it 'requests data for hearing data' do
+        expect(a_request(:get, api_data_path)
+                 .with(query: { date: '2019-10-23' }))
+          .to have_been_made.once
+      end
 
-    it 'displays events section' do
-      expect(page).to have_css('.govuk-heading-l', text: 'Events')
-    end
+      it 'displays details section' do
+        expect(page).to have_css('.govuk-heading-l', text: 'Details')
+      end
 
-    it 'displays court applications section' do
-      expect(page).to have_css('.govuk-heading-l', text: 'Court Applications')
+      it 'displays attendees section' do
+        expect(page).to have_css('.govuk-heading-l', text: 'Attendees')
+      end
+
+      it 'displays events section' do
+        expect(page).not_to have_css('.govuk-heading-l', text: 'Events')
+      end
+
+      it 'displays court applications section' do
+        expect(page).to have_css('.govuk-heading-l', text: 'Court Applications')
+      end
+
+      it 'displays flash at top of page' do
+        expect(page).to have_govuk_flash(:alert,
+                                         text: 'There was an error retrieving the hearing events from the server')
+      end
     end
   end
 end

--- a/spec/features/hearings_v2_spec.rb
+++ b/spec/features/hearings_v2_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-RSpec.feature 'Viewing the hearings page', type: :feature, stub_case_search: true, stub_v2_hearing_summary: true do
+RSpec.feature 'Viewing the hearings page', type: :feature, stub_case_search: true,
+                                           stub_v2_hearing_summary: true do
   let(:user) { create(:user) }
   let(:api_url_v2) { CdApi::BaseModel.site }
   let(:api_events_path) { "#{api_url_v2}hearing_events/#{hearing_id}?date=2019-10-23" }
@@ -128,7 +129,8 @@ RSpec.feature 'Viewing the hearings page', type: :feature, stub_case_search: tru
 
       it 'displays flash at top of page' do
         expect(page).to have_govuk_flash(:alert,
-                                         text: 'There was an error retrieving the hearing events from the server')
+                                         text: 'There was an error retrieving the hearing '\
+                                               'events from the server')
       end
     end
   end

--- a/spec/support/webmock/court_data_api/webmock.rb
+++ b/spec/support/webmock/court_data_api/webmock.rb
@@ -182,6 +182,26 @@ RSpec.configure do |config|
     )
   end
 
+  config.before(:each, stub_v2_hearing_events_not_found: true) do
+    stub_request(
+      :get, %r{/v2/hearing_events/#{hearing_id}}
+    ).with(
+      query: { date: '2019-10-23' }
+    ).to_return(
+      status: 404
+    )
+  end
+
+  config.before(:each, stub_v2_hearing_events_error: true) do
+    stub_request(
+      :get, %r{/v2/hearing_events/#{hearing_id}}
+    ).with(
+      query: { date: '2019-10-23' }
+    ).to_return(
+      status: 500
+    )
+  end
+
   config.before(:each, stub_v2_hearing_data: true) do
     stub_request(
       :get, %r{/v2/hearing/#{hearing_id}}


### PR DESCRIPTION
#### What

Adds error handling around the hearing events so that if we receive 400s the page doesnt error and if we receieve 424 or 500s we show a flash

#### Ticket

[CD UI - Hearing Events V2 Requires Error Handling](https://dsdmoj.atlassian.net/browse/AAC-631)

#### Why

To ensure a better user experience within the application

#### How

- Ensure 404 is captured and returns nil so that the events table is not rendered.
- Ensure 424 and 500s are captured, sent to sentry and return nil so table is not rendered. Also show flash to indicate there is an issue. 

