### PR TITLE
AAC-852 - Move initall to eventlistener for turbo

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -8,6 +8,7 @@
     = stylesheet_pack_tag 'application', media: 'all'
     = javascript_pack_tag 'application', defer: true
     = csrf_meta_tags
+    = javascript_pack_tag 'govuk-frontend'
 
     %meta{ content: "width=device-width, initial-scale=1, viewport-fit=cover", name: "viewport" }/
     %meta{ content: "blue", name: "theme-color" }/

--- a/app/webpack/packs/application.js
+++ b/app/webpack/packs/application.js
@@ -4,11 +4,8 @@
 // that code so it'll be compiled.
 
 import '../stylesheets/application.scss'
-import { initAll } from 'govuk-frontend'
 import '@hotwired/turbo-rails'
 require('@rails/ujs').start()
-initAll()
-require.context('govuk-frontend/govuk/assets')
 // require("@rails/activestorage").start();
 // require("channels");
 

--- a/app/webpack/packs/govuk-frontend.js
+++ b/app/webpack/packs/govuk-frontend.js
@@ -1,6 +1,6 @@
 import { initAll } from 'govuk-frontend'
 
-document.addEventListener('turbo:load', function(event) {
-    require.context('govuk-frontend/govuk/assets')
-    initAll()
+document.addEventListener('turbo:load', function (event) {
+  require.context('govuk-frontend/govuk/assets')
+  initAll()
 })

--- a/app/webpack/packs/govuk-frontend.js
+++ b/app/webpack/packs/govuk-frontend.js
@@ -1,0 +1,6 @@
+import { initAll } from 'govuk-frontend'
+
+document.addEventListener('turbo:load', function(event) {
+    require.context('govuk-frontend/govuk/assets')
+    initAll()
+})


### PR DESCRIPTION
#### What

Move the GOVUK initAll() function to an event listener so that it always gets fired for turbo. 

#### Ticket

[BUG - VCD - Applications not always appearing properly](https://dsdmoj.atlassian.net/browse/AAC-852)

#### Why

Turbo does not do page refreshing as it treats the site as a Single Page application. Because of this the initAll function is not always called and therefor GOVUK functionallity breaks. 

#### How

Move to its own packed file and add to event listener. 
