### PR TITLE
Remove test steps from test-build-deploy-master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -325,26 +325,9 @@ jobs:
 # ------------------
 workflows:
   version: 2
-  test-build-deploy-master:
+  build-deploy-master:
     jobs:
-      - build-test-container:
-          filters:
-            branches:
-              only:
-                - master
-      - linter-tests:
-          requires:
-            - build-test-container
-      - rspec-tests:
-          requires:
-            - build-test-container
-      - upload-test-coverage:
-          requires:
-            - rspec-tests
       - build-app-container:
-          requires:
-            - linter-tests
-            - rspec-tests
       - deploy-dev:
           context: laa-court-data-ui-live-dev
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -327,7 +327,7 @@ workflows:
   version: 2
   build-deploy-master:
     jobs:
-      - build-app-container:
+      - build-app-container
       - deploy-dev:
           context: laa-court-data-ui-live-dev
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -327,7 +327,11 @@ workflows:
   version: 2
   build-deploy-master:
     jobs:
-      - build-app-container
+      - build-app-container:
+        filters:
+          branches: 
+            only: 
+              - master
       - deploy-dev:
           context: laa-court-data-ui-live-dev
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -334,37 +334,30 @@ workflows:
       - build-app-container:
           <<: *master-only
       - deploy-dev:
-          <<: *master-only
           context: laa-court-data-ui-live-dev
           requires:
             - build-app-container
       - hold-staging:
-          <<: *master-only
           type: approval
           requires:
             - build-app-container
       - deploy-staging:
-          <<: *master-only
           context: laa-court-data-ui-live-staging
           requires:
             - hold-staging
       - hold-uat:
-          <<: *master-only
           type: approval
           requires:
             - build-app-container
       - deploy-uat:
-          <<: *master-only
           context: laa-court-data-ui-live-uat
           requires:
             - hold-uat
       - hold-production:
-          <<: *master-only
           type: approval
           requires:
             - build-app-container
       - deploy-production:
-          <<: *master-only
           context: laa-court-data-ui-live-production
           requires:
             - hold-production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,10 @@ references:
       command: |
         .circleci/build.sh
 
+  _master-only: &master-only
+    filters:
+      branches:
+        only: master
 # ------------------
 # EXECUTORS
 # ------------------
@@ -328,35 +332,39 @@ workflows:
   build-deploy-master:
     jobs:
       - build-app-container:
-        filters:
-          branches: 
-            only: 
-              - master
+          <<: *master-only
       - deploy-dev:
+          <<: *master-only
           context: laa-court-data-ui-live-dev
           requires:
             - build-app-container
       - hold-staging:
+          <<: *master-only
           type: approval
           requires:
             - build-app-container
       - deploy-staging:
+          <<: *master-only
           context: laa-court-data-ui-live-staging
           requires:
             - hold-staging
       - hold-uat:
+          <<: *master-only
           type: approval
           requires:
             - build-app-container
       - deploy-uat:
+          <<: *master-only
           context: laa-court-data-ui-live-uat
           requires:
             - hold-uat
       - hold-production:
+          <<: *master-only
           type: approval
           requires:
             - build-app-container
       - deploy-production:
+          <<: *master-only
           context: laa-court-data-ui-live-production
           requires:
             - hold-production


### PR DESCRIPTION
#### Ticket

[CD UI: Remove testing steps from deploy to master workflow](https://dsdmoj.atlassian.net/browse/AAC-696)

#### Why
The jobs aren't needed to run in this context, this will reduce deployment time

#### How
Remove all jobs before build-app-container in test-build-deploy-master workflow
Remove depedency of the removed jobs 
Changed name of test-build-deploy-master workflow to build-deploy-master
Apply a filter to the build-deploy-master workflow to only run on the master branch