### PR TITLE
Aac 715 make cd api endpoints restful case summary

### DIFF
--- a/app/controllers/hearings_controller.rb
+++ b/app/controllers/hearings_controller.rb
@@ -102,7 +102,7 @@ class HearingsController < ApplicationController
   end
 
   def prosecution_case_call_v2
-    logger.info 'USING_V2_ENDPOINT_HEARING_SUMMARIES'
+    logger.info 'USING_V2_ENDPOINT_CASE_SUMMARIES'
     @prosecution_case = helpers.decorate(@prosecution_case_search.call, CdApi::CaseSummaryDecorator)
   rescue ActiveResource::ServerError, ActiveResource::ClientError => e
     Rails.logger.error 'SERVER_ERROR_OCCURRED'

--- a/app/models/cd_api/case_summary.rb
+++ b/app/models/cd_api/case_summary.rb
@@ -2,8 +2,6 @@
 
 module CdApi
   class CaseSummary < BaseModel
-    self.element_name = 'hearingsummaries'
-
     has_many :hearing_summaries, class_name: 'cd_api/hearing_summary'
     has_many :overall_defendants, class_name: 'cd_api/overall_defendant'
 

--- a/app/services/cd_api/case_summary_service.rb
+++ b/app/services/cd_api/case_summary_service.rb
@@ -11,7 +11,7 @@ module CdApi
     end
 
     def call
-      Rails.logger.info 'V2_SEARCH_HEARING_SUMMARIES'
+      Rails.logger.info 'V2_SEARCH_CASE_SUMMARIES'
       CdApi::CaseSummary.find(@urn)
     end
   end

--- a/spec/support/webmock/court_data_api/webmock.rb
+++ b/spec/support/webmock/court_data_api/webmock.rb
@@ -262,7 +262,7 @@ RSpec.configure do |config|
 
   config.before(:each, stub_v2_hearing_summary: true) do
     stub_request(
-      :get, %r{/v2/hearingsummaries/#{case_reference}}
+      :get, %r{/v2/case_summaries/#{case_reference}}
     ).to_return(
       status: 200,
       headers: { 'Content-Type' => 'application/json' },
@@ -272,7 +272,7 @@ RSpec.configure do |config|
 
   config.before(:each, stub_v2_hearing_summary_error: true) do
     stub_request(
-      :get, %r{/v2/hearingsummaries/#{case_reference}}
+      :get, %r{/v2/case_summaries/#{case_reference}}
     ).to_return(
       status: 500,
       body: ''


### PR DESCRIPTION
#### What
Utilise case_summaries endpoint instead of hearingsummaries

#### Ticket
[Make CDA Endpoints RESTful](https://dsdmoj.atlassian.net/browse/AAC-715)

#### Why
The endpoint that was known as hearingsummaries was misleading as it contained more than just hearing summaries (also contained defendants). Therefore, naming it case_summaries instead is better 

#### How
Use default element name from case_summary model
Update logs
Update tests
