### PR TITLE
AAC-329 - Add in accessibility testing

### DIFF
--- a/cypress/config/dev.config.js
+++ b/cypress/config/dev.config.js
@@ -13,5 +13,17 @@ module.exports = defineConfig({
     caseworker_password: '',
     manager_password: '',
     admin_password: ''
+  },
+  setupNodeEvents (on, _config) {
+    on('task', {
+      log (message) {
+        console.log(message)
+        return null
+      },
+      table (message) {
+        console.table(message)
+        return null
+      }
+    })
   }
 })

--- a/cypress/config/prod.config.js
+++ b/cypress/config/prod.config.js
@@ -13,5 +13,17 @@ module.exports = defineConfig({
     caseworker_password: '',
     manager_password: '',
     admin_password: ''
+  },
+  setupNodeEvents (on, _config) {
+    on('task', {
+      log (message) {
+        console.log(message)
+        return null
+      },
+      table (message) {
+        console.table(message)
+        return null
+      }
+    })
   }
 })

--- a/cypress/config/stage.config.js
+++ b/cypress/config/stage.config.js
@@ -13,5 +13,17 @@ module.exports = defineConfig({
     caseworker_password: '',
     manager_password: '',
     admin_password: ''
+  },
+  setupNodeEvents (on, _config) {
+    on('task', {
+      log (message) {
+        console.log(message)
+        return null
+      },
+      table (message) {
+        console.table(message)
+        return null
+      }
+    })
   }
 })

--- a/cypress/config/uat.config.js
+++ b/cypress/config/uat.config.js
@@ -13,5 +13,17 @@ module.exports = defineConfig({
     caseworker_password: '',
     manager_password: '',
     admin_password: ''
+  },
+  setupNodeEvents (on, _config) {
+    on('task', {
+      log (message) {
+        console.log(message)
+        return null
+      },
+      table (message) {
+        console.table(message)
+        return null
+      }
+    })
   }
 })

--- a/cypress/e2e/cookies/cookie_banner.cy.js
+++ b/cypress/e2e/cookies/cookie_banner.cy.js
@@ -8,6 +8,11 @@ describe('Cookie banner', () => {
       beforeEach(() => {
         cy.visit('/')
       })
+
+      it('has no detectable a11y violations on load', () => {
+        cy.customA11yCheck(null, cy.a11yLog)
+      })
+
       it('can reject the cookie preferences', () => {
         cy.getCookie('cookies_preferences_set').should('not.exist')
         cy.get('[data-cy="reject_cookies"]')
@@ -15,6 +20,7 @@ describe('Cookie banner', () => {
           .and('have.attr', 'href')
           .and('include', 'analytics_cookies_set=false&show_confirm_banner=true')
         cy.get('[data-cy="reject_cookies"]').click()
+        cy.customA11yCheck(null, cy.a11yLog)
         cy.get('.govuk-cookie-banner__content > p').should('contain', rejectedAdditionalCookies)
         cy.getCookie('cookies_preferences_set').should('have.property', 'value', 'true')
         cy.getCookie('analytics_cookies_set').should('have.property', 'value', 'false')
@@ -31,6 +37,7 @@ describe('Cookie banner', () => {
         cy.get("[data-cy='hide_message']").click()
         cy.get('.app-cookie-banner').should('not.exist')
         cy.get("[data-cy='hide_message']").should('not.exist')
+        cy.customA11yCheck(null, cy.a11yLog)
       })
     })
 
@@ -45,6 +52,7 @@ describe('Cookie banner', () => {
           .and('have.attr', 'href')
           .and('include', 'analytics_cookies_set=true&show_confirm_banner=true')
         cy.get('[data-cy="accept_cookies"]').click()
+        cy.customA11yCheck(null, cy.a11yLog)
         cy.get('.govuk-cookie-banner__content > p').should('contain', acceptedAdditionalCookies)
         cy.getCookie('cookies_preferences_set').should('have.property', 'value', 'true')
         cy.getCookie('analytics_cookies_set').should('have.property', 'value', 'true')
@@ -61,6 +69,7 @@ describe('Cookie banner', () => {
         cy.get("[data-cy='hide_message']").click()
         cy.get('.app-cookie-banner').should('not.exist')
         cy.get("[data-cy='hide_message']").should('not.exist')
+        cy.customA11yCheck(null, cy.a11yLog)
       })
     })
   })
@@ -74,6 +83,7 @@ describe('Cookie banner', () => {
 
     it('does not display the banner', () => {
       cy.get('.app-cookie-banner').should('not.exist')
+      cy.customA11yCheck(null, cy.a11yLog)
     })
   })
 })

--- a/cypress/e2e/cookies/cookie_information.cy.js
+++ b/cypress/e2e/cookies/cookie_information.cy.js
@@ -4,6 +4,10 @@ describe('Cookie Information Page', () => {
   })
 
   context('main page', () => {
+    it('has no detectable a11y violations on load', () => {
+      cy.customA11yCheck(null, cy.a11yLog)
+    })
+
     it('displays the title', () => {
       cy.get('.govuk-heading-xl')
         .should('contain', 'Cookies on View Court Data')

--- a/cypress/e2e/cookies/cookie_settings.cy.js
+++ b/cypress/e2e/cookies/cookie_settings.cy.js
@@ -4,6 +4,10 @@ describe('Cookie settings page', () => {
   })
 
   context('main page', () => {
+    it('has no detectable a11y violations on load', () => {
+      cy.customA11yCheck(null, cy.a11yLog)
+    })
+
     it('displays the title', () => {
       cy.get('.govuk-heading-xl')
         .should('contain', 'Change your cookie settings')
@@ -61,6 +65,7 @@ describe('Cookie settings page', () => {
           cy.get('[data-cy="submit-cookies"]').click()
           cy.get('.govuk-notification-banner__heading').should('contain', 'You\'ve set your cookie preferences.')
           cy.getCookie('analytics_cookies_set', 'true')
+          cy.customA11yCheck(null, cy.a11yLog)
         })
       })
 
@@ -80,6 +85,7 @@ describe('Cookie settings page', () => {
           cy.get('[data-cy="submit-cookies"]').click()
           cy.get('.govuk-notification-banner__heading').should('contain', 'You\'ve set your cookie preferences.')
           cy.getCookie('analytics_cookies_set', 'false')
+          cy.customA11yCheck(null, cy.a11yLog)
         })
       })
     })

--- a/cypress/e2e/index/sign_in.cy.js
+++ b/cypress/e2e/index/sign_in.cy.js
@@ -9,6 +9,10 @@ describe('User Login Page', () => {
     cy.visit('/')
   })
 
+  it('has no detectable a11y violations on load', () => {
+    cy.customA11yCheck(null, cy.a11yLog)
+  })
+
   it(`displays the ${Cypress.env('environment')} banner`, () => {
     cy.get('.govuk-phase-banner__content').should('contain', Cypress.env('environment'))
   })
@@ -29,6 +33,7 @@ describe('User Login Page', () => {
         'contain',
         'Signed in successfully.'
       )
+      cy.customA11yCheck(null, cy.a11yLog)
     })
   })
 
@@ -38,6 +43,7 @@ describe('User Login Page', () => {
       'contain',
       'Invalid username or password.'
     )
+    cy.customA11yCheck(null, cy.a11yLog)
   })
 
   it('can log in with valid credentials after an invalid attempt', () => {
@@ -52,12 +58,17 @@ describe('User Login Page', () => {
       'contain',
       'Signed in successfully.'
     )
+    cy.customA11yCheck(null, cy.a11yLog)
   })
 
   context('logged in', () => {
     beforeEach(() => {
       cy.visit('/')
       cy.login(users[0].username, Cypress.env(users[0].password_env))
+    })
+
+    it('has no detectable a11y violations on load', () => {
+      cy.customA11yCheck(null, cy.a11yLog)
     })
 
     it('displays search filters page', () => {
@@ -75,6 +86,7 @@ describe('User Login Page', () => {
         'contain',
         'Signed out successfully.'
       )
+      cy.customA11yCheck(null, cy.a11yLog)
     })
   })
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -9,3 +9,30 @@ Cypress.Commands.add('login', (username, password) => {
   cy.get('[data-cy="login-password"]').clear().type(password)
   cy.get('[data-cy="login-submit"]').click()
 })
+
+Cypress.Commands.add('customA11yCheck', (selector, logCallback) => {
+  const options = {
+    includedImpacts: ['critical', 'serious']
+  }
+  cy.injectAxe()
+  cy.checkA11y(selector, options, logCallback)
+})
+
+Cypress.Commands.add('a11yLog', (violations) => {
+  cy.task(
+    'log',
+    `${violations.length} accessibility violation${violations.length === 1 ? '' : 's'
+    } ${violations.length === 1 ? 'was' : 'were'} detected`
+  )
+  // pluck specific keys to keep the table readable
+  const violationData = violations.map(
+    ({ id, impact, description, nodes }) => ({
+      id,
+      impact,
+      description,
+      nodes: nodes.length
+    })
+  )
+
+  cy.task('table', violationData)
+})

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -15,6 +15,7 @@
 
 // Import commands.js using ES2015 syntax:
 import './commands'
+import 'cypress-axe'
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "postcss": "^8.4.14"
   },
   "devDependencies": {
+    "axe-core": "^4.4.2",
     "cypress": "^10.1.0",
+    "cypress-axe": "^1.0.0",
     "standard": "^17.0.0",
     "stylelint": "^14.9.1",
     "stylelint-config-gds": "^0.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2027,6 +2027,11 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
+axe-core@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.4.2.tgz#dcf7fb6dea866166c3eab33d68208afe4d5f670c"
+  integrity sha512-LVAaGp/wkkgYJcjmHsoKx4juT1aQvJyPcW09MLCjVTh3V2cc6PnyempiLMNH5iMdfIX/zdbjUx2KDjMLCTdPeA==
+
 axios@^0.25.0:
   version "0.25.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.25.0.tgz#349cfbb31331a9b4453190791760a8d35b093e0a"
@@ -3194,6 +3199,11 @@ cyclist@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
+
+cypress-axe@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/cypress-axe/-/cypress-axe-1.0.0.tgz#ab4e9486eaa3bb956a90a1ae40d52df42827b4f0"
+  integrity sha512-QBlNMAd5eZoyhG8RGGR/pLtpHGkvgWXm2tkP68scJ+AjYiNNOlJihxoEwH93RT+rWOLrefw4iWwEx8kpEcrvJA==
 
 cypress@^10.1.0:
   version "10.1.0"


### PR DESCRIPTION
#### What

- Adds in accessibility testing to existing tests
- Adds commands for future testing

#### Ticket

[Setup accessibility testing and linting in Cypress](https://dsdmoj.atlassian.net/browse/AAC-329)

#### Why

E2E testing for CD UI
