### PR TITLE
AAC-627 Rollback defendants search feature for Production and UAT

### DIFF
--- a/.k8s/live/production/deployment.yaml
+++ b/.k8s/live/production/deployment.yaml
@@ -64,7 +64,7 @@ spec:
             - name: LAA_REFERENCES
               value: 'true'
             - name: DEFENDANTS_SEARCH
-              value: 'true'
+              value: 'false'
             - name: RAILS_LOG_TO_STDOUT
               value: enabled
             - name: COURT_DATA_ADAPTOR_API_UID

--- a/.k8s/live/uat/deployment.yaml
+++ b/.k8s/live/uat/deployment.yaml
@@ -66,7 +66,7 @@ spec:
             - name: LAA_REFERENCES
               value: 'true'
             - name: DEFENDANTS_SEARCH
-              value: 'true'
+              value: 'false'
             - name: DISPLAY_RAW_RESPONSES
               value: enabled
             - name: COURT_DATA_ADAPTOR_API_UID


### PR DESCRIPTION
Rollback from production and uat for defendants search because of missing plea data in prod

#### What

#### Ticket

[board ticket description](link)