### PR TITLE
AAC-325 Display the provider and defendant relationship

### DIFF
--- a/app/decorators/cd_api/defence_counsel_decorator.rb
+++ b/app/decorators/cd_api/defence_counsel_decorator.rb
@@ -20,8 +20,6 @@ module CdApi
     end
 
     def name
-      # TODO: Create a name service to build the name for reusability
-      # and confirm the must have portions of a name or validations needed
       return nil unless first_name || middle_name || last_name
 
       [first_name, middle_name, last_name].compact.reject(&:empty?).join(' ')
@@ -45,8 +43,6 @@ module CdApi
     end
 
     def format_defendant_name(first_name, middle_name, last_name)
-      # TODO: Create a name service to build the name for reusability
-      # and confirm the must have portions of a name or validations needed
       return nil unless first_name || middle_name || last_name
 
       [first_name, middle_name, last_name].compact.reject(&:empty?).join(' ')

--- a/app/decorators/cd_api/defence_counsel_decorator.rb
+++ b/app/decorators/cd_api/defence_counsel_decorator.rb
@@ -7,7 +7,7 @@ module CdApi
 
       return "#{formatted_name} (#{formatted_status})" if defendants.empty?
 
-      defence_counsel_list = formatted_multiples_defendant_names.map do |defendant_name|
+      defence_counsel_list = formatted_defendant_names.map do |defendant_name|
         "#{formatted_name} (#{formatted_status}) for #{defendant_name}"
       end
       safe_join(defence_counsel_list, tag.br)
@@ -35,13 +35,11 @@ module CdApi
       status || t('generic.not_available').downcase
     end
 
-    def formatted_multiples_defendant_names
+    def formatted_defendant_names
       names = []
       defendants.map do |defendant|
         names << format_defendant_name(defendant&.first_name, defendant&.middle_name, defendant&.last_name)
       end
-
-      return [] if names.empty?
 
       names.compact
     end

--- a/app/decorators/cd_api/defence_counsel_decorator.rb
+++ b/app/decorators/cd_api/defence_counsel_decorator.rb
@@ -2,7 +2,6 @@
 
 module CdApi
   class DefenceCounselDecorator < BaseDecorator
-
     def name_status_and_defendants
       return t('generic.not_available') if name_and_status_blank?
 

--- a/app/decorators/cd_api/defence_counsel_decorator.rb
+++ b/app/decorators/cd_api/defence_counsel_decorator.rb
@@ -2,10 +2,16 @@
 
 module CdApi
   class DefenceCounselDecorator < BaseDecorator
-    def name_and_status
+
+    def name_status_and_defendants
       return t('generic.not_available') if name_and_status_blank?
 
-      "#{formatted_name} (#{formatted_status})"
+      return "#{formatted_name} (#{formatted_status})" if defendants.empty?
+
+      defence_counsel_list = formatted_multiples_defendant_names.map do |defendant_name|
+        "#{formatted_name} (#{formatted_status}) for #{defendant_name}"
+      end
+      safe_join(defence_counsel_list, tag.br)
     end
 
     private
@@ -28,6 +34,25 @@ module CdApi
 
     def formatted_status
       status || t('generic.not_available').downcase
+    end
+
+    def formatted_multiples_defendant_names
+      names = []
+      defendants.map do |defendant|
+        names << format_defendant_name(defendant&.first_name, defendant&.middle_name, defendant&.last_name)
+      end
+
+      return [] if names.empty?
+
+      names.compact
+    end
+
+    def format_defendant_name(first_name, middle_name, last_name)
+      # TODO: Create a name service to build the name for reusability
+      # and confirm the must have portions of a name or validations needed
+      return nil unless first_name || middle_name || last_name
+
+      [first_name, middle_name, last_name].compact.reject(&:empty?).join(' ')
     end
   end
 end

--- a/app/decorators/cd_api/hearing_summary_decorator.rb
+++ b/app/decorators/cd_api/hearing_summary_decorator.rb
@@ -28,7 +28,7 @@ module CdApi
     def mapped_defence_counsels
       defence_counsels.each do |defence_counsel|
         defence_counsel.defendants.map! do |defendant_id|
-          defendants.select {|defendant| (defendant.id == defendant_id)}.first
+          defendants.find { |defendant| (defendant.id == defendant_id) }
         end
       end
     end

--- a/app/decorators/cd_api/hearing_summary_decorator.rb
+++ b/app/decorators/cd_api/hearing_summary_decorator.rb
@@ -17,12 +17,20 @@ module CdApi
 
     private
 
-    def decorated_defence_counsels
-      decorate_all(defence_counsels, CdApi::DefenceCounselDecorator)
+    def defence_counsel_sentences
+      decorated_defence_counsels&.map(&:name_status_and_defendants) || []
     end
 
-    def defence_counsel_sentences
-      decorated_defence_counsels&.map(&:name_and_status) || []
+    def decorated_defence_counsels
+      decorate_all(mapped_defence_counsels, CdApi::DefenceCounselDecorator)
+    end
+
+    def mapped_defence_counsels
+      defence_counsels.each do |defence_counsel|
+        defence_counsel.defendants.map! do |defendant_id|
+          defendants.select {|defendant| (defendant.id == defendant_id)}.first
+        end
+      end
     end
   end
 end

--- a/spec/decorators/cd_api/defence_counsel_decorator_spec.rb
+++ b/spec/decorators/cd_api/defence_counsel_decorator_spec.rb
@@ -24,7 +24,10 @@ RSpec.describe CdApi::DefenceCounselDecorator, type: :decorator do
   describe '#name_status_and_defendants' do
     subject(:call) { decorator.name_status_and_defendants }
 
-    let(:defence_counsel) { build :defence_counsel, first_name: 'Bob', last_name: 'Smith', status: 'QC', defendants: mapped_defendants  }
+    let(:defence_counsel) do
+      build :defence_counsel, first_name: 'Bob', last_name: 'Smith', status: 'QC',
+                              defendants: mapped_defendants
+    end
 
     # The mapping of the defendants occurs in the HearingSummaryDecorator
     let(:mapped_defendants) do
@@ -36,7 +39,7 @@ RSpec.describe CdApi::DefenceCounselDecorator, type: :decorator do
     context 'when multiple defendants' do
       let(:mapped_defendants) do
         [build(:defendant, first_name: 'John', middle_name: nil, last_name: 'Doe'),
-          build(:defendant, first_name: 'Jane', middle_name: nil, last_name: 'Doe')]
+         build(:defendant, first_name: 'Jane', middle_name: nil, last_name: 'Doe')]
       end
 
       it 'displays the provider defendant relationship' do
@@ -46,7 +49,8 @@ RSpec.describe CdApi::DefenceCounselDecorator, type: :decorator do
 
     context 'when defence counsel name and status is missing' do
       let(:defence_counsel) do
-        build :defence_counsel, first_name: '', middle_name: '', last_name: '', status: '', defendants: mapped_defendants
+        build :defence_counsel, first_name: '', middle_name: '', last_name: '', status: '',
+                                defendants: mapped_defendants
       end
 
       it { is_expected.to eql('Not available') }
@@ -54,7 +58,8 @@ RSpec.describe CdApi::DefenceCounselDecorator, type: :decorator do
 
     context 'when defence counsel name is only partially given' do
       let(:defence_counsel) do
-        build :defence_counsel, first_name: 'Bob', middle_name: 'Owl', last_name: '', status: 'QC', defendants: mapped_defendants
+        build :defence_counsel, first_name: 'Bob', middle_name: 'Owl', last_name: '', status: 'QC',
+                                defendants: mapped_defendants
       end
 
       it { is_expected.to eql('Bob Owl (QC) for John Doe') }
@@ -62,7 +67,8 @@ RSpec.describe CdApi::DefenceCounselDecorator, type: :decorator do
 
     context 'when defence counsel name is missing' do
       let(:defence_counsel) do
-        build :defence_counsel, first_name: nil, middle_name: nil, last_name: nil, status: 'QC', defendants: mapped_defendants
+        build :defence_counsel, first_name: nil, middle_name: nil, last_name: nil, status: 'QC',
+                                defendants: mapped_defendants
       end
 
       it { is_expected.to eql('Not available (QC) for John Doe') }
@@ -70,7 +76,8 @@ RSpec.describe CdApi::DefenceCounselDecorator, type: :decorator do
 
     context 'when defence counsel status is missing' do
       let(:defence_counsel) do
-        build :defence_counsel, first_name: 'Bob', middle_name: 'Owl', last_name: 'Smith', status: nil, defendants: mapped_defendants
+        build :defence_counsel, first_name: 'Bob', middle_name: 'Owl', last_name: 'Smith', status: nil,
+                                defendants: mapped_defendants
       end
 
       it { is_expected.to eql('Bob Owl Smith (not available) for John Doe') }
@@ -78,7 +85,8 @@ RSpec.describe CdApi::DefenceCounselDecorator, type: :decorator do
 
     context 'when defendants name is missing' do
       let(:defence_counsel) do
-        build :defence_counsel, first_name: 'Bob', middle_name: 'Owl', last_name: 'Smith', status: 'QC', defendants: []
+        build :defence_counsel, first_name: 'Bob', middle_name: 'Owl', last_name: 'Smith', status: 'QC',
+                                defendants: []
       end
 
       it { is_expected.to eql('Bob Owl Smith (QC)') }

--- a/spec/decorators/cd_api/hearing_summary_decorator_spec.rb
+++ b/spec/decorators/cd_api/hearing_summary_decorator_spec.rb
@@ -46,7 +46,8 @@ RSpec.describe CdApi::HearingSummaryDecorator, type: :decorator do
       let(:hearing_summary) { build :hearing_summary, defence_counsels:, defendants: }
       let(:defence_counsels) { [defence_counsel1, defence_counsel2] }
       let(:defence_counsel1) do
-        build :defence_counsel, first_name: 'Jammy', last_name: 'Dodger', status: 'Junior', defendants: defendant_ids
+        build :defence_counsel, first_name: 'Jammy', last_name: 'Dodger', status: 'Junior',
+                                defendants: defendant_ids
       end
       let(:defence_counsel2) { build :defence_counsel, first_name: 'Bob', last_name: 'Smith', status: 'QC' }
 
@@ -54,13 +55,15 @@ RSpec.describe CdApi::HearingSummaryDecorator, type: :decorator do
         [defendant1, defendant2].map(&:id)
       end
 
-      let(:defendants) { [defendant1, defendant2]}
+      let(:defendants) { [defendant1, defendant2] }
 
       let(:defendant1) { build(:defendant, first_name: 'John', middle_name: '', last_name: 'Doe') }
       let(:defendant2) { build(:defendant, first_name: 'Jane', middle_name: '', last_name: 'Doe') }
 
       it 'returns defence counsel list' do
-        expect(subject).to eql('Jammy Dodger (Junior) for John Doe<br>Jammy Dodger (Junior) for Jane Doe<br>Bob Smith (QC)')
+        expect(decorator.defence_counsel_list).to eql('Jammy Dodger (Junior) for John Doe<br>' \
+                                                      'Jammy Dodger (Junior) for Jane Doe<br>' \
+                                                      'Bob Smith (QC)')
       end
     end
 

--- a/spec/decorators/cd_api/hearing_summary_decorator_spec.rb
+++ b/spec/decorators/cd_api/hearing_summary_decorator_spec.rb
@@ -42,6 +42,28 @@ RSpec.describe CdApi::HearingSummaryDecorator, type: :decorator do
       it { is_expected.to eql('Jammy Dodger (Junior)<br>Bob Smith (QC)') }
     end
 
+    context 'when there are multiple defendents in defence_counsels' do
+      let(:hearing_summary) { build :hearing_summary, defence_counsels:, defendants: }
+      let(:defence_counsels) { [defence_counsel1, defence_counsel2] }
+      let(:defence_counsel1) do
+        build :defence_counsel, first_name: 'Jammy', last_name: 'Dodger', status: 'Junior', defendants: defendant_ids
+      end
+      let(:defence_counsel2) { build :defence_counsel, first_name: 'Bob', last_name: 'Smith', status: 'QC' }
+
+      let(:defendant_ids) do
+        [defendant1, defendant2].map(&:id)
+      end
+
+      let(:defendants) { [defendant1, defendant2]}
+
+      let(:defendant1) { build(:defendant, first_name: 'John', middle_name: '', last_name: 'Doe') }
+      let(:defendant2) { build(:defendant, first_name: 'Jane', middle_name: '', last_name: 'Doe') }
+
+      it 'returns defence counsel list' do
+        expect(subject).to eql('Jammy Dodger (Junior) for John Doe<br>Jammy Dodger (Junior) for Jane Doe<br>Bob Smith (QC)')
+      end
+    end
+
     context 'with no defence_counsels' do
       let(:defence_counsels) { [] }
 

--- a/spec/factories/cd_api/defendant.rb
+++ b/spec/factories/cd_api/defendant.rb
@@ -3,6 +3,7 @@
 FactoryBot.define do
   # ActiveResource Factory, use :build not :create to prevent HTTP calls
   factory :defendant, class: 'CdApi::Defendant' do
+    id { SecureRandom.uuid }
     national_insurance_number { 'AP662165A' }
     arrest_summons_number { 'BXIM1ECIO3JH' }
     name { 'Jammy Edward Dodger' }

--- a/spec/factories/cd_api/hearing_summary.rb
+++ b/spec/factories/cd_api/hearing_summary.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     hearing_type { 'Trial' }
     court_centre { FactoryBot.build :court_centre }
     hearing_days { [] }
+    defendants { [] }
     defence_counsels { [] }
 
     trait :with_hearing_days do


### PR DESCRIPTION
#### What

Display the provider and defendant relationship

#### Ticket

[AAC-325](https://dsdmoj.atlassian.net/browse/AAC-325)

#### How

- map defence_counsel.defendants (ids) to hearing summary.defendants (objects)
- Include defendants info to the defence counsel list
- Add unit testing

#### Why

The defence counsels has a list of defendant_ids that they each represent. This does not contain the defendant information like first name and last name. Thus mapped the defendant data in the hearing summary to it.

Defence counsel list is now: "Defence Counsel Name (status) for Defendant A"
or when it's multiple defendants it's 
"Defence Counsel1 Name (status) for Defendant A< br>Defence Counsel1 Name (status) for Defendant B< br>Defence Counsel2 Name (QC) for Defendant C"
