### PR TITLE
Enable DEFENDANTS_SEARCH flag in production

### DIFF
--- a/.k8s/live/production/deployment.yaml
+++ b/.k8s/live/production/deployment.yaml
@@ -64,7 +64,7 @@ spec:
             - name: LAA_REFERENCES
               value: 'true'
             - name: DEFENDANTS_SEARCH
-              value: 'false'
+              value: 'true'
             - name: RAILS_LOG_TO_STDOUT
               value: enabled
             - name: COURT_DATA_ADAPTOR_API_UID


### PR DESCRIPTION
#### Ticket

[CD UI - Enable Defendants Search](https://dsdmoj.atlassian.net/jira/software/c/projects/AAC/boards/622?modal=detail&selectedIssue=AAC-636)

#### Why
Now that the work has been done and implemented to have a feature flag around V1/V2 of the Common Platform Case searching work, we need to enable it in the environments so that it can be tested/used and ensure that it is working as intended and then released for general use.

