### PR TITLE
AAC-629 AAC-692 Enable V2 on prosecution case and hearing day page in Production

### DIFF
--- a/.k8s/live/production/deployment.yaml
+++ b/.k8s/live/production/deployment.yaml
@@ -64,9 +64,9 @@ spec:
             - name: DEFENDANTS_SEARCH
               value: 'true'
             - name: HEARING
-              value: 'false'
+              value: 'true'
             - name: HEARING_SUMMARIES
-              value: 'false'
+              value: 'true'
             - name: RAILS_LOG_TO_STDOUT
               value: enabled
             - name: COURT_DATA_ADAPTOR_API_UID


### PR DESCRIPTION
#### What

Enable V2 on the prosecution case and hearing day pages in **Production**

#### Ticket

[AAC-692 Hearing Day](https://dsdmoj.atlassian.net/browse/AAC-692)
[AAC-629 Prosecution Case](https://dsdmoj.atlassian.net/browse/AAC-629)

#### Why

To enable V2 calls on the prosecution case and hearing day pages

#### How

Set HEARING_SUMMARIES and HEARING env variable to true in the k8s  **Production** deployment config file
