### PR TITLE
AAC-683 - Change the time we are using

### DIFF
--- a/app/views/hearings/_details_v2.haml
+++ b/app/views/hearings/_details_v2.haml
@@ -12,4 +12,4 @@
   .govuk-heading-s{:class => "govuk-!-margin-bottom-1"}
     = t('hearings.show.time_listed')
   %p.govuk-body{:class => "govuk-!-margin-bottom-2"}
-    = hearing.shared_time.to_datetime.strftime('%H:%M') || t('generic.not_available')
+    = hearing.hearing.hearing_days.first.sitting_day.to_datetime.strftime('%H:%M') || t('generic.not_available')


### PR DESCRIPTION
#### What

Using the `hearing_days` array and using the sittings day property to show the time listed as opposed to the `shared_time`

#### Ticket

[Repoint Time Listed on CD UI to Listing Time ](https://dsdmoj.atlassian.net/browse/AAC-683)

#### Why

Data parity between V1 and V2

