### PR TITLE
Split Feature Flags for Defendant Page and Search page

### DIFF
--- a/app/controllers/defendants_controller.rb
+++ b/app/controllers/defendants_controller.rb
@@ -52,7 +52,7 @@ class DefendantsController < ApplicationController
   end
 
   def load_and_authorize_defendant_search
-    if Feature.enabled?(:defendants_search)
+    if Feature.enabled?(:defendants_page)
       @defendant_search = CdApi::SearchService.new('uuid_reference', { uuid: defendant_params[:id],
                                                                        urn: defendant_params[:urn] }, nil)
     else

--- a/app/controllers/laa_references_controller.rb
+++ b/app/controllers/laa_references_controller.rb
@@ -57,7 +57,7 @@ class LaaReferencesController < ApplicationController
   end
 
   def load_and_authorize_defendant_search
-    if Feature.enabled?(:defendants_search)
+    if Feature.enabled?(:defendants_page)
       @defendant_search = CdApi::SearchService.new('uuid_reference', { uuid: defendant_uuid,
                                                                        urn: laa_reference_params[:urn] }, nil)
     else

--- a/app/views/defendants/_form.html.haml
+++ b/app/views/defendants/_form.html.haml
@@ -3,7 +3,7 @@
 
   = render 'defendants/defendant'
 
-  - if Feature.enabled?(:defendants_search)
+  - if Feature.enabled?(:defendants_page)
     = render 'defendants/offences_v2'
   - else
     = render 'defendants/offences'

--- a/app/views/laa_references/_form.html.haml
+++ b/app/views/laa_references/_form.html.haml
@@ -3,7 +3,7 @@
 
   = render 'defendants/defendant'
 
-  - if Feature.enabled?(:defendants_search)
+  - if Feature.enabled?(:defendants_page)
     = render 'defendants/offences_v2'
   - else
     = render 'defendants/offences'

--- a/config/database.yml
+++ b/config/database.yml
@@ -29,10 +29,10 @@ development:
   # To create additional roles in postgres see `$ createuser --help`.
   # When left blank, postgres will use the default role. This is
   # the same name as the operating system user that initialized the database.
-  username:  postgres
+  #username: laa_court_data_ui
 
   # The password associated with the postgres role (username).
-  password: Pass2021!
+  #password:
 
   # Connect on a TCP socket. Omitted by default since the client uses a
   # domain socket that doesn't need configuration. Windows does not have
@@ -41,7 +41,7 @@ development:
 
   # The TCP port the server listens on. Defaults to 5432.
   # If your server runs on a different port number, change accordingly.
-  port: 5432
+  #port: 5432
 
   # Schema search path. The server defaults to $user,public
   #schema_search_path: myapp,sharedapp,public
@@ -58,23 +58,6 @@ development:
 test:
   <<: *default
   database: laa_court_data_ui_test
- # The specified database role being used to connect to postgres.
-  # To create additional roles in postgres see `$ createuser --help`.
-  # When left blank, postgres will use the default role. This is
-  # the same name as the operating system user that initialized the database.
-  username:  postgres
-
-  # The password associated with the postgres role (username).
-  password: Pass2021!
-
-  # Connect on a TCP socket. Omitted by default since the client uses a
-  # domain socket that doesn't need configuration. Windows does not have
-  # domain sockets, so uncomment these lines.
-  #host: localhost
-
-  # The TCP port the server listens on. Defaults to 5432.
-  # If your server runs on a different port number, change accordingly.
-  port: 5432
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is

--- a/config/database.yml
+++ b/config/database.yml
@@ -29,10 +29,10 @@ development:
   # To create additional roles in postgres see `$ createuser --help`.
   # When left blank, postgres will use the default role. This is
   # the same name as the operating system user that initialized the database.
-  #username: laa_court_data_ui
+  username:  postgres
 
   # The password associated with the postgres role (username).
-  #password:
+  password: Pass2021!
 
   # Connect on a TCP socket. Omitted by default since the client uses a
   # domain socket that doesn't need configuration. Windows does not have
@@ -41,7 +41,7 @@ development:
 
   # The TCP port the server listens on. Defaults to 5432.
   # If your server runs on a different port number, change accordingly.
-  #port: 5432
+  port: 5432
 
   # Schema search path. The server defaults to $user,public
   #schema_search_path: myapp,sharedapp,public
@@ -58,6 +58,23 @@ development:
 test:
   <<: *default
   database: laa_court_data_ui_test
+ # The specified database role being used to connect to postgres.
+  # To create additional roles in postgres see `$ createuser --help`.
+  # When left blank, postgres will use the default role. This is
+  # the same name as the operating system user that initialized the database.
+  username:  postgres
+
+  # The password associated with the postgres role (username).
+  password: Pass2021!
+
+  # Connect on a TCP socket. Omitted by default since the client uses a
+  # domain socket that doesn't need configuration. Windows does not have
+  # domain sockets, so uncomment these lines.
+  #host: localhost
+
+  # The TCP port the server listens on. Defaults to 5432.
+  # If your server runs on a different port number, change accordingly.
+  port: 5432
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is

--- a/spec/features/defendants_view_spec.rb
+++ b/spec/features/defendants_view_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature 'defendants view', type: :feature, stub_defendants_uuid_urn_search
   let(:defendant_id) { '844a6542-ffcb-4cd0-94ce-fda3ffc3081b' }
 
   before do
-    allow(Feature).to receive(:enabled?).with(:defendants_page).and_return(true)
+    allow(Feature).to receive(:enabled?).with(:defendants_search).and_return(true)
     sign_in user
   end
 

--- a/spec/features/defendants_view_spec.rb
+++ b/spec/features/defendants_view_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature 'defendants view', type: :feature, stub_defendants_uuid_urn_search
   let(:defendant_id) { '844a6542-ffcb-4cd0-94ce-fda3ffc3081b' }
 
   before do
-    allow(Feature).to receive(:enabled?).with(:defendants_search).and_return(true)
+    allow(Feature).to receive(:enabled?).with(:defendants_page).and_return(true)
     sign_in user
   end
 

--- a/spec/features/unlinking_a_defendant_from_maat_v2_spec.rb
+++ b/spec/features/unlinking_a_defendant_from_maat_v2_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature 'Unlinking a defendant from MAAT', type: :feature, stub_unlink_v2:
   let(:user) { create(:user) }
 
   before do
-    allow(Feature).to receive(:enabled?).with(:defendants_page).and_return(false)
+    allow(Feature).to receive(:enabled?).with(:defendants_search).and_return(false)
     allow(Feature).to receive(:enabled?).with(:laa_references).and_return(true)
     sign_in user
 

--- a/spec/features/unlinking_a_defendant_from_maat_v2_spec.rb
+++ b/spec/features/unlinking_a_defendant_from_maat_v2_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature 'Unlinking a defendant from MAAT', type: :feature, stub_unlink_v2:
   let(:user) { create(:user) }
 
   before do
-    allow(Feature).to receive(:enabled?).with(:defendants_search).and_return(false)
+    allow(Feature).to receive(:enabled?).with(:defendants_page).and_return(false)
     allow(Feature).to receive(:enabled?).with(:laa_references).and_return(true)
     sign_in user
 

--- a/spec/requests/linking/link_defendant_maat_reference_v2_spec.rb
+++ b/spec/requests/linking/link_defendant_maat_reference_v2_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'link defendant maat reference', type: :request, vcr: true, stub_
 
   before do
     allow(Feature).to receive(:enabled?).with(:laa_references).and_return(true)
-    allow(Feature).to receive(:enabled?).with(:defendants_page).and_return(false)
+    allow(Feature).to receive(:enabled?).with(:defendants_search).and_return(false)
     allow(Feature).to receive(:enabled?).with(:hearing_summaries).and_return(false)
   end
 

--- a/spec/requests/linking/link_defendant_maat_reference_v2_spec.rb
+++ b/spec/requests/linking/link_defendant_maat_reference_v2_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'link defendant maat reference', type: :request, vcr: true, stub_
 
   before do
     allow(Feature).to receive(:enabled?).with(:laa_references).and_return(true)
-    allow(Feature).to receive(:enabled?).with(:defendants_search).and_return(false)
+    allow(Feature).to receive(:enabled?).with(:defendants_page).and_return(false)
     allow(Feature).to receive(:enabled?).with(:hearing_summaries).and_return(false)
   end
 

--- a/spec/requests/unlinking/unlink_defendant_maat_reference_v2_spec.rb
+++ b/spec/requests/unlinking/unlink_defendant_maat_reference_v2_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'unlink defendant maat reference', type: :request, stub_unlink_v2
   before do
     create(:unlink_reason, code: 1, description: 'Reason not requiring text', text_required: false)
     create(:unlink_reason, code: 7, description: 'Reason requiring text', text_required: true)
-    allow(Feature).to receive(:enabled?).with(:defendants_page).and_return(false)
+    allow(Feature).to receive(:enabled?).with(:defendants_search).and_return(false)
     allow(Feature).to receive(:enabled?).with(:laa_references).and_return(true)
   end
 

--- a/spec/requests/unlinking/unlink_defendant_maat_reference_v2_spec.rb
+++ b/spec/requests/unlinking/unlink_defendant_maat_reference_v2_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'unlink defendant maat reference', type: :request, stub_unlink_v2
   before do
     create(:unlink_reason, code: 1, description: 'Reason not requiring text', text_required: false)
     create(:unlink_reason, code: 7, description: 'Reason requiring text', text_required: true)
-    allow(Feature).to receive(:enabled?).with(:defendants_search).and_return(false)
+    allow(Feature).to receive(:enabled?).with(:defendants_page).and_return(false)
     allow(Feature).to receive(:enabled?).with(:laa_references).and_return(true)
   end
 


### PR DESCRIPTION
#### What


#### Ticket

[Split Feature Flags for Defendant Page and Search page](https://dsdmoj.atlassian.net/browse/AAC-635)

#### Why
Currently the Search page in the beginning of the user journey of CD UI and the Defendant page after the Prosecution Case page are under one feature flag for v2 (DEFENDANT_SEARCH). This means both have to be ready to release either. 

To allow us to be more flexible and deliver value to users quicker, we should split these flags up into: 
DEFENDANT_SEARCH

DEFENDANT_PAGE

#### How
Split defendant feature flags to: 
DEFENDANT_SEARCH
DEFENDANT_PAGE

