### PR TITLE
AAC-425 Show Trial Estimation of Hearing

### DIFF
--- a/app/decorators/cd_api/case_summary_decorator.rb
+++ b/app/decorators/cd_api/case_summary_decorator.rb
@@ -15,7 +15,8 @@ module CdApi
     def sorted_hearing_summaries_with_day
       Enumerator.new do |enum|
         sorter.sorted_hearings.each do |hearing|
-          sorter.sorted_hearing_days(hearing).each do |day|
+          sorter.sorted_hearing_days(hearing).each_with_index do |day, index|
+            hearing.estimated_duration = nil if index != 0
             hearing.day = day
             enum.yield(hearing)
           end

--- a/app/decorators/cd_api/hearing_summary_decorator.rb
+++ b/app/decorators/cd_api/hearing_summary_decorator.rb
@@ -16,7 +16,6 @@ module CdApi
 
     def formatted_estimated_duration
       return unless estimated_duration
-
       "#{t('hearing_summary.estimated_duration')} #{estimated_duration.downcase}"
     end
 

--- a/app/decorators/cd_api/hearing_summary_decorator.rb
+++ b/app/decorators/cd_api/hearing_summary_decorator.rb
@@ -14,6 +14,12 @@ module CdApi
       @hearing_days ||= decorate_all(object.hearing_days, CdApi::HearingDayDecorator)
     end
 
+    def formatted_estimated_duration
+      return unless estimated_duration
+
+      "#{t('hearing_summary.estimated_duration')} #{estimated_duration.downcase}"
+    end
+
     private
 
     def defence_counsel_sentences

--- a/app/views/prosecution_cases/cd_api/_hearing_summaries.html.haml
+++ b/app/views/prosecution_cases/cd_api/_hearing_summaries.html.haml
@@ -19,7 +19,7 @@
         %td.govuk-table__cell
           = hearing_summary.hearing_type
           - if hearing_summary.estimated_duration
-            %br 
+            %br
             %span.app-body-secondary
               = hearing_summary.formatted_estimated_duration
         %td.govuk-table__cell

--- a/app/views/prosecution_cases/cd_api/_hearing_summaries.html.haml
+++ b/app/views/prosecution_cases/cd_api/_hearing_summaries.html.haml
@@ -18,5 +18,9 @@
           = link_to hearing_summary.day.strftime('%d/%m/%Y'), hearing_path(id: hearing_summary.id, urn: case_summary.prosecution_case_reference, column: case_summary.hearings_sort_column, direction: case_summary.hearings_sort_direction, page: idx), class: 'govuk-link'
         %td.govuk-table__cell
           = hearing_summary.hearing_type
+          - if hearing_summary.estimated_duration
+            %br 
+            %span.app-body-secondary
+              = hearing_summary.formatted_estimated_duration
         %td.govuk-table__cell
           = hearing_summary ? hearing_summary.defence_counsel_list : t('generic.not_available')

--- a/config/locales/en/decorators/hearing_summary.yml
+++ b/config/locales/en/decorators/hearing_summary.yml
@@ -1,0 +1,4 @@
+---
+en:
+  hearing_summary:
+    estimated_duration: Estimated duration

--- a/spec/decorators/cd_api/hearing_summary_decorator_spec.rb
+++ b/spec/decorators/cd_api/hearing_summary_decorator_spec.rb
@@ -105,4 +105,21 @@ RSpec.describe CdApi::HearingSummaryDecorator, type: :decorator do
       it { is_expected.to eql [] }
     end
   end
+
+  describe '#formatted_estimated_duration' do 
+
+    context "when there is an estimated duration" do 
+      it "returns formated estimated duration in a sentence" do
+        expect(subject.formatted_estimated_duration).to eq "Estimated duration 20 days"
+      end
+    end
+
+    context "when there is no estimated duration" do 
+      let(:hearing_summary) { build :hearing_summary, estimated_duration: nil }
+      it "returns nil" do
+        expect(subject.formatted_estimated_duration).to be_nil
+      end
+    end
+    
+  end
 end

--- a/spec/decorators/cd_api/hearing_summary_decorator_spec.rb
+++ b/spec/decorators/cd_api/hearing_summary_decorator_spec.rb
@@ -106,20 +106,21 @@ RSpec.describe CdApi::HearingSummaryDecorator, type: :decorator do
     end
   end
 
-  describe '#formatted_estimated_duration' do 
+  describe '#formatted_estimated_duration' do
+    subject(:call) { decorator.formatted_estimated_duration }
 
-    context "when there is an estimated duration" do 
-      it "returns formated estimated duration in a sentence" do
-        expect(subject.formatted_estimated_duration).to eq "Estimated duration 20 days"
+    context 'when there is an estimated duration' do
+      it 'returns formated estimated duration in a sentence' do
+        expect(call).to eq 'Estimated duration 20 days'
       end
     end
 
-    context "when there is no estimated duration" do 
+    context 'when there is no estimated duration' do
       let(:hearing_summary) { build :hearing_summary, estimated_duration: nil }
-      it "returns nil" do
-        expect(subject.formatted_estimated_duration).to be_nil
+
+      it 'returns nil' do
+        expect(call).to be_nil
       end
     end
-    
   end
 end

--- a/spec/factories/cd_api/hearing_summary.rb
+++ b/spec/factories/cd_api/hearing_summary.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     hearing_days { [] }
     defendants { [] }
     defence_counsels { [] }
-    estimated_duration { "20 DAYS" }
+    estimated_duration { '20 DAYS' }
 
     trait :with_hearing_days do
       hearing_day1 = FactoryBot.build :hearing_day

--- a/spec/factories/cd_api/hearing_summary.rb
+++ b/spec/factories/cd_api/hearing_summary.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
     hearing_days { [] }
     defendants { [] }
     defence_counsels { [] }
+    estimated_duration { "20 DAYS" }
 
     trait :with_hearing_days do
       hearing_day1 = FactoryBot.build :hearing_day

--- a/spec/views/prosecution_cases/cd_api/_hearing_summaries.html.haml_spec.rb
+++ b/spec/views/prosecution_cases/cd_api/_hearing_summaries.html.haml_spec.rb
@@ -109,5 +109,28 @@ RSpec.describe 'prosecution_cases/cd_api/_hearing_summaries.html.haml', type: :v
           .and have_selector('tbody.govuk-table__body tr:nth-child(4)', text: %r{20/01/2021.*Sentence}m)
       end
     end
+
+    context 'with estimated duration on multiday hearings' do
+      let(:hearing_summaries) { [hearing_summary] }
+      let(:hearing1_day1) { build :hearing_day, sitting_day: '2021-01-19T10:45:00.000Z' }
+      let(:hearing1_day2) { build :hearing_day, sitting_day: '2021-01-20T10:45:00.000Z' }
+      let(:hearing_summary) do
+        build :hearing_summary, id: 'hearing1-uuid', hearing_type: 'Trial',
+                                hearing_days: [hearing1_day1, hearing1_day2], defence_counsels:
+      end
+
+      it 'renders formated estimated duration on the first hearing day' do
+        expect(rendered)
+          .to have_selector('tbody.govuk-table__body tr:nth-child(1)',
+                            text: %r{19/01/2021.*Trial\n\n\nEstimated duration 20 days}m)
+          .and have_selector('tbody.govuk-table__body tr:nth-child(2)', text: %r{20/01/2021.*Trial}m)
+      end
+
+      it 'does not render duplicated estmated duration' do
+        expect(rendered)
+          .not_to have_selector('tbody.govuk-table__body tr:nth-child(2)',
+                                text: %r{20/01/2021.*Trial\n\n\nEstimated duration 20 days}m)
+      end
+    end
   end
 end

--- a/spec/views/prosecution_cases/cd_api/_hearing_summaries.html.haml_spec.rb
+++ b/spec/views/prosecution_cases/cd_api/_hearing_summaries.html.haml_spec.rb
@@ -113,7 +113,6 @@ RSpec.describe 'prosecution_cases/cd_api/_hearing_summaries.html.haml', type: :v
       end
     end
 
-
     context 'with estimated duration on multiday hearings' do
       let(:hearing_summaries) { [hearing_summary] }
       let(:hearing1_day1) { build :hearing_day, sitting_day: '2021-01-19T10:45:00.000Z' }
@@ -149,7 +148,6 @@ RSpec.describe 'prosecution_cases/cd_api/_hearing_summaries.html.haml', type: :v
       it 'does not render provider for hearing day' do
         expect(rendered).not_to have_selector('tbody.govuk-table__body tr:nth-child(2)',
                                               text: 'Fred Dibnah (QC)')
-
       end
     end
   end


### PR DESCRIPTION
#### What

Caseworkers need to see estimated duration when assessing interim bills and cracked trials, as it changes the claimable fee when a trial estimate breaches a threshold of length.

#### Ticket

[Show Trial Estimation of Hearing](https://dsdmoj.atlassian.net/browse/AAC-425)

#### Why

We added the estimated duration to trials on the case summary page hearings table. This will allow our users to easily identify the trials estimations and authorise interim and cracked trial bills.

#### How

Added method to format estimated duration string in hearing_summary decorator.

Added styling and estimated duration call to hearing_summaries view.

Updated case_summary decorator to set 'estimated_duration' to nil for future multi day hearings. This ensures estimated duration is only shown on the first hearing day.

Updated unit tests.

