### PR TITLE
AAC-908 - Update CircleCi Config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,8 +222,7 @@ commands:
         type: string
     steps:
       - checkout
-      - setup_remote_docker:
-          version: 20.10.11
+      - setup_remote_docker
       - run:
           name: deploying to << parameters.environment >>
           command: |
@@ -280,7 +279,6 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 20.10.11
           docker_layer_caching: true
       - build-temp-image
       - snyk/scan:
@@ -296,7 +294,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 20.10.11
+          docker_layer_caching: true
       - *script-build-app-container
 
   deploy-dev:


### PR DESCRIPTION
#### What

Remove the version lock on the Docker dependency in CircleCI so we can always get the latest for security and feature updates. 

#### Ticket

[CD UI - Remove Docker Version from CircleCI](https://dsdmoj.atlassian.net/browse/AAC-908)

#### Why

Potential Deprecation of features in older versions