### PR TITLE
AAC-688 - laa-transaction-id journey from cdui

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,7 @@ class ApplicationController < ActionController::Base
 
   default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
   protect_from_forgery prepend: true, with: :exception
-  before_action :authenticate_user!, :set_default_cookies
+  before_action :authenticate_user!, :set_default_cookies, :set_transaction_id
   check_authorization
 
   # NOTE: errors checked bottom to top
@@ -52,5 +52,10 @@ class ApplicationController < ActionController::Base
       Sentry.capture_exception(exception)
       redirect_to controller: :errors, action: :internal_error
     end
+  end
+
+  def set_transaction_id
+    Current.request_id = request.headers['laa-transaction-id'] || request.request_id
+    response.set_header('laa-transaction-id', Current.request_id)
   end
 end

--- a/app/models/cd_api/base_model.rb
+++ b/app/models/cd_api/base_model.rb
@@ -12,7 +12,7 @@ module CdApi
     def self.headers
       {
         'Content-Type' => 'application/json',
-        'Laa-Transaction-Id' => SecureRandom.uuid
+        'Laa-Transaction-Id' => Current.request_id
       }
     end
   end

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Current < ActiveSupport::CurrentAttributes
+  attribute :request_id
+end

--- a/config/initializers/logstasher.rb
+++ b/config/initializers/logstasher.rb
@@ -3,6 +3,7 @@
 if LogStasher.enabled?
   LogStasher.add_custom_fields_to_request_context do |fields|
     fields[:headers] = log_headers request.headers.env
+    fields['laa-transaction-id'] = request.request_id
   end
 end
 


### PR DESCRIPTION
#### What

Start the correlation-id journey from the VCD frontend so that we can trace calls throughout the journey

#### Ticket

[CDUI: Add laa-transaction-id to the start of the journey](https://dsdmoj.atlassian.net/browse/AAC-688)

#### Why

Better tracability when debugging

#### How

- Set request_id in application controller, for incoming and outgoing requests
- set laa-transaction-id header based on this request_id
- Add the id to logs

### Evidence

Log entry below shows correlation between the 2 services.

https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-2w,to:now))&_a=(columns:!(_source),index:'45bb7370-00eb-11ec-b879-8f5b8a74f645',interval:auto,query:(language:kuery,query:'194a6d538921f075d95491f0947fa9c2'),sort:!(!('@timestamp',desc))) 