### PR TITLE
AAC-629 Enable V2 on prosecution case page in Staging

### DIFF
--- a/.k8s/live/staging/deployment.yaml
+++ b/.k8s/live/staging/deployment.yaml
@@ -67,6 +67,8 @@ spec:
               value: 'true'
             - name: HEARING
               value: 'true'
+            - name: HEARING_SUMMARIES
+              value: 'true'
             - name: DISPLAY_RAW_RESPONSES
               value: enabled
             - name: COURT_DATA_ADAPTOR_API_UID


### PR DESCRIPTION
#### What

Enable V2 on prosecution case page in the **STAGING** environment

#### Ticket

[AAC-629 Prosecution Case](https://dsdmoj.atlassian.net/browse/AAC-629)

#### Why

To enabled V2 CDAPI calls on the prosecution case pages.

#### How

Set HEARING_SUMMARIES env variable to **true** in DEV
Set HEARING_SUMMARIES env variable to **false** in UAT, Staging and Prod

### To note

Its counterpart page - Hearing day page - is already on V2 in Staging and thus already set to true in the config.