### PR TITLE
Re-enable DEFENDANT_SEARCH flag in UAT

### DIFF
--- a/.k8s/live/uat/deployment.yaml
+++ b/.k8s/live/uat/deployment.yaml
@@ -66,7 +66,7 @@ spec:
             - name: LAA_REFERENCES
               value: 'true'
             - name: DEFENDANTS_SEARCH
-              value: 'false'
+              value: 'true'
             - name: DISPLAY_RAW_RESPONSES
               value: enabled
             - name: COURT_DATA_ADAPTOR_API_UID


### PR DESCRIPTION
#### Ticket

[CDUI - Enable defendant search via v2](https://github.com/ministryofjustice/laa-court-data-ui/pull/1010)

#### Why
Now that the work has been done and implemented to have a feature flag around V1/V2 of the Common Platform Case searching work, we need to enable it in the environments so that it can be tested/used and ensure that it is working as intended and then released for general use (without affecting the defendant page)


#### How
Change UAT DEFENDANTS_SEARCH flag in kubernetes deployment config file
