### PR TITLE
AAC-828 BugFix Filter DefenceCounsels on attendance days

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,7 +32,7 @@ Layout/EmptyLinesAroundAttributeAccessor:
 
 Layout/LineLength:
   Max: 110
-  IgnoredPatterns: ['(\A|\s)#','.*\s+ # .*', "body: '{\".*\":", "%r{http.*"]
+  AllowedPatterns: ['(\A|\s)#','.*\s+ # .*', "body: '{\".*\":", "%r{http.*"]
   AllowHeredoc: true
 
 Layout/RedundantLineBreak:

--- a/app/decorators/cd_api/hearing_decorator.rb
+++ b/app/decorators/cd_api/hearing_decorator.rb
@@ -18,11 +18,14 @@ module CdApi
     private
 
     def defence_counsel_sentences
-      decorated_defence_counsels || []
+      return [t('generic.not_available')] if decorated_defence_counsels.empty?
+
+      decorated_defence_counsels
     end
 
     def decorated_defence_counsels
-      CdApi::HearingDetails::DefenceCounselsListService.call(mapped_defence_counsels)
+      service = CdApi::HearingDetails::DefenceCounselsListService
+      @decorated_defence_counsels ||= service.call(mapped_defence_counsels)
     end
 
     def mapped_defence_counsels

--- a/app/decorators/cd_api/hearing_summary_decorator.rb
+++ b/app/decorators/cd_api/hearing_summary_decorator.rb
@@ -25,12 +25,18 @@ module CdApi
     end
 
     def mapped_defence_counsels
-      defence_counsels.each do |defence_counsel|
+      attended_defence_counsels.each do |defence_counsel|
         defence_counsel.defendants.map! do |defendant_id|
           details = defendants.find { |defendant| (defendant.id == defendant_id) }
 
           details || defendant_id
         end
+      end
+    end
+
+    def attended_defence_counsels
+      defence_counsels.filter_map do |defence_counsel|
+        defence_counsel if defence_counsel.attendance_days.include?(day.strftime('%Y-%m-%d'))
       end
     end
   end

--- a/app/decorators/cd_api/hearing_summary_decorator.rb
+++ b/app/decorators/cd_api/hearing_summary_decorator.rb
@@ -17,13 +17,15 @@ module CdApi
     private
 
     def defence_counsel_sentences
+      decorated_defence_counsels = decorate_defence_counsels
+
       return [t('generic.not_available')] if decorated_defence_counsels.empty?
 
       decorated_defence_counsels.map(&:name_status_and_defendants)
     end
 
-    def decorated_defence_counsels
-      @decorated_defence_counsels ||= decorate_all(mapped_defence_counsels, CdApi::DefenceCounselDecorator)
+    def decorate_defence_counsels
+      decorate_all(mapped_defence_counsels, CdApi::DefenceCounselDecorator) || []
     end
 
     def mapped_defence_counsels

--- a/app/decorators/cd_api/hearing_summary_decorator.rb
+++ b/app/decorators/cd_api/hearing_summary_decorator.rb
@@ -17,11 +17,13 @@ module CdApi
     private
 
     def defence_counsel_sentences
-      decorated_defence_counsels&.map(&:name_status_and_defendants) || []
+      return [t('generic.not_available')] if decorated_defence_counsels.empty?
+
+      decorated_defence_counsels.map(&:name_status_and_defendants)
     end
 
     def decorated_defence_counsels
-      decorate_all(mapped_defence_counsels, CdApi::DefenceCounselDecorator)
+      @decorated_defence_counsels ||= decorate_all(mapped_defence_counsels, CdApi::DefenceCounselDecorator)
     end
 
     def mapped_defence_counsels

--- a/spec/decorators/cd_api/hearing_decorator_spec.rb
+++ b/spec/decorators/cd_api/hearing_decorator_spec.rb
@@ -155,6 +155,22 @@ RSpec.describe CdApi::HearingDecorator, type: :decorator do
       end
     end
 
+    context 'when no defence counsels attending the hearing day' do
+      let(:defence_counsels) { [defence_counsel1] }
+      let(:defence_counsel1) do
+        build :defence_counsel, first_name: 'Jane', last_name: 'Doe', attendance_days: []
+      end
+
+      before do
+        allow(CdApi::HearingDetails::DefenceCounselsListService).to receive(:call)
+          .with([]).and_return([])
+      end
+
+      it 'returns not available' do
+        expect(decorator.defence_counsels_list).to eq 'Not available'
+      end
+    end
+
     context 'when there is no current_sitting_day' do
       let(:mapped_defence_counsels) { [] }
       let(:day) { nil }

--- a/spec/decorators/cd_api/hearing_summary_decorator_spec.rb
+++ b/spec/decorators/cd_api/hearing_summary_decorator_spec.rb
@@ -31,7 +31,6 @@ RSpec.describe CdApi::HearingSummaryDecorator, type: :decorator do
     subject(:call) { decorator.defence_counsel_list }
 
     before do
-      allow_any_instance_of(described_class).to receive(:decorate_all).with(any_args).and_return([])
       allow_any_instance_of(described_class).to receive(:day).and_return(sitting_day)
     end
 
@@ -121,6 +120,30 @@ RSpec.describe CdApi::HearingSummaryDecorator, type: :decorator do
       end
 
       it { is_expected.to eql 'Not available' }
+    end
+
+    context 'when called again after day has been altered' do
+      let(:hearing_summary) { build :hearing_summary, defence_counsels: }
+
+      let(:defence_counsels) { [defence_counsel1, defence_counsel2] }
+      let(:defence_counsel1) do
+        build(:defence_counsel, first_name: 'First', last_name: 'Counsel', status: 'Junior',
+                                attendance_days: ['2022-01-01'])
+      end
+      let(:defence_counsel2) do
+        build(:defence_counsel, first_name: 'Second', last_name: 'Counsel', status: 'Junior',
+                                attendance_days: ['2022-01-01'])
+      end
+
+      before { decorator.defence_counsel_list }
+
+      it 'returns new un-memoized defence counsel list' do
+        allow_any_instance_of(described_class).to receive(:day).and_return(DateTime.parse('2022-01-01'))
+        expect_any_instance_of(described_class).to receive(:decorate_all).with(
+          [defence_counsel1, defence_counsel2], any_args
+        )
+        decorator.defence_counsel_list
+      end
     end
   end
 

--- a/spec/decorators/cd_api/hearing_summary_decorator_spec.rb
+++ b/spec/decorators/cd_api/hearing_summary_decorator_spec.rb
@@ -93,8 +93,6 @@ RSpec.describe CdApi::HearingSummaryDecorator, type: :decorator do
     end
 
     context 'when defence counsel did not attend on the hearing day' do
-      subject(:call) { decorator.defence_counsel_list }
-
       let(:hearing_summary) { build :hearing_summary, defence_counsels: }
 
       let(:defence_counsels) { [defence_counsel1, defence_counsel2] }
@@ -111,6 +109,18 @@ RSpec.describe CdApi::HearingSummaryDecorator, type: :decorator do
         expect_any_instance_of(described_class).to receive(:decorate_all).with([defence_counsel1], any_args)
         decorator.defence_counsel_list
       end
+    end
+
+    context 'when no defence counsels attended the hearing day' do
+      let(:hearing_summary) { build :hearing_summary, defence_counsels: }
+
+      let(:defence_counsels) { [defence_counsel1] }
+      let(:defence_counsel1) do
+        build(:defence_counsel, first_name: 'Jammy', last_name: 'Dodger', status: 'Junior',
+                                attendance_days: [])
+      end
+
+      it { is_expected.to eql 'Not available' }
     end
   end
 

--- a/spec/factories/cd_api/hearing_day.rb
+++ b/spec/factories/cd_api/hearing_day.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   # ActiveResource Factory, use :build not :create to prevent HTTP calls
   factory :hearing_day, class: 'CdApi::HearingDay' do
-    sitting_day { '2021-01-19T10:45:00.000Z' }
+    sitting_day { DateTime.parse('2021-01-19T10:45:00.000Z') }
     listing_sequence { nil }
     listed_duration_minutes { 167 }
     has_shared_results { true }

--- a/spec/fixtures/stubs/cd_api/hearing_data_response.json
+++ b/spec/fixtures/stubs/cd_api/hearing_data_response.json
@@ -155,7 +155,8 @@
         "last_name": "jones",
         "status": "junior",
         "attendance_days": [
-          "2021-03-29"
+          "2021-03-29",
+          "2019-10-23"
         ],
         "defendants": [
           "b39400d5-046f-4588-9268-bfc47c40cafb"
@@ -168,7 +169,8 @@
         "last_name": "williams",
         "status": "junior",
         "attendance_days": [
-          "2021-03-29"
+          "2021-03-29",
+          "2019-10-23"
         ],
         "defendants": [
           "fc449b85-35e5-47a5-9670-3d1d30891108"

--- a/spec/views/hearings/_attendees_v2.html.haml_spec.rb
+++ b/spec/views/hearings/_attendees_v2.html.haml_spec.rb
@@ -50,10 +50,27 @@ RSpec.describe 'hearings/_attendees_v2', type: :view do
     end
 
     context 'with defence_counsel' do
+      before do
+        allow(decorated_hearing).to receive(:current_sitting_day).and_return('2019-10-23')
+      end
+
       it 'displays list of defence council' do
         text_match = /Mark Jones \(junior\) for Leon Goodwin.*David Williams \(junior\) for not available/
         is_expected.to have_tag('p.govuk-body#defence',
                                 text: text_match)
+      end
+    end
+
+    context 'when defence counsel did not attend' do
+      let(:unattended_day) { '2099-10-23' }
+
+      before do
+        allow(decorated_hearing).to receive(:current_sitting_day).and_return(unattended_day)
+      end
+
+      it 'displays list of defence council' do
+        text_match = /Mark Jones \(junior\) for Leon Goodwin.*David Williams \(junior\) for not available/
+        is_expected.not_to have_tag('p.govuk-body#defence', text: text_match)
       end
     end
 

--- a/spec/views/prosecution_cases/cd_api/_hearing_summaries.html.haml_spec.rb
+++ b/spec/views/prosecution_cases/cd_api/_hearing_summaries.html.haml_spec.rb
@@ -32,7 +32,10 @@ RSpec.describe 'prosecution_cases/cd_api/_hearing_summaries.html.haml', type: :v
   let(:hearing2_day) { build :hearing_day, sitting_day: '2021-01-19T15:19:15.000Z' }
 
   let(:defence_counsels) { [defence_counsel] }
-  let(:defence_counsel) { build :defence_counsel, first_name: 'Fred', last_name: 'Dibnah', status: 'QC' }
+  let(:defence_counsel) do
+    build :defence_counsel, first_name: 'Fred', last_name: 'Dibnah', status: 'QC', attendance_days:
+  end
+  let(:attendance_days) { %w[2021-01-17 2021-01-18 2021-01-19] }
 
   before do
     allow(Feature).to receive(:enabled?).with(:hearing_summaries).and_return(true)
@@ -107,6 +110,21 @@ RSpec.describe 'prosecution_cases/cd_api/_hearing_summaries.html.haml', type: :v
           .and have_selector('tbody.govuk-table__body tr:nth-child(2)', text: %r{19/01/2021.*Trial}m)
           .and have_selector('tbody.govuk-table__body tr:nth-child(3)', text: %r{20/01/2021.*Trial}m)
           .and have_selector('tbody.govuk-table__body tr:nth-child(4)', text: %r{20/01/2021.*Sentence}m)
+      end
+    end
+
+    context 'when defence counsel did not attend hearing day' do
+      let(:attendance_days) { %w[2021-01-17 2021-01-19] }
+
+      it 'renders provider list per row' do
+        expect(rendered)
+          .to have_selector('tbody.govuk-table__body tr:nth-child(1)', text: 'Fred Dibnah (QC)')
+          .and have_selector('tbody.govuk-table__body tr:nth-child(3)', text: 'Fred Dibnah (QC)')
+      end
+
+      it 'does not render provider for hearing day' do
+        expect(rendered).not_to have_selector('tbody.govuk-table__body tr:nth-child(2)',
+                                              text: 'Fred Dibnah (QC)')
       end
     end
   end


### PR DESCRIPTION
#### What

AAC-828 Filter DefenceCounsels on attendance days for the **Case Page and Hearing day Page**

#### Ticket

[AAC-828](https://dsdmoj.atlassian.net/browse/AAC-828)

#### Why

To filter out defence counsels that did not attend a particular hearing day of a multi-day hearing.
Defence Counsels have property :attendance_days, which needs to be used when creating the Providers Attending or Defence Advocates lists on the Case page and Hearing day pages respectively. 

#### How

- Add current_sitting_day to the hearing decorator, in order to know what the current hearing day is being called. This is used to compare with the defence counsels.attendance_days
- Add logic to not show defence_counsels where their attendance_days does not include the hearing day being worked on.
- Filter out defence_counsels where the hearing_summary.day is not included in their attendance_days (meaning they did not attending that hearing). This is for the Case page.
- Update unit and feature tests
- Update the test json body response to have attendance_days

⚠️ To note: When there are defence_counsels where none of them attended a hearing day then return 'Not available' . I will create a tech debt ticket to look at improving this message e.g. 'No defence counsels attended'

