### PR TITLE
AAC-806 - Update prod ingress

### DIFF
--- a/.k8s/live/production/ingress.yaml
+++ b/.k8s/live/production/ingress.yaml
@@ -4,7 +4,6 @@ metadata:
   name: laa-court-data-ui-app-ingress
   namespace: laa-court-data-ui-production
   annotations:
-    kubernetes.io/ingress.class: modsec01
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
@@ -27,6 +26,7 @@ metadata:
           return 403;
         }
 spec:
+  ingressClassName: modsec
   rules:
     - host: view-court-data.service.justice.gov.uk
       http:


### PR DESCRIPTION
#### What

Update prod ingress to use new controller as per [this documentation](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/networking/Switch-ingress-to-v1-ingress-controller.html#switch-to-the-new-nginx-ingress-controller)

#### Ticket

[CDUI - Update Ingress for new Cloud Platforms controller](https://dsdmoj.atlassian.net/browse/AAC-806)

#### Why

To maintain compatibility with Cloud Platform
