### PR TITLE
AAC-627 - Enable defendants search on Staging

### DIFF
--- a/.k8s/live/staging/deployment.yaml
+++ b/.k8s/live/staging/deployment.yaml
@@ -65,6 +65,8 @@ spec:
               value: enabled
             - name: LAA_REFERENCES
               value: 'true'
+            - name: DEFENDANTS_SEARCH
+              value: 'true'
             - name: DISPLAY_RAW_RESPONSES
               value: enabled
             - name: COURT_DATA_ADAPTOR_API_UID


### PR DESCRIPTION
#### What

Enable Defendant Search to utilise the V2 endpoints on Staging

This effects the Search Results page and the Defendants Page

#### Ticket

[CDUI - Enable Case Search Via V2](https://dsdmoj.atlassian.net/browse/AAC-627)

- [Related Dev PR](https://github.com/ministryofjustice/laa-court-data-ui/pull/999)

#### Why

V2 Migration

#### How

`DEFENDANTS_SEARCH: true`
