### PR TITLE
AAC-748 Remove Turbo Stream from cookie banner

### DIFF
--- a/app/views/layouts/cookie_banner/_success.html.haml
+++ b/app/views/layouts/cookie_banner/_success.html.haml
@@ -1,18 +1,15 @@
-%turbo-frame#hideable
-  %turbo-frame#removable
-    .app-cookie-banner.govuk-cookie-banner{'aria-label': 'Cookies on View Court Data', role: 'region', data: { module: 'app-cookie-banner', nosnippet: ''}}
-      .govuk-cookie-banner__message.govuk-width-container
-        .govuk-grid-row
-          .govuk-grid-column-two-thirds
-            .govuk-cookie-banner__content
-              %p.govuk-body
-                = analytics_cookies_accepted ? t('layouts.application.cookies.confirmation_accept') : t('layouts.application.cookies.confirmation_reject')
-                = t('layouts.application.cookies.confirmation_link_to_settings_html', href: cookies_settings_path).html_safe
+%turbo-frame#removable
+  .app-cookie-banner.govuk-cookie-banner{'aria-label': 'Cookies on View Court Data', role: 'region', data: { module: 'app-cookie-banner', nosnippet: ''}}
+    .govuk-cookie-banner__message.govuk-width-container
+      .govuk-grid-row
+        .govuk-grid-column-two-thirds
+          .govuk-cookie-banner__content
+            %p.govuk-body
+              = analytics_cookies_accepted ? t('layouts.application.cookies.confirmation_accept') : t('layouts.application.cookies.confirmation_reject')
+              = t('layouts.application.cookies.confirmation_link_to_settings_html', href: cookies_settings_path).html_safe
 
-            .govuk-button-group
-              %a.govuk-button{'data-module': 'govuk-button', type: 'button', draggable: 'false', 'href': update_cookies_path(hide_banner: true)}
-                = t('layouts.application.cookies.hide_message')
-    -# Script to add google analytics cookies
-    = render partial: 'layouts/google_analytics', analytics_cookies_accepted: true
-
-    %turbo-stream{:action => "replace", :target => "removable"}
+          .govuk-button-group
+            %a.govuk-button{'data-module': 'govuk-button', type: 'button', draggable: 'false', 'href': update_cookies_path(hide_banner: true)}
+              = t('layouts.application.cookies.hide_message')
+  -# Script to add google analytics cookies
+  = render partial: 'layouts/google_analytics', analytics_cookies_accepted: true


### PR DESCRIPTION
#### What

Remove Turbo Stream from cookie banner

#### Ticket

[AAC-748](https://dsdmoj.atlassian.net/browse/AAC-748?atlOrigin=eyJpIjoiZjUxOTE2ZjQ2YWM5NGU4OTlkOWU4OGQ1ZmYwOWVlMWIiLCJwIjoiaiJ9)

#### Why

Turbo Stream is not required for the cookie banner. Instead, we are using Turbo Frames

#### How

Remove turbo-stream from the cookie banner view partials

--------