### PR TITLE
DRAFT - Remove unused deprecated gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,6 @@ group :test do
   gem 'brakeman'
   gem 'capybara'
   gem 'capybara_table'
-  gem 'codeclimate-test-reporter', '>= 1.0.7', require: false
   gem 'fakeredis', require: 'fakeredis/rspec'
   gem 'haml_lint', require: false
   gem 'i18n-tasks', '~> 1.0.12'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,8 +120,6 @@ GEM
       terminal-table
       xpath (>= 2.1)
     childprocess (4.1.0)
-    codeclimate-test-reporter (1.0.7)
-      simplecov
     coderay (1.1.3)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
@@ -500,7 +498,6 @@ DEPENDENCIES
   cancancan
   capybara
   capybara_table
-  codeclimate-test-reporter (>= 1.0.7)
   colorize
   devise (~> 4.8, >= 4.8.1)
   dotenv-rails


### PR DESCRIPTION
#### What
This is to check that we don't actually need or used the below deprecated gem.

Remove codeclimate-test-reporter as it's deprecated and no longer used

#### Ticket

[board ticket description](link)

#### Why

#### How

--------

#### TODO (wip)

 - [ ] item 1
 - [X] item 2
 - [X] Has the Acceptance Criteria been met
