### PR TITLE
Enable v2 HEARING flag on PRODUCTION

### DIFF
--- a/.k8s/live/production/deployment.yaml
+++ b/.k8s/live/production/deployment.yaml
@@ -65,6 +65,8 @@ spec:
               value: 'true'
             - name: DEFENDANTS_SEARCH
               value: 'true'
+            - name: HEARING
+              value: 'true'
             - name: RAILS_LOG_TO_STDOUT
               value: enabled
             - name: COURT_DATA_ADAPTOR_API_UID


### PR DESCRIPTION
What
Enable v2 Flag for Hearing page on PRODUCTION environment

Ticket
[CDUI - Enable Population of Hearing Day Via V2](https://dsdmoj.atlassian.net/browse/AAC-628)

Why
Upgrade will lead to performance increase for users on VCD

How
Update Kubernetes deployment.yaml file for production env