### PR TITLE
Aac 656 accessing defendant page via search

### DIFF
--- a/app/models/cd_api/defendant.rb
+++ b/app/models/cd_api/defendant.rb
@@ -3,7 +3,7 @@
 module CdApi
   class Defendant < BaseModel
     def linked?
-      self.offence_summaries[0]&.laa_application&.reference&.present?
+      offence_summaries[0]&.laa_application&.reference&.present?
     end
   end
 end

--- a/app/models/cd_api/defendant.rb
+++ b/app/models/cd_api/defendant.rb
@@ -2,5 +2,8 @@
 
 module CdApi
   class Defendant < BaseModel
+    def linked?
+      self.offence_summaries[0]&.laa_application&.reference&.present?
+    end
   end
 end

--- a/app/models/cd_api/defendant.rb
+++ b/app/models/cd_api/defendant.rb
@@ -3,7 +3,8 @@
 module CdApi
   class Defendant < BaseModel
     def linked?
-      offence_summaries[0]&.laa_application&.reference&.present?
+      maat_references = offence_summaries.map { |offence| offence&.laa_application&.reference }
+      maat_references.compact.first.present?
     end
   end
 end


### PR DESCRIPTION
#### What
[Accessing Defendant Page via Search Fails in v2](https://dsdmoj.atlassian.net/jira/software/c/projects/AAC/boards/622?modal=detail&selectedIssue=AAC-656)

#### Why
Because when accessing defendant page via search page when search page is in v2, opening the page fails as the linked? method is missing

#### How
Add linked method to CD API defendant model using the first offence summary
