### PR TITLE
AAC-152 - Add initial sign in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ Brewfile.lock.json
 .dccache
 .DS_Store
 .vscode
+cypress.env.json

--- a/Makefile
+++ b/Makefile
@@ -41,3 +41,7 @@ test: #: run test suite locally
 
 open: #: open localhost:3000 in default browser
 	@open http://localhost:3000
+
+e2e: #: run cypress end to end testing
+	@yarn install --frozen-lockfile
+	@yarn run start:server && yarn run cypress:run

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -11,8 +11,8 @@
         autocomplete: 'email',
         'data-cy': 'login-username')
 
-      = f.govuk_password_field(:password, 
-        label: { text: 'Password' }, 
+      = f.govuk_password_field(:password,
+        label: { text: 'Password' },
         autocomplete: 'current-password',
         'data-cy': 'login-password')
 

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -8,9 +8,13 @@
       = f.govuk_text_field(:login,
         label: { text: t('users.form.fields.login_label') },
         autofocus: true,
-        autocomplete: 'email')
+        autocomplete: 'email',
+        'data-cy': 'login-username')
 
-      = f.govuk_password_field(:password, label: { text: 'Password' }, autocomplete: 'current-password')
+      = f.govuk_password_field(:password, 
+        label: { text: 'Password' }, 
+        autocomplete: 'current-password',
+        'data-cy': 'login-password')
 
       - if devise_mapping.rememberable?
         = f.govuk_collection_radio_buttons :remember_me,
@@ -21,6 +25,6 @@
           legend: { text: 'Remember me', size: 's' },
           hint: { text: 'Do you want to be remembered on this computer?' }
 
-        = f.govuk_submit(t('devise.sessions.user.form.submit'))
+        = f.govuk_submit(t('devise.sessions.user.form.submit'), 'data-cy': 'login-submit')
 
     = render "devise/shared/links"

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -7,5 +7,11 @@ module.exports = defineConfig({
     ],
     baseUrl: "http://localhost:3000",
     video: false
+  },
+  env: {
+    environment: "local",
+    caseworker_password: "",
+    manager_password: "",
+    admin_password: ""
   }
 })

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -2,7 +2,7 @@ const { defineConfig } = require('cypress')
 
 module.exports = defineConfig({
   e2e: {
-    Hblockosts: [
+    blockHosts: [
       '*.google-analytics.com'
     ],
     baseUrl: 'http://localhost:3000',

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -3,15 +3,15 @@ const { defineConfig } = require('cypress')
 module.exports = defineConfig({
   e2e: {
     Hblockosts: [
-      "*.google-analytics.com"
+      '*.google-analytics.com'
     ],
-    baseUrl: "http://localhost:3000",
+    baseUrl: 'http://localhost:3000',
     video: false
   },
   env: {
-    environment: "local",
-    caseworker_password: "",
-    manager_password: "",
-    admin_password: ""
+    environment: 'local',
+    caseworker_password: '',
+    manager_password: '',
+    admin_password: ''
   }
 })

--- a/cypress.env.json
+++ b/cypress.env.json
@@ -1,6 +1,3 @@
 {
-    "environment": "local",
-    "caseworker_password": "",
-    "manager_password": "",
-    "admin_password": ""
+    "environment": "local"
 }

--- a/cypress.env.json
+++ b/cypress.env.json
@@ -1,3 +1,6 @@
 {
-    "environment": "local"
+    "environment": "local",
+    "caseworker_password": "",
+    "manager_password": "",
+    "admin_password": ""
 }

--- a/cypress.json
+++ b/cypress.json
@@ -1,5 +1,0 @@
-{
-    "blockHosts": ["*.google-analytics.com"],
-    "baseUrl": "http://localhost:3000",
-    "video": false
-  }

--- a/cypress/config/dev.config.js
+++ b/cypress/config/dev.config.js
@@ -2,7 +2,7 @@ const { defineConfig } = require('cypress')
 
 module.exports = defineConfig({
   e2e: {
-    Hblockosts: [
+    blockHosts: [
       '*.google-analytics.com'
     ],
     baseUrl: 'https://dev.view-court-data.service.justice.gov.uk/',

--- a/cypress/config/dev.config.js
+++ b/cypress/config/dev.config.js
@@ -7,5 +7,11 @@ module.exports = defineConfig({
     ],
     baseUrl: "https://dev.view-court-data.service.justice.gov.uk/",
     video: false
+  },
+  env: {
+    environment: "develop",
+    caseworker_password: "",
+    manager_password: "",
+    admin_password: ""
   }
 })

--- a/cypress/config/dev.config.js
+++ b/cypress/config/dev.config.js
@@ -5,7 +5,7 @@ module.exports = defineConfig({
     Hblockosts: [
       "*.google-analytics.com"
     ],
-    baseUrl: "http://localhost:3000",
+    baseUrl: "https://dev.view-court-data.service.justice.gov.uk/",
     video: false
   }
 })

--- a/cypress/config/dev.config.js
+++ b/cypress/config/dev.config.js
@@ -3,15 +3,15 @@ const { defineConfig } = require('cypress')
 module.exports = defineConfig({
   e2e: {
     Hblockosts: [
-      "*.google-analytics.com"
+      '*.google-analytics.com'
     ],
-    baseUrl: "https://dev.view-court-data.service.justice.gov.uk/",
+    baseUrl: 'https://dev.view-court-data.service.justice.gov.uk/',
     video: false
   },
   env: {
-    environment: "develop",
-    caseworker_password: "",
-    manager_password: "",
-    admin_password: ""
+    environment: 'develop',
+    caseworker_password: '',
+    manager_password: '',
+    admin_password: ''
   }
 })

--- a/cypress/config/develop.json
+++ b/cypress/config/develop.json
@@ -1,5 +1,0 @@
-{
-    "blockHosts": ["*.google-analytics.com"],
-    "baseUrl": "https://dev.view-court-data.service.justice.gov.uk/",
-    "video": false
-  }

--- a/cypress/config/prod.config.js
+++ b/cypress/config/prod.config.js
@@ -5,7 +5,7 @@ module.exports = defineConfig({
     Hblockosts: [
       "*.google-analytics.com"
     ],
-    baseUrl: "http://localhost:3000",
+    baseUrl: "https://view-court-data.service.justice.gov.uk/",
     video: false
   }
 })

--- a/cypress/config/prod.config.js
+++ b/cypress/config/prod.config.js
@@ -7,5 +7,11 @@ module.exports = defineConfig({
     ],
     baseUrl: "https://view-court-data.service.justice.gov.uk/",
     video: false
+  },
+  env: {
+    environment: "alpha",
+    caseworker_password: "",
+    manager_password: "",
+    admin_password: ""
   }
 })

--- a/cypress/config/prod.config.js
+++ b/cypress/config/prod.config.js
@@ -2,7 +2,7 @@ const { defineConfig } = require('cypress')
 
 module.exports = defineConfig({
   e2e: {
-    Hblockosts: [
+    blockHosts: [
       '*.google-analytics.com'
     ],
     baseUrl: 'https://view-court-data.service.justice.gov.uk/',

--- a/cypress/config/prod.config.js
+++ b/cypress/config/prod.config.js
@@ -3,15 +3,15 @@ const { defineConfig } = require('cypress')
 module.exports = defineConfig({
   e2e: {
     Hblockosts: [
-      "*.google-analytics.com"
+      '*.google-analytics.com'
     ],
-    baseUrl: "https://view-court-data.service.justice.gov.uk/",
+    baseUrl: 'https://view-court-data.service.justice.gov.uk/',
     video: false
   },
   env: {
-    environment: "alpha",
-    caseworker_password: "",
-    manager_password: "",
-    admin_password: ""
+    environment: 'alpha',
+    caseworker_password: '',
+    manager_password: '',
+    admin_password: ''
   }
 })

--- a/cypress/config/production.json
+++ b/cypress/config/production.json
@@ -1,5 +1,0 @@
-{
-    "blockHosts": ["*.google-analytics.com"],
-    "baseUrl": "https://view-court-data.service.justice.gov.uk/",
-    "video": false
-  }

--- a/cypress/config/stage.config.js
+++ b/cypress/config/stage.config.js
@@ -7,5 +7,11 @@ module.exports = defineConfig({
     ],
     baseUrl: "https://staging.view-court-data.service.justice.gov.uk/",
     video: false
+  },
+  env: {
+    environment: "staging",
+    caseworker_password: "",
+    manager_password: "",
+    admin_password: ""
   }
 })

--- a/cypress/config/stage.config.js
+++ b/cypress/config/stage.config.js
@@ -5,7 +5,7 @@ module.exports = defineConfig({
     Hblockosts: [
       "*.google-analytics.com"
     ],
-    baseUrl: "http://localhost:3000",
+    baseUrl: "https://staging.view-court-data.service.justice.gov.uk/",
     video: false
   }
 })

--- a/cypress/config/stage.config.js
+++ b/cypress/config/stage.config.js
@@ -3,15 +3,15 @@ const { defineConfig } = require('cypress')
 module.exports = defineConfig({
   e2e: {
     Hblockosts: [
-      "*.google-analytics.com"
+      '*.google-analytics.com'
     ],
-    baseUrl: "https://staging.view-court-data.service.justice.gov.uk/",
+    baseUrl: 'https://staging.view-court-data.service.justice.gov.uk/',
     video: false
   },
   env: {
-    environment: "staging",
-    caseworker_password: "",
-    manager_password: "",
-    admin_password: ""
+    environment: 'staging',
+    caseworker_password: '',
+    manager_password: '',
+    admin_password: ''
   }
 })

--- a/cypress/config/stage.config.js
+++ b/cypress/config/stage.config.js
@@ -2,7 +2,7 @@ const { defineConfig } = require('cypress')
 
 module.exports = defineConfig({
   e2e: {
-    Hblockosts: [
+    blockHosts: [
       '*.google-analytics.com'
     ],
     baseUrl: 'https://staging.view-court-data.service.justice.gov.uk/',

--- a/cypress/config/staging.json
+++ b/cypress/config/staging.json
@@ -1,5 +1,0 @@
-{
-    "blockHosts": ["*.google-analytics.com"],
-    "baseUrl": "https://staging.view-court-data.service.justice.gov.uk/",
-    "video": false
-  }

--- a/cypress/config/uat.config.js
+++ b/cypress/config/uat.config.js
@@ -2,7 +2,7 @@ const { defineConfig } = require('cypress')
 
 module.exports = defineConfig({
   e2e: {
-    Hblockosts: [
+    blockHosts: [
       '*.google-analytics.com'
     ],
     baseUrl: 'https://uat.view-court-data.service.justice.gov.uk/',

--- a/cypress/config/uat.config.js
+++ b/cypress/config/uat.config.js
@@ -7,5 +7,11 @@ module.exports = defineConfig({
     ],
     baseUrl: "https://uat.view-court-data.service.justice.gov.uk/",
     video: false
+  },
+  env: {
+    environment: "uat",
+    caseworker_password: "",
+    manager_password: "",
+    admin_password: ""
   }
 })

--- a/cypress/config/uat.config.js
+++ b/cypress/config/uat.config.js
@@ -5,7 +5,7 @@ module.exports = defineConfig({
     Hblockosts: [
       "*.google-analytics.com"
     ],
-    baseUrl: "http://localhost:3000",
+    baseUrl: "https://uat.view-court-data.service.justice.gov.uk/",
     video: false
   }
 })

--- a/cypress/config/uat.config.js
+++ b/cypress/config/uat.config.js
@@ -3,15 +3,15 @@ const { defineConfig } = require('cypress')
 module.exports = defineConfig({
   e2e: {
     Hblockosts: [
-      "*.google-analytics.com"
+      '*.google-analytics.com'
     ],
-    baseUrl: "https://uat.view-court-data.service.justice.gov.uk/",
+    baseUrl: 'https://uat.view-court-data.service.justice.gov.uk/',
     video: false
   },
   env: {
-    environment: "uat",
-    caseworker_password: "",
-    manager_password: "",
-    admin_password: ""
+    environment: 'uat',
+    caseworker_password: '',
+    manager_password: '',
+    admin_password: ''
   }
 })

--- a/cypress/config/uat.json
+++ b/cypress/config/uat.json
@@ -1,5 +1,0 @@
-{
-    "blockHosts": ["*.google-analytics.com"],
-    "baseUrl": "https://uat.view-court-data.service.justice.gov.uk/",
-    "video": false
-  }

--- a/cypress/e2e/index/sign_in.cy.js
+++ b/cypress/e2e/index/sign_in.cy.js
@@ -47,21 +47,18 @@ describe("User Login Page", () => {
 			"contain",
 			"Invalid username or password."
 		);
-		cy.fixture("users").then((users) => {
-			cy.login(users[0].username, Cypress.env(users[0].password_env));
-			cy.get(".govuk-error-summary__title").should(
-				"contain",
-				"Signed in successfully."
-			);
-		});
+
+		cy.login(users[0].username, Cypress.env(users[0].password_env));
+		cy.get(".govuk-error-summary__title").should(
+			"contain",
+			"Signed in successfully."
+		);
 	});
 
 	context("logged in", () => {
 		beforeEach(() => {
 			cy.visit("/");
-			cy.fixture("users").then((users) => {
-				cy.login(users[0].username, Cypress.env(users[0].password_env));
-			});
+			cy.login(users[0].username, Cypress.env(users[0].password_env));
 		});
 
 		it("displays search filters page", () => {

--- a/cypress/e2e/index/sign_in.cy.js
+++ b/cypress/e2e/index/sign_in.cy.js
@@ -1,0 +1,90 @@
+import users from "../../fixtures/users.json";
+
+describe("User Login Page", () => {
+	before(() => {
+		cy.visit("/");
+	});
+
+	beforeEach(() => {
+		cy.visit("/");
+	});
+
+	it(`displays the ${Cypress.env("environment")} banner`, () => {
+		cy.get(".govuk-phase-banner__content").should("contain", Cypress.env("environment"));
+	});
+
+	it("displays the login page", () => {
+		cy.get(".govuk-heading-xl").should("have.text", "Sign in");
+		cy.get("#new_user")
+			.should("contain", "Username or email")
+			.and("contain", "Password");
+		cy.get("input#user-login-field").should("exist");
+		cy.get("input#user-password-field").should("exist");
+	});
+
+
+	users.forEach(user => {
+		it(`${user.roles[0]} can log in with correct credentials`, () => {
+			cy.login(user.username, Cypress.env(user.password_env));
+			cy.get(".govuk-error-summary__title").should(
+				"contain",
+				"Signed in successfully."
+			);
+		});
+	});
+
+	it("cannot log in with incorrect credentials", () => {
+		cy.login("someone", "some-password");
+		cy.get(".govuk-error-summary__title").should(
+			"contain",
+			"Invalid username or password."
+		);
+	});
+
+	it("can log in with valid credentials after an invalid attempt", () => {
+		cy.login("invalid-username", "invalid-password");
+		cy.get(".govuk-error-summary__title").should(
+			"contain",
+			"Invalid username or password."
+		);
+		cy.fixture("users").then((users) => {
+			cy.login(users[0].username, Cypress.env(users[0].password_env));
+			cy.get(".govuk-error-summary__title").should(
+				"contain",
+				"Signed in successfully."
+			);
+		});
+	});
+
+	context("logged in", () => {
+		beforeEach(() => {
+			cy.visit("/");
+			cy.fixture("users").then((users) => {
+				cy.login(users[0].username, Cypress.env(users[0].password_env));
+			});
+		});
+
+		it("displays search filters page", () => {
+			cy.get(".govuk-fieldset__legend").should("contain", "Search for");
+		});
+
+		it("can log out", () => {
+			cy.get("[data-method='delete']")
+				.should("have.text", "Sign out")
+				.should("have.attr", "href")
+				.and("include", "/users/sign_out");
+
+			cy.get("[data-method='delete']").click();
+			cy.get(".govuk-error-summary__title").should(
+				"contain",
+				"Signed out successfully."
+			);
+		});
+	});
+
+	context("logged out", () => {
+		it("can not see search filters", () => {
+			cy.get("#main-content").not("contain", "Search for");
+		});
+	});
+});

--- a/cypress/e2e/index/sign_in.cy.js
+++ b/cypress/e2e/index/sign_in.cy.js
@@ -1,87 +1,86 @@
-import users from "../../fixtures/users.json";
+import users from '../../fixtures/users.json'
 
-describe("User Login Page", () => {
-	before(() => {
-		cy.visit("/");
-	});
+describe('User Login Page', () => {
+  before(() => {
+    cy.visit('/')
+  })
 
-	beforeEach(() => {
-		cy.visit("/");
-	});
+  beforeEach(() => {
+    cy.visit('/')
+  })
 
-	it(`displays the ${Cypress.env("environment")} banner`, () => {
-		cy.get(".govuk-phase-banner__content").should("contain", Cypress.env("environment"));
-	});
+  it(`displays the ${Cypress.env('environment')} banner`, () => {
+    cy.get('.govuk-phase-banner__content').should('contain', Cypress.env('environment'))
+  })
 
-	it("displays the login page", () => {
-		cy.get(".govuk-heading-xl").should("have.text", "Sign in");
-		cy.get("#new_user")
-			.should("contain", "Username or email")
-			.and("contain", "Password");
-		cy.get("input#user-login-field").should("exist");
-		cy.get("input#user-password-field").should("exist");
-	});
+  it('displays the login page', () => {
+    cy.get('.govuk-heading-xl').should('have.text', 'Sign in')
+    cy.get('#new_user')
+      .should('contain', 'Username or email')
+      .and('contain', 'Password')
+    cy.get('input#user-login-field').should('exist')
+    cy.get('input#user-password-field').should('exist')
+  })
 
+  users.forEach(user => {
+    it(`${user.roles[0]} can log in with correct credentials`, () => {
+      cy.login(user.username, Cypress.env(user.password_env))
+      cy.get('.govuk-error-summary__title').should(
+        'contain',
+        'Signed in successfully.'
+      )
+    })
+  })
 
-	users.forEach(user => {
-		it(`${user.roles[0]} can log in with correct credentials`, () => {
-			cy.login(user.username, Cypress.env(user.password_env));
-			cy.get(".govuk-error-summary__title").should(
-				"contain",
-				"Signed in successfully."
-			);
-		});
-	});
+  it('cannot log in with incorrect credentials', () => {
+    cy.login('someone', 'some-password')
+    cy.get('.govuk-error-summary__title').should(
+      'contain',
+      'Invalid username or password.'
+    )
+  })
 
-	it("cannot log in with incorrect credentials", () => {
-		cy.login("someone", "some-password");
-		cy.get(".govuk-error-summary__title").should(
-			"contain",
-			"Invalid username or password."
-		);
-	});
+  it('can log in with valid credentials after an invalid attempt', () => {
+    cy.login('invalid-username', 'invalid-password')
+    cy.get('.govuk-error-summary__title').should(
+      'contain',
+      'Invalid username or password.'
+    )
 
-	it("can log in with valid credentials after an invalid attempt", () => {
-		cy.login("invalid-username", "invalid-password");
-		cy.get(".govuk-error-summary__title").should(
-			"contain",
-			"Invalid username or password."
-		);
+    cy.login(users[0].username, Cypress.env(users[0].password_env))
+    cy.get('.govuk-error-summary__title').should(
+      'contain',
+      'Signed in successfully.'
+    )
+  })
 
-		cy.login(users[0].username, Cypress.env(users[0].password_env));
-		cy.get(".govuk-error-summary__title").should(
-			"contain",
-			"Signed in successfully."
-		);
-	});
+  context('logged in', () => {
+    beforeEach(() => {
+      cy.visit('/')
+      cy.login(users[0].username, Cypress.env(users[0].password_env))
+    })
 
-	context("logged in", () => {
-		beforeEach(() => {
-			cy.visit("/");
-			cy.login(users[0].username, Cypress.env(users[0].password_env));
-		});
+    it('displays search filters page', () => {
+      cy.get('.govuk-fieldset__legend').should('contain', 'Search for')
+    })
 
-		it("displays search filters page", () => {
-			cy.get(".govuk-fieldset__legend").should("contain", "Search for");
-		});
+    it('can log out', () => {
+      cy.get("[data-method='delete']")
+        .should('have.text', 'Sign out')
+        .should('have.attr', 'href')
+        .and('include', '/users/sign_out')
 
-		it("can log out", () => {
-			cy.get("[data-method='delete']")
-				.should("have.text", "Sign out")
-				.should("have.attr", "href")
-				.and("include", "/users/sign_out");
+      cy.get("[data-method='delete']").click()
+      cy.get('.govuk-error-summary__title').should(
+        'contain',
+        'Signed out successfully.'
+      )
+    })
+  })
 
-			cy.get("[data-method='delete']").click();
-			cy.get(".govuk-error-summary__title").should(
-				"contain",
-				"Signed out successfully."
-			);
-		});
-	});
-
-	context("logged out", () => {
-		it("can not see search filters", () => {
-			cy.get("#main-content").not("contain", "Search for");
-		});
-	});
-});
+  context('logged out', () => {
+    it('can not see search filters', () => {
+      cy.get('#main-content').not('contain', 'Search for')
+    })
+  })
+})

--- a/cypress/fixtures/example.json
+++ b/cypress/fixtures/example.json
@@ -1,5 +1,0 @@
-{
-  "name": "Using fixtures to represent data",
-  "email": "hello@cypress.io",
-  "body": "Fixtures are a great way to mock data for responses to routes"
-}

--- a/cypress/fixtures/users.json
+++ b/cypress/fixtures/users.json
@@ -1,0 +1,17 @@
+[
+    {
+        "username": "caseworker@example.com",
+        "password_env": "caseworker_password",
+        "roles": ["caseworker"]
+    },
+    {
+        "username": "manager@example.com",
+        "password_env": "manager_password",
+        "roles": ["manager"]
+    },
+    {
+        "username": "admin@example.com",
+        "password_env": "admin_password",
+        "roles": ["admin"]
+    }
+]

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -2,10 +2,10 @@
  * Command to allow login into the Court Data UI application
  * @param {string} username
  * @param {string} password
- * 
+ *
  */
-Cypress.Commands.add("login", (username, password) => {
-    cy.get("[data-cy=\"login-username\"]").clear().type(username);
-    cy.get("[data-cy=\"login-password\"]").clear().type(password);
-    cy.get("[data-cy=\"login-submit\"]").click();
-});
+Cypress.Commands.add('login', (username, password) => {
+  cy.get('[data-cy="login-username"]').clear().type(username)
+  cy.get('[data-cy="login-password"]').clear().type(password)
+  cy.get('[data-cy="login-submit"]').click()
+})

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,25 +1,11 @@
-// ***********************************************
-// This example commands.js shows you how to
-// create various custom commands and overwrite
-// existing commands.
-//
-// For more comprehensive examples of custom
-// commands please read more here:
-// https://on.cypress.io/custom-commands
-// ***********************************************
-//
-//
-// -- This is a parent command --
-// Cypress.Commands.add('login', (email, password) => { ... })
-//
-//
-// -- This is a child command --
-// Cypress.Commands.add('drag', { prevSubject: 'element'}, (subject, options) => { ... })
-//
-//
-// -- This is a dual command --
-// Cypress.Commands.add('dismiss', { prevSubject: 'optional'}, (subject, options) => { ... })
-//
-//
-// -- This will overwrite an existing command --
-// Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
+/**
+ * Command to allow login into the Court Data UI application
+ * @param {string} username
+ * @param {string} password
+ * 
+ */
+Cypress.Commands.add("login", (username, password) => {
+    cy.get("[data-cy=\"login-username\"]").clear().type(username);
+    cy.get("[data-cy=\"login-password\"]").clear().type(password);
+    cy.get("[data-cy=\"login-submit\"]").click();
+});

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -102,8 +102,12 @@ OAuth2 access token requests are configured to be be ignored by VCR to avoid pro
 We use [Cypress](https://cypress.io) as our E2E UI testing suite. The goal of this test suite is to interact with the interface as the user would to be able to capture any issues earlier in the process and provide an extra bit of security.
 
 #### Locally
-Once you have installed the local dependencies and have the application in a running state, to run the tests locally you can run the following command to run the tests. The Environment variables will need updating for user passwords as not to keep secrets in the repo. These will be the same as what you have set for these users in your local setup. 
+Once you have installed the local dependencies and have the application in a running state, to run the tests locally you can run the following command to run the tests. 
 
 ```
-RUBYOPT=-W:no-deprecated yarn run start:server && yarn run cypress:run
+yarn run start:server && yarn run cypress:run
 ```
+
+> **Note**
+>
+> The Environment variables will need updating for user passwords as not to keep secrets in the repo. These will be the same as what you have set for these users in your local setup.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,6 +1,7 @@
 # Testing
 
-For testing we use [rspec](https://relishapp.com/rspec/). Linters and static analysers are also run - [rubocop](https://github.com/rubocop-hq/rubocop), Stylelint, jlint-js [brakeman](https://brakemanscanner.org/docs/introduction/))
+For testing we use [rspec](https://relishapp.com/rspec/). Linters and static analysers are also run - [rubocop](https://github.com/rubocop-hq/rubocop), Stylelint, jlint-js [brakeman](https://brakemanscanner.org/docs/introduction/)).
+For end to end testing we use [cypress](https://cypress.io).
 
 ## Running test suite
 
@@ -24,6 +25,9 @@ make run
 
 # run the entire test suite
 make test
+
+# run the end to end tests
+make e2e
 ```
 
 ## VCR and Webmock
@@ -92,3 +96,14 @@ OAuth2 access token requests are configured to be be ignored by VCR to avoid pro
     ```
 
     This will disable real OAuth2 access token requests. API endpoint requests should now be stubbed and therefore tests should pass with no locally running adaptor API or connectivity to hosted services. Try running tests again with no internet or local servers running.
+
+
+## Cypress E2E
+We use [Cypress](https://cypress.io) as our E2E UI testing suite. The goal of this test suite is to interact with the interface as the user would to be able to capture any issues earlier in the process and provide an extra bit of security.
+
+#### Locally
+Once you have installed the local dependencies and have the application in a running state, to run the tests locally you can run the following command to run the tests. The Environment variables will need updating for user passwords as not to keep secrets in the repo. These will be the same as what you have set for these users in your local setup. 
+
+```
+RUBYOPT=-W:no-deprecated yarn run start:server && yarn run cypress:run
+```

--- a/package.json
+++ b/package.json
@@ -54,6 +54,9 @@
       "googleTrackingID",
       "Cypress",
       "cy"
+    ],
+    "env": [
+      "mocha"
     ]
   }
 }


### PR DESCRIPTION
#### What

- Update config files to use the new js format supported by cypress 10
- Add testing command to the MAKE file
- Update the login view with data-cy attributes
- Add initial sign in tests and fixture
- Add command for login
- Update readme

#### Ticket

[Test user login](https://dsdmoj.atlassian.net/browse/AAC-152)

#### Why

Allow for E2E test suite to run within CD UI
