### PR TITLE
Enabled Hearing v2 flag on STAGING env

### DIFF
--- a/.k8s/live/staging/deployment.yaml
+++ b/.k8s/live/staging/deployment.yaml
@@ -67,6 +67,8 @@ spec:
               value: 'true'
             - name: DEFENDANTS_SEARCH
               value: 'true'
+            - name: HEARING
+              value: 'true'
             - name: DISPLAY_RAW_RESPONSES
               value: enabled
             - name: COURT_DATA_ADAPTOR_API_UID


### PR DESCRIPTION
#### What
Enable v2 Flag for Hearing page on STAGING environment
#### Ticket

[CDUI - Enable Population of Hearing Day Via V2](https://dsdmoj.atlassian.net/browse/AAC-628)

#### Why
To test v2 upgrade of VCD in Staging Environment - upgrade will lead to performance increase for users on VCD

#### How
Update Kubernetes deployment.yaml file for staging env
