### PR TITLE
AAC-708 Fix haml-lint MultilinePipe warning

### DIFF
--- a/.haml-lint_todo.yml
+++ b/.haml-lint_todo.yml
@@ -44,6 +44,7 @@ linters:
       - "app/views/prosecution_cases/cd_api/_raw_response.html.haml"
 
   # Offense count: 1
-  MultilinePipe:
+  IdNames:
     exclude:
       - "app/views/devise/shared/_error_messages.html.haml"
+

--- a/app/views/devise/shared/_error_messages.html.haml
+++ b/app/views/devise/shared/_error_messages.html.haml
@@ -1,9 +1,7 @@
 - if resource.errors.any?
   #error-explanation
     %h2
-      = I18n.t("errors.messages.not_saved",                 |
-        count: resource.errors.count,                       |
-        resource: resource.class.model_name.human.downcase) |
+      = I18n.t("errors.messages.not_saved", count: resource.errors.count, resource: resource.class.model_name.human.downcase)
     %ul
       - resource.errors.full_messages.each do |message|
         %li= message


### PR DESCRIPTION
#### AAC-708 Fix haml-lint MultilinePipe warning

#### Ticket

[AAC-708](https://dsdmoj.atlassian.net/browse/AAC-708)

#### Why

Maintenance of our service with good coding practices that are standardised with the haml-lint package.

#### How

- Run `haml-lint -i MultilinePipe`
- Fix error warning in code