### PR TITLE
AAC-768 - Unique sorted hearings

### DIFF
--- a/app/decorators/prosecution_case_decorator.rb
+++ b/app/decorators/prosecution_case_decorator.rb
@@ -9,7 +9,7 @@ class ProsecutionCaseDecorator < BaseDecorator
 
   def sorted_hearings_with_day
     Enumerator.new do |enum|
-      sorter.sorted_hearings.each do |hearing|
+      sorter.sorted_hearings.uniq(&:id).each do |hearing|
         sorter.sorted_hearing_days(hearing).each do |day|
           hearing.day = day
           enum.yield(hearing)


### PR DESCRIPTION
#### What

- Update the table sorter to deal with unique hearingIds to prevent duplication with MDH.

#### Ticket

[CD UI - MDH show 3 times](https://dsdmoj.atlassian.net/browse/AAC-768)

#### Why

Hearings with Multiple days were coming through the V1 API multiple times (probably because of the different days) and because of the way we construct the interface in V1 this was replicating the days. 

#### How

Adding a uniq on the ID for the hearing, we should be able to correctly split everything out and only show what is available now. 