### PR TITLE
AAC-689 BugFix - Use sitting_day for time_listed on V2 hearing day page

### DIFF
--- a/app/views/hearings/_details_v2.haml
+++ b/app/views/hearings/_details_v2.haml
@@ -12,4 +12,4 @@
   .govuk-heading-s{:class => "govuk-!-margin-bottom-1"}
     = t('hearings.show.time_listed')
   %p.govuk-body{:class => "govuk-!-margin-bottom-2"}
-    = hearing.hearing.hearing_days.first.sitting_day.to_datetime.strftime('%H:%M') || t('generic.not_available')
+    = hearing_day.to_datetime.strftime('%H:%M') || t('generic.not_available')

--- a/spec/features/hearings_v2_spec.rb
+++ b/spec/features/hearings_v2_spec.rb
@@ -15,7 +15,6 @@ RSpec.feature 'Viewing the hearings page', type: :feature, stub_case_search: tru
     allow(Feature).to receive(:enabled?).with(:hearing_summaries).and_return(false)
     allow(Feature).to receive(:enabled?).with(:hearing).and_return(true)
     allow(Feature).to receive(:enabled?).with(:hearing_summaries).and_return(false)
-
     sign_in user
     visit(url)
   end
@@ -78,6 +77,16 @@ RSpec.feature 'Viewing the hearings page', type: :feature, stub_case_search: tru
 
       it 'displays details section' do
         expect(page).to have_css('.govuk-heading-l', text: 'Details')
+      end
+
+      context 'when raw response not displayed' do
+        before do
+          allow(Rails.configuration.x).to receive(:display_raw_responses).and_return(false)
+        end
+
+        it 'displays time listed' do
+          expect(page).to have_text '08:30'
+        end
       end
 
       it 'displays attendees section' do

--- a/spec/views/hearings/show.html.haml_spec.rb
+++ b/spec/views/hearings/show.html.haml_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe 'hearings/show.html.haml', type: :view do
     allow(prosecution_case).to receive(:hearings_sort_column=)
     allow(prosecution_case).to receive(:hearings_sort_direction=)
     assign(:hearing, decorated_hearing)
+    assign(:hearing_day, hearing_day)
     assign(:paginator, paginator)
   end
 

--- a/spec/views/hearings/show_v2.html.haml_spec.rb
+++ b/spec/views/hearings/show_v2.html.haml_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe 'hearings/show.html.haml', type: :view, stub_v2_hearing_data: tru
     allow(view).to receive(:govuk_page_title).and_return 'Hearings Page'
 
     assign(:hearing, hearing)
+    assign(:hearing_day, hearing_day)
     assign(:paginator, paginator)
   end
 


### PR DESCRIPTION
#### What

Use sitting_day for time_listed on V2 hearing day page

#### Ticket

[AAC-689](https://dsdmoj.atlassian.net/browse/AAC-689)

#### Why

Improve the accuracy of time_listed in V2 hearing day pages

#### How

Use hearing_day to acquire the time_listed from the sitting_day.

Test this with feature testing for now
