### PR TITLE
AAC-643 - Build speed increases and parrellism

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ references:
     save_cache:
       key: v4-bundle-{{ checksum "Gemfile.lock" }}
       paths:
-        - ~/vendor/bundle
+        - ~/.bundle
 
   _restore-assets: &restore-assets
     restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -338,7 +338,7 @@ workflows:
       - rspec-tests:
           requires:
             - build-test-container
-      - upload-coverage:
+      - upload-test-coverage:
           requires:
             - rspec-tests
       - build-app-container:
@@ -387,7 +387,7 @@ workflows:
       - rspec-tests:
           requires:
             - build-test-container
-      - upload-coverage:
+      - upload-test-coverage:
           requires:
             - rspec-tests
       - scan-docker-image:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,9 +9,9 @@ references:
   _restore-bundle: &restore-bundle
     restore_cache:
       keys:
-        - v4-bundle-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+        - v1-bundle-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
         # fallback to using the latest cache if no exact match is found
-        - v4-bundle-
+        - v1-bundle-
 
   _install-bundle: &install-bundle
     run:
@@ -25,7 +25,7 @@ references:
 
   _save-bundle: &save-bundle
     save_cache:
-      key: v4-bundle-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+      key: v1-bundle-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
       paths:
         - ~/.bundle
         - ~/vendor/bundle
@@ -33,9 +33,9 @@ references:
   _restore-assets: &restore-assets
     restore_cache:
       keys:
-        - v4-yarn-{{ .Branch }}-{{ checksum "yarn.lock" }}
+        - v1-yarn-{{ .Branch }}-{{ checksum "yarn.lock" }}
         # fallback to using the latest asset cache if no exact match is found
-        - v4-yarn-
+        - v1-yarn-
 
   _install-assets: &install-assets
     run:
@@ -46,7 +46,7 @@ references:
 
   _save-assets: &save-assets
     save_cache:
-      key: v4-yarn-{{ .Branch }}-{{ checksum "yarn.lock" }}
+      key: v1-yarn-{{ .Branch }}-{{ checksum "yarn.lock" }}
       paths:
         - node_modules
         - public/packs-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,6 +100,11 @@ commands:
       - *restore-assets
       - *install-assets
       - *save-assets
+    
+  restore-dependencies:
+    steps:
+      - *restore-bundle
+      - *restore-assets
 
   build-base:
     steps:
@@ -233,7 +238,7 @@ jobs:
     parallelism: 1
     steps:
       - checkout
-      - build-base
+      - restore-dependencies
       - linter
       - rubocop
       - brakeman
@@ -243,7 +248,7 @@ jobs:
     parallelism: 1
     steps:
       - checkout
-      - build-base
+      - restore-dependencies
       - *attach-tmp-workspace
       - browser-tools/install-browser-tools
       - rspec
@@ -263,7 +268,7 @@ jobs:
       - setup_remote_docker:
           version: 20.10.11
           docker_layer_caching: true
-      - build-base
+      - restore-dependencies
       - build-temp-image
       - snyk/scan:
           token-variable: SNYK_TOKEN

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -247,7 +247,7 @@ jobs:
 
   rspec-tests:
     executor: test-executor
-    parallelism: 1
+    parallelism: 4
     steps:
       - checkout
       - restore-dependencies
@@ -260,6 +260,11 @@ jobs:
             - coverage/codeclimate.*.json
       - store_artifacts:
           path: tmp/coverage
+  
+  upload-test-coverage:
+    executor: test-executor
+    steps:
+      - *attach-tmp-workspace
       - upload-coverage
 
   scan-docker-image:
@@ -333,6 +338,9 @@ workflows:
       - rspec-tests:
           requires:
             - build-test-container
+      - upload-coverage:
+          requires:
+            - rspec-tests
       - build-app-container:
           requires:
             - linter-tests
@@ -379,6 +387,9 @@ workflows:
       - rspec-tests:
           requires:
             - build-test-container
+      - upload-coverage:
+          requires:
+            - rspec-tests
       - scan-docker-image:
           requires:
             - build-test-container

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,12 +21,14 @@ references:
         gem install bundler -v $bundler_version
         bundle config set path '~/vendor/bundle'
         bundle check || bundle install --jobs=4 --retry=3
+        bundle clean --force
 
   _save-bundle: &save-bundle
     save_cache:
       key: v4-bundle-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
       paths:
         - ~/.bundle
+        - ~/vendor/bundle
 
   _restore-assets: &restore-assets
     restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ references:
   _restore-bundle: &restore-bundle
     restore_cache:
       keys:
-        - v4-bundle-{{ checksum "Gemfile.lock" }}
+        - v4-bundle-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
         # fallback to using the latest cache if no exact match is found
         - v4-bundle-
 
@@ -24,14 +24,14 @@ references:
 
   _save-bundle: &save-bundle
     save_cache:
-      key: v4-bundle-{{ checksum "Gemfile.lock" }}
+      key: v4-bundle-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
       paths:
         - ~/.bundle
 
   _restore-assets: &restore-assets
     restore_cache:
       keys:
-        - v4-yarn-{{ checksum "yarn.lock" }}
+        - v4-yarn-{{ .Branch }}-{{ checksum "yarn.lock" }}
         # fallback to using the latest asset cache if no exact match is found
         - v4-yarn-
 
@@ -44,7 +44,7 @@ references:
 
   _save-assets: &save-assets
     save_cache:
-      key: v4-yarn-{{ checksum "yarn.lock" }}
+      key: v4-yarn-{{ .Branch }}-{{ checksum "yarn.lock" }}
       paths:
         - node_modules
         - public/packs-test
@@ -268,7 +268,6 @@ jobs:
       - setup_remote_docker:
           version: 20.10.11
           docker_layer_caching: true
-      - restore-dependencies
       - build-temp-image
       - snyk/scan:
           token-variable: SNYK_TOKEN


### PR DESCRIPTION
#### What

Reuse cache for building to increase speed and parrellise the rspec tests to reduce time taken

#### Ticket

[Apply Parralelism to R-spec Testing in Circle CI](https://dsdmoj.atlassian.net/browse/AAC-643)

#### Why

Decrease time to production on code releases

#### How

- Reuse cached bundle/yarn
- parrellise rspec
- remove rebuilds in steps
- extra step for codeclimate away from push
