### PR TITLE
Enable HEARING flag on UAT

### DIFF
--- a/.k8s/live/uat/deployment.yaml
+++ b/.k8s/live/uat/deployment.yaml
@@ -67,6 +67,8 @@ spec:
               value: 'true'
             - name: DEFENDANTS_SEARCH
               value: 'true'
+            - name: HEARING
+              value: 'true'
             - name: DISPLAY_RAW_RESPONSES
               value: enabled
             - name: COURT_DATA_ADAPTOR_API_UID


### PR DESCRIPTION
#### What
Enable HEARING flag on UAT by setting to TRUE in deployment.yaml file
#### Ticket

[CDUI - Enable Population of Hearing Day Via V2](https://dsdmoj.atlassian.net/jira/software/c/projects/AAC/boards/622?modal=detail&selectedIssue=AAC-628)

#### Why
So that we can test UAT to confirm no negative impact to users as we enable v2

--------

#### TODO (wip)

 - [ ] Upload and test
