### PR TITLE
AAC-868 Filter Prosecution Counsels on hearing day page

### DIFF
--- a/app/decorators/cd_api/hearing_decorator.rb
+++ b/app/decorators/cd_api/hearing_decorator.rb
@@ -10,9 +10,15 @@ module CdApi
     end
 
     def defence_counsels_list
-      return t('generic.not_available') if hearing.defence_counsels.blank?
-
       safe_join(defence_counsel_sentences, tag.br)
+    end
+
+    def prosecution_counsels_list
+      formatted_prosecution_counsels = filter_prosecution_counsels.map { |pc| "#{pc.first_name&.capitalize} #{pc.last_name&.capitalize}" }
+
+      return t('generic.not_available') if formatted_prosecution_counsels.blank?
+
+      safe_join(formatted_prosecution_counsels, tag.br)
     end
 
     private
@@ -30,6 +36,10 @@ module CdApi
 
     def mapped_defence_counsels
       @mapped_defence_counsels ||= map_defence_counsels
+    end
+
+    def filter_prosecution_counsels
+      hearing.prosecution_counsels.select { |prosecution_counsel| attended_hearing_day?(prosecution_counsel) }
     end
 
     def map_defence_counsels
@@ -52,10 +62,10 @@ module CdApi
       end
     end
 
-    def attended_hearing_day?(defence_counsel)
+    def attended_hearing_day?(counsels)
       return false unless current_sitting_day
 
-      defence_counsel.attendance_days.include?(DateTime.parse(current_sitting_day).strftime('%Y-%m-%d'))
+      counsels.attendance_days.include?(DateTime.parse(current_sitting_day).strftime('%Y-%m-%d'))
     end
   end
 end

--- a/app/models/cd_api/prosecution_counsel.rb
+++ b/app/models/cd_api/prosecution_counsel.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module CdApi
+  class ProsecutionCounsel < BaseModel
+    belongs_to :hearing
+  end
+end

--- a/app/views/hearings/_attendees_v2.html.haml
+++ b/app/views/hearings/_attendees_v2.html.haml
@@ -22,7 +22,7 @@
     - unless hearing_details && hearing_details.prosecution_counsels&.any?
       = t('generic.not_available')
     - else
-      = safe_join(hearing_details.prosecution_counsels.map { |pc| "#{pc.first_name} #{pc.last_name}"}, tag.br)
+      = hearing.prosecution_counsels_list
   .govuk-heading-s{ :class => "govuk-!-margin-bottom-1" }
     = t('hearings.show.attendees.judges')
   %p.govuk-body{ :class => "govuk-!-margin-bottom-2", :id => "judges" }

--- a/spec/decorators/cd_api/hearing_decorator_spec.rb
+++ b/spec/decorators/cd_api/hearing_decorator_spec.rb
@@ -182,4 +182,86 @@ RSpec.describe CdApi::HearingDecorator, type: :decorator do
       end
     end
   end
+
+  describe '#prosecution_counsels_list' do
+    let(:hearing_details) do
+      build :hearing_details, prosecution_counsels:, hearing_days: [hearing_day1],
+                              prosecution_cases: [prosecution_case]
+    end
+    let(:hearing_day1) { build(:hearing_day) }
+
+    let(:prosecution_case) do
+      build :hearing_prosecution_case
+    end
+
+    let(:prosecution_counsels) { [prosecution_counsel1, prosecution_counsel2] }
+    let(:prosecution_counsel1) do
+      build :hearing_prosecution_counsel, first_name: 'Jane', last_name: 'Doe', attendance_days: [day],
+                                          prosecution_cases: [prosecution_case.id]
+    end
+    let(:prosecution_counsel2) do
+      build :hearing_prosecution_counsel, attendance_days: [day], prosecution_cases: [prosecution_case.id]
+    end
+
+    let(:day) { hearing_day1.sitting_day.strftime('%Y-%m-%d') }
+
+    before do
+      allow(hearing).to receive(:hearing).and_return(hearing_details)
+      allow_any_instance_of(described_class).to receive(:current_sitting_day).and_return(day)
+    end
+
+    it 'filters prosecution_counsels by attendance_days' do
+      expect(decorator.prosecution_counsels_list).to eq('Jane Doe<br>John Smith')
+    end
+
+    context 'when the prosecution counsel did not attend the hearing day' do
+      let(:hearing_details) do
+        build :hearing_details, prosecution_counsels:, hearing_days: [hearing_day1],
+                                prosecution_cases: [prosecution_case]
+      end
+
+      let(:prosecution_counsel1) do
+        build :hearing_prosecution_counsel, first_name: 'Jane', last_name: 'Doe', attendance_days: [],
+                                            prosecution_cases: [prosecution_case.id]
+      end
+      let(:prosecution_counsel2) do
+        build :hearing_prosecution_counsel, attendance_days: [day], prosecution_cases: [prosecution_case.id]
+      end
+
+      it 'does not add the prosecution counsel to the list' do
+        expect(decorator.prosecution_counsels_list).to eq('John Smith')
+      end
+    end
+
+    context 'when no prosecution counsels attending the hearing day' do
+      let(:prosecution_counsels) { [prosecution_counsel1] }
+      let(:prosecution_counsel1) do
+        build :hearing_prosecution_counsel, first_name: 'Jane', last_name: 'Doe', attendance_days: []
+      end
+
+      it 'returns not available' do
+        expect(decorator.prosecution_counsels_list).to eq 'Not available'
+      end
+    end
+
+    context 'when there is no current_sitting_day' do
+      let(:day) { nil }
+
+      it 'does not add the defence counsel to the list' do
+        expect(decorator.prosecution_counsels_list).to eq 'Not available'
+      end
+    end
+
+    context 'when the name is missing' do
+      let(:prosecution_counsels) { [prosecution_counsel1] }
+      let(:prosecution_counsel1) do
+        build :hearing_prosecution_counsel, first_name: '', last_name: '', attendance_days: [day],
+                                            prosecution_cases: [prosecution_case.id]
+      end
+
+      it 'returns empty string with space' do
+        expect(decorator.prosecution_counsels_list).to eq ' '
+      end
+    end
+  end
 end

--- a/spec/factories/cd_api/hearing/prosecution_case.rb
+++ b/spec/factories/cd_api/hearing/prosecution_case.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
   factory :hearing_prosecution_case, class: 'CdApi::ProsecutionCase' do
     association :hearing_details
 
-    id { 'Mr' }
+    id { SecureRandom.uuid }
     prosecution_case_identifier { {} }
     status { 'INACTIVE' }
     statement_of_facts { 'Fuga laudantium tenetur next level et.' }

--- a/spec/factories/cd_api/hearing/prosecution_counsel.rb
+++ b/spec/factories/cd_api/hearing/prosecution_counsel.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  # ActiveResource Factory, use :build not :create to prevent HTTP calls
+  factory :hearing_prosecution_counsel, class: 'CdApi::ProsecutionCounsel' do
+    association :hearing_details
+
+    title { 'Mr' }
+    first_name { 'John' }
+    middle_name { '' }
+    last_name { 'Smith' }
+    status { 'Junior' }
+    attendance_days { [] }
+    prosecution_cases { [] }
+  end
+end

--- a/spec/features/hearings_v2_spec.rb
+++ b/spec/features/hearings_v2_spec.rb
@@ -28,6 +28,13 @@ RSpec.feature 'Viewing the hearings page', type: :feature, stub_case_search: tru
       end
     end
 
+    context 'with multiple prosecution counsels', stub_v2_hearing_events: true do
+      it 'displays details section' do
+        expect(page).to have_text('John Smith' \
+                                  'Jane Doe')
+      end
+    end
+
     context 'with hearing events', stub_v2_hearing_events: true do
       it 'requests data for hearing summary' do
         expect(a_request(:get, api_summary_path))

--- a/spec/fixtures/stubs/cd_api/hearing_data_response.json
+++ b/spec/fixtures/stubs/cd_api/hearing_data_response.json
@@ -143,7 +143,22 @@
           "810a1f9e-3614-481c-9e53-7ee658f05aca"
         ],
         "attendance_days": [
-          "2021-03-29"
+          "2021-03-29",
+          "2019-10-23"
+        ]
+      },
+      {
+        "title": "",
+        "first_name": "Jane",
+        "middle_name": "",
+        "last_name": "Doe",
+        "status": "junior",
+        "prosecution_cases": [
+          "810a1f9e-3614-481c-9e53-7ee658f05aca"
+        ],
+        "attendance_days": [
+          "2021-03-29",
+          "2019-10-23"
         ]
       }
     ],

--- a/spec/views/hearings/_attendees_v2.html.haml_spec.rb
+++ b/spec/views/hearings/_attendees_v2.html.haml_spec.rb
@@ -75,8 +75,12 @@ RSpec.describe 'hearings/_attendees_v2', type: :view do
     end
 
     context 'with prosecution_counsel' do
+      before do
+        allow(decorated_hearing).to receive(:current_sitting_day).and_return('2019-10-23')
+      end
+
       it 'displays list of prosecution counsel' do
-        is_expected.to have_tag('p.govuk-body#prosecution', text: /john smith/)
+        is_expected.to have_tag('p.govuk-body#prosecution', text: /John Smith/)
       end
     end
 


### PR DESCRIPTION
#### What

Filter out prosecution counsels that did not attend the particular hearing day on the Hearing day page.

#### Ticket

[AAC-868 BUG - Multi Day Trial Prosecution Advocates display](https://dsdmoj.atlassian.net/browse/AAC-868)

#### Why

So users aren't mislead into believing a prosecution counsel member attended a hearing day on a multiday hearing, when they didn't.

#### How

Filter out the prosecution counsels where their attendance_days does not include the current_hearing_day on the hearing page.

Add unit and feature tests

