### PR TITLE
aac-706/HAML-linting-UnnecessaryStringOutput

### DIFF
--- a/.haml-lint_todo.yml
+++ b/.haml-lint_todo.yml
@@ -11,7 +11,6 @@ linters:
   RuboCop:
     enabled: false
 
-
   # Offense count: 1
   ViewLength:
     exclude:
@@ -29,16 +28,6 @@ linters:
   # Offense count: 43
   LineLength:
     enabled: false
-
-  # Offense count: 18
-  UnnecessaryStringOutput:
-    exclude:
-      - "app/views/defendants/_offences.html.haml"
-      - "app/views/defendants/_offences_v2.html.haml"
-      - "app/views/defendants/_representation_orders.html.haml"
-      - "app/views/hearings/_raw_response.html.haml"
-      - "app/views/prosecution_cases/_raw_response.html.haml"
-      - "app/views/prosecution_cases/cd_api/_raw_response.html.haml"
 
   # Offense count: 1
   IdNames:

--- a/app/views/defendants/_offences.html.haml
+++ b/app/views/defendants/_offences.html.haml
@@ -19,6 +19,6 @@
         %td.govuk-table__cell
           = offence.plea_list
         %td.govuk-table__cell
-          = "#{offence.mode_of_trial}:"
+          #{offence.mode_of_trial}:
           %br
           = offence.mode_of_trial_reason_list

--- a/app/views/defendants/_offences_v2.html.haml
+++ b/app/views/defendants/_offences_v2.html.haml
@@ -22,4 +22,4 @@
         %td.govuk-table__cell
           = offence.plea_sentence
         %td.govuk-table__cell
-          = "#{offence.mode_of_trial}"
+          #{offence.mode_of_trial}

--- a/app/views/defendants/_representation_orders.html.haml
+++ b/app/views/defendants/_representation_orders.html.haml
@@ -12,8 +12,8 @@
   %tbody.govuk-table__body
     %tr.govuk-table__row
       %td.govuk-table__cell
-        = 'todo'
+        todo
       %td.govuk-table__cell
-        = 'todo'
+        todo
       %td.govuk-table__cell
-        = 'todo'
+        todo

--- a/app/views/hearings/_raw_response.html.haml
+++ b/app/views/hearings/_raw_response.html.haml
@@ -7,15 +7,15 @@
   - hearing&.court_applications&.each.with_index do |court_application, caidx|
     %pre
       = JSON.pretty_generate(hearing&.court_applications&.map(&:attributes))
-      %h4= "Court application type for court application #{caidx}"
+      %h4 Court application type for court application #{caidx}
       %pre
         = JSON.pretty_generate(court_application.type&.attributes)
-      %h4= "Judicial results for court application #{caidx}"
+      %h4 Judicial results for court application #{caidx}
       = "none" if court_application.judicial_results.blank?
       - Array(court_application.judicial_results).each.with_index do |result, ridx|
         %pre
           = JSON.pretty_generate(result.attributes)
-      %h4= "Respondents for court application #{caidx}"
+      %h4 Respondents for court application #{caidx}
       = "none" if court_application.respondents.blank?
       - Array(court_application.respondents).each.with_index do |respondent, ridx|
         %pre

--- a/app/views/prosecution_cases/_raw_response.html.haml
+++ b/app/views/prosecution_cases/_raw_response.html.haml
@@ -7,9 +7,9 @@
   %h3= 'Defendants'
   %pre
     - prosecution_case.defendants.each.with_index do |defendant, idx|
-      %h4= "defendant #{idx}"
+      %h4 defendant #{idx} 
       = JSON.pretty_generate(defendant.attributes)
-      %h4= "Offences for defendant #{idx}"
+      %h4 Offences for defendant #{idx}
       - defendant.offences.each do |offence|
         = JSON.pretty_generate(offence.attributes)
 
@@ -20,25 +20,25 @@
 
   %h3= 'Hearings'
   - prosecution_case.hearings.each.with_index do |hearing, hidx|
-    %h4= "hearing #{hidx}"
+    %h4 hearing #{hidx}
     %pre
       = JSON.pretty_generate(hearing.attributes)
 
-    %h4= "Hearing events for hearing #{hidx}"
+    %h4 Hearing events for hearing #{hidx}
     = 'none' if hearing.hearing_events.blank?
     - Array(hearing.hearing_events).each.with_index do |event, eidx|
       %pre
         = JSON.pretty_generate(event.attributes)
 
-    %h4= "Providers for hearing #{hidx}"
+    %h4 Providers for hearing #{hidx}
     = 'none' if hearing.providers.blank?
     - Array(hearing.providers).each.with_index do |event, pidx|
       %pre
         = JSON.pretty_generate(event.attributes)
 
-    %h4= "Cracked ineffective details for hearing #{hidx}"
+    %h4 Cracked ineffective details for hearing #{hidx}
     - if hearing.cracked_ineffective_trial.nil?
-      = 'none'
+      none
     - else
       %pre
         = JSON.pretty_generate(hearing.cracked_ineffective_trial.attributes)

--- a/app/views/prosecution_cases/_raw_response.html.haml
+++ b/app/views/prosecution_cases/_raw_response.html.haml
@@ -7,7 +7,7 @@
   %h3= 'Defendants'
   %pre
     - prosecution_case.defendants.each.with_index do |defendant, idx|
-      %h4 defendant #{idx} 
+      %h4 defendant #{idx}
       = JSON.pretty_generate(defendant.attributes)
       %h4 Offences for defendant #{idx}
       - defendant.offences.each do |offence|

--- a/app/views/prosecution_cases/cd_api/_raw_response.html.haml
+++ b/app/views/prosecution_cases/cd_api/_raw_response.html.haml
@@ -7,7 +7,7 @@
   %h3= 'Overall defendants'
   %pre
     - case_summary.overall_defendants.each.with_index do |defendant, idx|
-      %h4= "defendant #{idx}"
+      %h4 defendant #{idx}
       = JSON.pretty_generate(defendant.attributes)
 
   %h3= 'Hearing summaries'
@@ -18,11 +18,11 @@
 
   %h3= 'Hearing summaries'
   - case_summary.hearing_summaries.each.with_index do |hearing_summary, hidx|
-    %h4= "hearing summary #{hidx}"
+    %h4 hearing summary #{hidx}
     %pre
       = JSON.pretty_generate(JSON.parse(hearing_summary.attributes.to_json))
 
-    %h4= "Defence counsels for hearing summary #{hidx}"
+    %h4 Defence counsels for hearing summary #{hidx}
     = 'none' if hearing_summary.defence_counsels.blank?
     - Array(hearing_summary.defence_counsels).each.with_index do |event, pidx|
       %pre


### PR DESCRIPTION
#### What
Fix HAML Linting Issues: UnnecessaryStringOutput

#### Ticket

[AAC-706](https://dsdmoj.atlassian.net/browse/AAC-706)

#### Why
As part of introducing code linting to check for stylistic errors and issues with our HAML files - we need to eliminate the day 0 lints in our code. 

#### How
As stated in the [UnnecessaryStringOutput](https://www.rubydoc.info/gems/haml_lint/HamlLint/Linter/UnnecessaryStringOutput) lints doc. 

The following two code snippets are equivalent, but the latter is more concise (and thus preferred):

```
%tag= "Some #{expression}"
%tag Some #{expression}
```
Reducing code by eliminating double quotes and equal characters

--------

