### PR TITLE
[CTSKF-53] Rubocop: Fix RSpec/FactoryBot/ConsistentParenthesesStyle

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -135,9 +135,6 @@ RSpec/ExampleLength:
   Exclude:
     - spec/features/**/*
 
-RSpec/FactoryBot/ConsistentParenthesesStyle: #120 errors
-  Enabled: false
-
 RSpec/ImplicitSubject:
   Enabled: false
 

--- a/spec/decorators/cd_api/case_summary_decorator_spec.rb
+++ b/spec/decorators/cd_api/case_summary_decorator_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe CdApi::CaseSummaryDecorator, type: :decorator do
     allow(Feature).to receive(:enabled?).with(:hearing_summaries).and_return(true)
   end
 
-  let(:case_summary) { build :case_summary }
+  let(:case_summary) { build(:case_summary) }
   let(:view_object) { view_class.new }
 
   let(:view_class) do
@@ -39,8 +39,8 @@ RSpec.describe CdApi::CaseSummaryDecorator, type: :decorator do
 
     context 'with multiple v2 hearing_summaries' do
       let(:hearing_summaries) { [hearing_summary1, hearing_summary2] }
-      let(:hearing_summary1) { build :hearing_summary }
-      let(:hearing_summary2) { build :hearing_summary }
+      let(:hearing_summary1) { build(:hearing_summary) }
+      let(:hearing_summary2) { build(:hearing_summary) }
 
       it { is_expected.to all(be_instance_of(CdApi::HearingSummaryDecorator)) }
     end
@@ -56,7 +56,7 @@ RSpec.describe CdApi::CaseSummaryDecorator, type: :decorator do
     subject(:call) { decorator.defendants }
 
     context 'with multiple overall defendants' do
-      let(:case_summary) { build :case_summary, :with_overall_defendants }
+      let(:case_summary) { build(:case_summary, :with_overall_defendants) }
 
       it { is_expected.to all(be_instance_of(CdApi::OverallDefendantDecorator)) }
     end

--- a/spec/decorators/cd_api/cracked_ineffective_trial_decorator_spec.rb
+++ b/spec/decorators/cd_api/cracked_ineffective_trial_decorator_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe CdApi::CrackedIneffectiveTrialDecorator, type: :decorator do
   subject(:decorator) { described_class.new(cracked_ineffective_trial, view_object) }
 
-  let(:cracked_ineffective_trial) { build :cracked_ineffective_trial }
+  let(:cracked_ineffective_trial) { build(:cracked_ineffective_trial) }
   let(:view_object) { view_class.new }
 
   let(:view_class) do
@@ -31,8 +31,8 @@ RSpec.describe CdApi::CrackedIneffectiveTrialDecorator, type: :decorator do
   describe '#cracked_on_sentence' do
     subject(:call) { decorator.cracked_on_sentence(hearing.hearing) }
 
-    let(:hearing) { build :hearing, hearing: hearing_details }
-    let(:hearing_details) { build :hearing_details, :with_hearing_days }
+    let(:hearing) { build(:hearing, hearing: hearing_details) }
+    let(:hearing_details) { build(:hearing_details, :with_hearing_days) }
 
     before do
       allow(cracked_ineffective_trial).to receive_messages(type:)

--- a/spec/decorators/cd_api/defence_counsel_decorator_spec.rb
+++ b/spec/decorators/cd_api/defence_counsel_decorator_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe CdApi::DefenceCounselDecorator, type: :decorator do
   subject(:decorator) { described_class.new(defence_counsel, view_object) }
 
-  let(:defence_counsel) { build :defence_counsel }
+  let(:defence_counsel) { build(:defence_counsel) }
   let(:view_object) { view_class.new }
 
   let(:view_class) do
@@ -25,8 +25,8 @@ RSpec.describe CdApi::DefenceCounselDecorator, type: :decorator do
     subject(:call) { decorator.name_status_and_defendants }
 
     let(:defence_counsel) do
-      build :defence_counsel, first_name: 'Bob', last_name: 'Smith', status: 'QC',
-                              defendants: mapped_defendants
+      build(:defence_counsel, first_name: 'Bob', last_name: 'Smith', status: 'QC',
+                              defendants: mapped_defendants)
     end
 
     # The mapping of the defendants occurs in the HearingSummaryDecorator
@@ -49,8 +49,8 @@ RSpec.describe CdApi::DefenceCounselDecorator, type: :decorator do
 
     context 'when defence counsel name and status is missing' do
       let(:defence_counsel) do
-        build :defence_counsel, first_name: '', middle_name: '', last_name: '', status: '',
-                                defendants: mapped_defendants
+        build(:defence_counsel, first_name: '', middle_name: '', last_name: '', status: '',
+                                defendants: mapped_defendants)
       end
 
       it { is_expected.to eql('Not available') }
@@ -58,8 +58,8 @@ RSpec.describe CdApi::DefenceCounselDecorator, type: :decorator do
 
     context 'when defence counsel name is only partially given' do
       let(:defence_counsel) do
-        build :defence_counsel, first_name: 'Bob', middle_name: 'Owl', last_name: '', status: 'QC',
-                                defendants: mapped_defendants
+        build(:defence_counsel, first_name: 'Bob', middle_name: 'Owl', last_name: '', status: 'QC',
+                                defendants: mapped_defendants)
       end
 
       it { is_expected.to eql('Bob Owl (QC) for John Doe') }
@@ -67,8 +67,8 @@ RSpec.describe CdApi::DefenceCounselDecorator, type: :decorator do
 
     context 'when defence counsel name is missing' do
       let(:defence_counsel) do
-        build :defence_counsel, first_name: nil, middle_name: nil, last_name: nil, status: 'QC',
-                                defendants: mapped_defendants
+        build(:defence_counsel, first_name: nil, middle_name: nil, last_name: nil, status: 'QC',
+                                defendants: mapped_defendants)
       end
 
       it { is_expected.to eql('Not available (QC) for John Doe') }
@@ -76,8 +76,8 @@ RSpec.describe CdApi::DefenceCounselDecorator, type: :decorator do
 
     context 'when defence counsel status is missing' do
       let(:defence_counsel) do
-        build :defence_counsel, first_name: 'Bob', middle_name: 'Owl', last_name: 'Smith', status: nil,
-                                defendants: mapped_defendants
+        build(:defence_counsel, first_name: 'Bob', middle_name: 'Owl', last_name: 'Smith', status: nil,
+                                defendants: mapped_defendants)
       end
 
       it { is_expected.to eql('Bob Owl Smith (not available) for John Doe') }
@@ -85,8 +85,8 @@ RSpec.describe CdApi::DefenceCounselDecorator, type: :decorator do
 
     context 'when defendants name is missing' do
       let(:defence_counsel) do
-        build :defence_counsel, first_name: 'Bob', middle_name: 'Owl', last_name: 'Smith', status: 'QC',
-                                defendants: []
+        build(:defence_counsel, first_name: 'Bob', middle_name: 'Owl', last_name: 'Smith', status: 'QC',
+                                defendants: [])
       end
 
       it { is_expected.to eql('Bob Owl Smith (QC)') }
@@ -113,8 +113,8 @@ RSpec.describe CdApi::DefenceCounselDecorator, type: :decorator do
       end
 
       let(:defence_counsel) do
-        build :defence_counsel, first_name: 'bob', last_name: 'smith', status: 'qc',
-                                defendants: mapped_defendants
+        build(:defence_counsel, first_name: 'bob', last_name: 'smith', status: 'qc',
+                                defendants: mapped_defendants)
       end
 
       it { is_expected.to eql('Bob Smith (qc) for John Jim Jane') }

--- a/spec/decorators/cd_api/hearing_day_decorator_spec.rb
+++ b/spec/decorators/cd_api/hearing_day_decorator_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe CdApi::HearingDayDecorator, type: :decorator do
   subject(:decorator) { described_class.new(hearing_day, view_object) }
 
-  let(:hearing_day) { build :hearing_day }
+  let(:hearing_day) { build(:hearing_day) }
   let(:view_object) { view_class.new }
 
   let(:view_class) do
@@ -25,7 +25,7 @@ RSpec.describe CdApi::HearingDayDecorator, type: :decorator do
     subject(:call) { decorator.to_datetime }
 
     context 'when there are sitting days' do
-      let(:hearing_day) { build :hearing_day, sitting_day: }
+      let(:hearing_day) { build(:hearing_day, sitting_day:) }
       let(:sitting_day) { '2021-01-19T10:45:00.000Z' }
 
       it 'returns sitting day in datetime type' do
@@ -38,7 +38,7 @@ RSpec.describe CdApi::HearingDayDecorator, type: :decorator do
     end
 
     context 'when there are no sitting days' do
-      let(:hearing_day) { build :hearing_day, sitting_day: nil }
+      let(:hearing_day) { build(:hearing_day, sitting_day: nil) }
 
       it 'returns nil' do
         expect(call).to be_nil

--- a/spec/decorators/cd_api/hearing_decorator_spec.rb
+++ b/spec/decorators/cd_api/hearing_decorator_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe CdApi::HearingDecorator, type: :decorator do
   subject(:decorator) { described_class.new(hearing, view_object) }
 
-  let(:hearing) { build :hearing }
+  let(:hearing) { build(:hearing) }
   let(:view_object) { view_class.new }
 
   let(:view_class) do
@@ -22,8 +22,8 @@ RSpec.describe CdApi::HearingDecorator, type: :decorator do
   end
 
   describe '#cracked_ineffective_trial' do
-    let(:hearing_details) { build :hearing_details, cracked_ineffective_trial: }
-    let(:hearing) { build :hearing, hearing: hearing_details }
+    let(:hearing_details) { build(:hearing_details, cracked_ineffective_trial:) }
+    let(:hearing) { build(:hearing, hearing: hearing_details) }
     let(:cracked_ineffective_trial) { instance_double(CdApi::CrackedIneffectiveTrial) }
 
     before do
@@ -38,23 +38,23 @@ RSpec.describe CdApi::HearingDecorator, type: :decorator do
 
   describe '#defence_counsels_list' do
     let(:hearing_details) do
-      build :hearing_details, defence_counsels:, prosecution_cases: [prosecution_case],
-                              hearing_days: [hearing_day1]
+      build(:hearing_details, defence_counsels:, prosecution_cases: [prosecution_case],
+                              hearing_days: [hearing_day1])
     end
     let(:hearing_day1) { build(:hearing_day) }
     let(:prosecution_case) do
-      build :hearing_prosecution_case, defendants: [hearing_defendant1, hearing_defendant2]
+      build(:hearing_prosecution_case, defendants: [hearing_defendant1, hearing_defendant2])
     end
 
     let(:defence_counsels) { [defence_counsel1, defence_counsel2] }
     let(:defence_counsel1) do
-      build :defence_counsel, defendants: [hearing_defendant1.id, hearing_defendant2.id], first_name: 'Jane',
-                              last_name: 'Doe', attendance_days: [day]
+      build(:defence_counsel, defendants: [hearing_defendant1.id, hearing_defendant2.id], first_name: 'Jane',
+                              last_name: 'Doe', attendance_days: [day])
     end
-    let(:defence_counsel2) { build :defence_counsel, attendance_days: [day] }
+    let(:defence_counsel2) { build(:defence_counsel, attendance_days: [day]) }
 
-    let(:hearing_defendant1) { build :hearing_defendant, :with_defendant_details }
-    let(:hearing_defendant2) { build :hearing_defendant, :with_defendant_details }
+    let(:hearing_defendant1) { build(:hearing_defendant, :with_defendant_details) }
+    let(:hearing_defendant2) { build(:hearing_defendant, :with_defendant_details) }
     let(:day) { hearing_day1.sitting_day.strftime('%Y-%m-%d') }
 
     let(:mapped_defence_counsels) { hearing_details.defence_counsels }
@@ -81,7 +81,7 @@ RSpec.describe CdApi::HearingDecorator, type: :decorator do
 
     context 'when defence counsels are empty' do
       let(:hearing_details) do
-        build :hearing_details, defence_counsels: [], prosecution_cases: [prosecution_case]
+        build(:hearing_details, defence_counsels: [], prosecution_cases: [prosecution_case])
       end
 
       it 'returns not available' do
@@ -91,7 +91,7 @@ RSpec.describe CdApi::HearingDecorator, type: :decorator do
 
     context 'when prosecution case is missing the defendant information' do
       let(:defence_counsels) { [defence_counsel1] }
-      let(:prosecution_case) { build :hearing_prosecution_case, defendants: [] }
+      let(:prosecution_case) { build(:hearing_prosecution_case, defendants: []) }
 
       it 'returns array with defendant ids' do
         decorator.defence_counsels_list
@@ -102,9 +102,9 @@ RSpec.describe CdApi::HearingDecorator, type: :decorator do
 
     context 'when defence counsels have no defendants' do
       let(:defence_counsels) { [defence_counsel1] }
-      let(:prosecution_case) { build :hearing_prosecution_case, defendants: [] }
+      let(:prosecution_case) { build(:hearing_prosecution_case, defendants: []) }
       let(:defence_counsel1) do
-        build :defence_counsel, defendants: [], first_name: 'Jane', last_name: 'Doe', attendance_days: [day]
+        build(:defence_counsel, defendants: [], first_name: 'Jane', last_name: 'Doe', attendance_days: [day])
       end
 
       it 'returns empty array' do
@@ -116,13 +116,13 @@ RSpec.describe CdApi::HearingDecorator, type: :decorator do
 
     context 'when there are two prosecution cases' do
       let(:hearing_details) do
-        build :hearing_details, defence_counsels:, prosecution_cases: [prosecution_case1, prosecution_case2]
+        build(:hearing_details, defence_counsels:, prosecution_cases: [prosecution_case1, prosecution_case2])
       end
       let(:prosecution_case1) do
-        build :hearing_prosecution_case, defendants: [hearing_defendant1]
+        build(:hearing_prosecution_case, defendants: [hearing_defendant1])
       end
       let(:prosecution_case2) do
-        build :hearing_prosecution_case, defendants: [hearing_defendant2]
+        build(:hearing_prosecution_case, defendants: [hearing_defendant2])
       end
 
       it 'maps defendants in defence counsels' do
@@ -136,11 +136,11 @@ RSpec.describe CdApi::HearingDecorator, type: :decorator do
     context 'when the defence counsel did not attend the hearing day' do
       let(:defence_counsels) { [defence_counsel1, defence_counsel2] }
       let(:defence_counsel1) do
-        build :defence_counsel, defendants: [hearing_defendant1.id, hearing_defendant2.id],
-                                first_name: 'Jane', last_name: 'Doe', attendance_days: [day]
+        build(:defence_counsel, defendants: [hearing_defendant1.id, hearing_defendant2.id],
+                                first_name: 'Jane', last_name: 'Doe', attendance_days: [day])
       end
       let(:defence_counsel2) do
-        build :defence_counsel, first_name: 'John', last_name: 'Smith', attendance_days: []
+        build(:defence_counsel, first_name: 'John', last_name: 'Smith', attendance_days: [])
       end
 
       before do
@@ -158,7 +158,7 @@ RSpec.describe CdApi::HearingDecorator, type: :decorator do
     context 'when no defence counsels attending the hearing day' do
       let(:defence_counsels) { [defence_counsel1] }
       let(:defence_counsel1) do
-        build :defence_counsel, first_name: 'Jane', last_name: 'Doe', attendance_days: []
+        build(:defence_counsel, first_name: 'Jane', last_name: 'Doe', attendance_days: [])
       end
 
       before do
@@ -185,22 +185,22 @@ RSpec.describe CdApi::HearingDecorator, type: :decorator do
 
   describe '#prosecution_counsels_list' do
     let(:hearing_details) do
-      build :hearing_details, prosecution_counsels:, hearing_days: [hearing_day1],
-                              prosecution_cases: [prosecution_case]
+      build(:hearing_details, prosecution_counsels:, hearing_days: [hearing_day1],
+                              prosecution_cases: [prosecution_case])
     end
     let(:hearing_day1) { build(:hearing_day) }
 
     let(:prosecution_case) do
-      build :hearing_prosecution_case
+      build(:hearing_prosecution_case)
     end
 
     let(:prosecution_counsels) { [prosecution_counsel1, prosecution_counsel2] }
     let(:prosecution_counsel1) do
-      build :hearing_prosecution_counsel, first_name: 'Jane', last_name: 'Doe', attendance_days: [day],
-                                          prosecution_cases: [prosecution_case.id]
+      build(:hearing_prosecution_counsel, first_name: 'Jane', last_name: 'Doe', attendance_days: [day],
+                                          prosecution_cases: [prosecution_case.id])
     end
     let(:prosecution_counsel2) do
-      build :hearing_prosecution_counsel, attendance_days: [day], prosecution_cases: [prosecution_case.id]
+      build(:hearing_prosecution_counsel, attendance_days: [day], prosecution_cases: [prosecution_case.id])
     end
 
     let(:day) { hearing_day1.sitting_day.strftime('%Y-%m-%d') }
@@ -216,16 +216,16 @@ RSpec.describe CdApi::HearingDecorator, type: :decorator do
 
     context 'when the prosecution counsel did not attend the hearing day' do
       let(:hearing_details) do
-        build :hearing_details, prosecution_counsels:, hearing_days: [hearing_day1],
-                                prosecution_cases: [prosecution_case]
+        build(:hearing_details, prosecution_counsels:, hearing_days: [hearing_day1],
+                                prosecution_cases: [prosecution_case])
       end
 
       let(:prosecution_counsel1) do
-        build :hearing_prosecution_counsel, first_name: 'Jane', last_name: 'Doe', attendance_days: [],
-                                            prosecution_cases: [prosecution_case.id]
+        build(:hearing_prosecution_counsel, first_name: 'Jane', last_name: 'Doe', attendance_days: [],
+                                            prosecution_cases: [prosecution_case.id])
       end
       let(:prosecution_counsel2) do
-        build :hearing_prosecution_counsel, attendance_days: [day], prosecution_cases: [prosecution_case.id]
+        build(:hearing_prosecution_counsel, attendance_days: [day], prosecution_cases: [prosecution_case.id])
       end
 
       it 'does not add the prosecution counsel to the list' do
@@ -236,7 +236,7 @@ RSpec.describe CdApi::HearingDecorator, type: :decorator do
     context 'when no prosecution counsels attending the hearing day' do
       let(:prosecution_counsels) { [prosecution_counsel1] }
       let(:prosecution_counsel1) do
-        build :hearing_prosecution_counsel, first_name: 'Jane', last_name: 'Doe', attendance_days: []
+        build(:hearing_prosecution_counsel, first_name: 'Jane', last_name: 'Doe', attendance_days: [])
       end
 
       it 'returns not available' do
@@ -255,8 +255,8 @@ RSpec.describe CdApi::HearingDecorator, type: :decorator do
     context 'when the name is missing' do
       let(:prosecution_counsels) { [prosecution_counsel1] }
       let(:prosecution_counsel1) do
-        build :hearing_prosecution_counsel, first_name: '', last_name: '', attendance_days: [day],
-                                            prosecution_cases: [prosecution_case.id]
+        build(:hearing_prosecution_counsel, first_name: '', last_name: '', attendance_days: [day],
+                                            prosecution_cases: [prosecution_case.id])
       end
 
       it 'returns empty string with space' do

--- a/spec/decorators/cd_api/hearing_summary_decorator_spec.rb
+++ b/spec/decorators/cd_api/hearing_summary_decorator_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe CdApi::HearingSummaryDecorator, type: :decorator do
   subject(:decorator) { described_class.new(hearing_summary, view_object) }
 
-  let(:hearing_summary) { build :hearing_summary }
+  let(:hearing_summary) { build(:hearing_summary) }
   let(:view_object) { view_class.new }
 
   let(:view_class) do
@@ -38,14 +38,14 @@ RSpec.describe CdApi::HearingSummaryDecorator, type: :decorator do
     let(:formatted_date) { sitting_day.strftime('%Y-%m-%d') }
     let(:sitting_day) { DateTime.parse(day) }
 
-    let(:hearing_summary) { build :hearing_summary, defence_counsels: }
+    let(:hearing_summary) { build(:hearing_summary, defence_counsels:) }
 
     context 'when there are multiple defendants in defence_counsels' do
-      let(:hearing_summary) { build :hearing_summary, defence_counsels:, defendants: }
+      let(:hearing_summary) { build(:hearing_summary, defence_counsels:, defendants:) }
       let(:defence_counsels) { [defence_counsel1] }
       let(:defence_counsel1) do
-        build :defence_counsel, first_name: 'Jammy', last_name: 'Dodger', status: 'Junior',
-                                defendants: defendant_ids, attendance_days: [formatted_date]
+        build(:defence_counsel, first_name: 'Jammy', last_name: 'Dodger', status: 'Junior',
+                                defendants: defendant_ids, attendance_days: [formatted_date])
       end
       let(:defendant_ids) do
         [defendant1, defendant2].map(&:id)
@@ -77,11 +77,11 @@ RSpec.describe CdApi::HearingSummaryDecorator, type: :decorator do
     context 'when defence counsels defendant ids fail to match' do
       let(:defence_counsels) { [defence_counsel] }
       let(:defence_counsel) do
-        build :defence_counsel, first_name: 'Bob', last_name: 'Smith', status: 'QC',
-                                defendants: [defendant.id]
+        build(:defence_counsel, first_name: 'Bob', last_name: 'Smith', status: 'QC',
+                                defendants: [defendant.id])
       end
-      let(:defendant) { build :defendant }
-      let(:hearing_summary) { build :hearing_summary, defence_counsels:, defendants: [] }
+      let(:defendant) { build(:defendant) }
+      let(:hearing_summary) { build(:hearing_summary, defence_counsels:, defendants: []) }
 
       it 'returns defendant id' do
         decorator.defence_counsel_list
@@ -92,7 +92,7 @@ RSpec.describe CdApi::HearingSummaryDecorator, type: :decorator do
     end
 
     context 'when defence counsel did not attend on the hearing day' do
-      let(:hearing_summary) { build :hearing_summary, defence_counsels: }
+      let(:hearing_summary) { build(:hearing_summary, defence_counsels:) }
 
       let(:defence_counsels) { [defence_counsel1, defence_counsel2] }
       let(:defence_counsel1) do
@@ -111,7 +111,7 @@ RSpec.describe CdApi::HearingSummaryDecorator, type: :decorator do
     end
 
     context 'when no defence counsels attended the hearing day' do
-      let(:hearing_summary) { build :hearing_summary, defence_counsels: }
+      let(:hearing_summary) { build(:hearing_summary, defence_counsels:) }
 
       let(:defence_counsels) { [defence_counsel1] }
       let(:defence_counsel1) do
@@ -123,7 +123,7 @@ RSpec.describe CdApi::HearingSummaryDecorator, type: :decorator do
     end
 
     context 'when called again after day has been altered' do
-      let(:hearing_summary) { build :hearing_summary, defence_counsels: }
+      let(:hearing_summary) { build(:hearing_summary, defence_counsels:) }
 
       let(:defence_counsels) { [defence_counsel1, defence_counsel2] }
       let(:defence_counsel1) do
@@ -150,12 +150,12 @@ RSpec.describe CdApi::HearingSummaryDecorator, type: :decorator do
   describe '#hearing_days' do
     subject(:call) { decorator.hearing_days }
 
-    let(:hearing_summary) { build :hearing_summary, hearing_days: }
+    let(:hearing_summary) { build(:hearing_summary, hearing_days:) }
 
     context 'with multiple hearing_days' do
       let(:hearing_days) { [hearing_day1, hearing_day2] }
-      let(:hearing_day1) { build :hearing_day }
-      let(:hearing_day2) { build :hearing_day }
+      let(:hearing_day1) { build(:hearing_day) }
+      let(:hearing_day2) { build(:hearing_day) }
 
       it { is_expected.to all(be_instance_of(CdApi::HearingDayDecorator)) }
     end
@@ -177,7 +177,7 @@ RSpec.describe CdApi::HearingSummaryDecorator, type: :decorator do
     end
 
     context 'when there is no estimated duration' do
-      let(:hearing_summary) { build :hearing_summary, estimated_duration: nil }
+      let(:hearing_summary) { build(:hearing_summary, estimated_duration: nil) }
 
       it 'returns nil' do
         expect(call).to be_nil

--- a/spec/decorators/cd_api/overall_defendant_decorator_spec.rb
+++ b/spec/decorators/cd_api/overall_defendant_decorator_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe CdApi::OverallDefendantDecorator, type: :decorator do
     allow(Feature).to receive(:enabled?).with(:hearing_summaries).and_return(true)
   end
 
-  let(:overall_defendant) { build :overall_defendant }
+  let(:overall_defendant) { build(:overall_defendant) }
   let(:view_object) { view_class.new }
 
   let(:view_class) do
@@ -29,7 +29,7 @@ RSpec.describe CdApi::OverallDefendantDecorator, type: :decorator do
     subject(:call) { decorator.name }
 
     let(:overall_defendant) do
-      build :overall_defendant, first_name:, middle_name:, last_name:
+      build(:overall_defendant, first_name:, middle_name:, last_name:)
     end
     let(:first_name) { 'John' }
     let(:middle_name) { 'Cluedo' }
@@ -52,7 +52,7 @@ RSpec.describe CdApi::OverallDefendantDecorator, type: :decorator do
     subject(:call) { decorator.linked? }
 
     context 'when maat_reference exists and does not begin with "Z"' do
-      let(:overall_defendant) { build :overall_defendant, maat_reference: '1234567' }
+      let(:overall_defendant) { build(:overall_defendant, maat_reference: '1234567') }
 
       it 'returns true' do
         expect(call).to be_truthy
@@ -60,7 +60,7 @@ RSpec.describe CdApi::OverallDefendantDecorator, type: :decorator do
     end
 
     context 'when maat_reference exists and begins with "Z"' do
-      let(:overall_defendant) { build :overall_defendant, maat_reference: 'Z1234567' }
+      let(:overall_defendant) { build(:overall_defendant, maat_reference: 'Z1234567') }
 
       it 'returns false' do
         expect(call).to be_falsey
@@ -68,7 +68,7 @@ RSpec.describe CdApi::OverallDefendantDecorator, type: :decorator do
     end
 
     context 'when maat_reference does not exist' do
-      let(:overall_defendant) { build :overall_defendant, maat_reference: nil }
+      let(:overall_defendant) { build(:overall_defendant, maat_reference: nil) }
 
       it 'returns false' do
         expect(call).to be_falsey

--- a/spec/factories/cd_api/case_summary.rb
+++ b/spec/factories/cd_api/case_summary.rb
@@ -9,8 +9,8 @@ FactoryBot.define do
 
     trait :with_overall_defendants do
       after(:build) do |case_summary|
-        defendant1 = FactoryBot.build :overall_defendant, case_summary: case_summary
-        defendant2 = FactoryBot.build :overall_defendant, case_summary: case_summary
+        defendant1 = FactoryBot.build(:overall_defendant, case_summary:)
+        defendant2 = FactoryBot.build(:overall_defendant, case_summary:)
         case_summary.overall_defendants = [defendant1, defendant2]
       end
     end

--- a/spec/factories/cd_api/hearing.rb
+++ b/spec/factories/cd_api/hearing.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     shared_time { '2022-07-22T15:31:42.832Z[UTC]' }
 
     trait :with_hearing_details do
-      hearing { build :hearing_details }
+      hearing { build(:hearing_details) }
     end
   end
 
@@ -30,7 +30,7 @@ FactoryBot.define do
 
     trait :with_hearing_days do
       after(:build) do |hearing|
-        hearing_day1 = FactoryBot.build :hearing_day, hearing: hearing
+        hearing_day1 = FactoryBot.build(:hearing_day, hearing:)
         hearing.hearing_days = [hearing_day1]
       end
     end

--- a/spec/factories/cd_api/hearing/defendant.rb
+++ b/spec/factories/cd_api/hearing/defendant.rb
@@ -16,7 +16,7 @@ FactoryBot.define do
     isYouth { nil }
 
     trait :with_defendant_details do
-      defendant_details { build :hearing_defendant_details, :with_person_details }
+      defendant_details { build(:hearing_defendant_details, :with_person_details) }
     end
   end
 end

--- a/spec/factories/cd_api/hearing/defendant_details.rb
+++ b/spec/factories/cd_api/hearing/defendant_details.rb
@@ -10,7 +10,7 @@ FactoryBot.define do
     bail_status { {} }
 
     trait :with_person_details do
-      person_details { build :hearing_person_details }
+      person_details { build(:hearing_person_details) }
     end
   end
 end

--- a/spec/factories/cd_api/hearing_summary.rb
+++ b/spec/factories/cd_api/hearing_summary.rb
@@ -4,20 +4,20 @@ FactoryBot.define do
   # ActiveResource Factory, use :build not :create to prevent HTTP calls
   factory :hearing_summary, class: 'CdApi::HearingSummary' do
     hearing_type { 'Trial' }
-    court_centre { FactoryBot.build :court_centre }
+    court_centre { FactoryBot.build(:court_centre) }
     hearing_days { [] }
     defendants { [] }
     defence_counsels { [] }
     estimated_duration { '20 DAYS' }
 
     trait :with_hearing_days do
-      hearing_day1 = FactoryBot.build :hearing_day
+      hearing_day1 = FactoryBot.build(:hearing_day)
       hearing_days { [hearing_day1] }
     end
 
     trait :with_defence_counsels do
-      defence_counsel1 = FactoryBot.build :defence_counsel
-      defence_counsel2 = FactoryBot.build :defence_counsel
+      defence_counsel1 = FactoryBot.build(:defence_counsel)
+      defence_counsel2 = FactoryBot.build(:defence_counsel)
       defence_counsels { [defence_counsel1, defence_counsel2] }
     end
   end

--- a/spec/factories/cd_api/offence_summary.rb
+++ b/spec/factories/cd_api/offence_summary.rb
@@ -18,7 +18,7 @@ FactoryBot.define do
     laa_application { {} }
 
     trait :with_laa_application do
-      laa_application { build :laa_application }
+      laa_application { build(:laa_application) }
     end
   end
 end

--- a/spec/factories/cd_api/overall_defendant.rb
+++ b/spec/factories/cd_api/overall_defendant.rb
@@ -15,7 +15,7 @@ FactoryBot.define do
     maat_reference { 1_234_567 }
 
     trait :with_hearing_days do
-      hearing_days { build :hearing_days }
+      hearing_days { build(:hearing_days) }
     end
   end
 end

--- a/spec/models/cd_api/defendant_spec.rb
+++ b/spec/models/cd_api/defendant_spec.rb
@@ -8,13 +8,13 @@ RSpec.describe CdApi::Defendant, type: :model do
     let(:offence_summaries) { [build(:offence_summary, laa_application:)] }
 
     context 'when maat_reference present' do
-      let(:laa_application) { build :laa_application, reference: '2123456' }
+      let(:laa_application) { build(:laa_application, reference: '2123456') }
 
       it { is_expected.to be_truthy }
     end
 
     context 'when maat_reference not present' do
-      let(:laa_application) { build :laa_application, reference: '' }
+      let(:laa_application) { build(:laa_application, reference: '') }
 
       it { is_expected.to be_falsey }
     end
@@ -26,7 +26,7 @@ RSpec.describe CdApi::Defendant, type: :model do
     end
 
     context 'when maat_reference is prefixed with a Z' do
-      let(:laa_application) { build :laa_application, reference: 'Z1000586' }
+      let(:laa_application) { build(:laa_application, reference: 'Z1000586') }
 
       it { is_expected.to be_falsey }
     end

--- a/spec/models/unlink_reasons_spec.rb
+++ b/spec/models/unlink_reasons_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe UnlinkReason, type: :model do
-  subject(:unlink_reason) { create :unlink_reason }
+  subject(:unlink_reason) { create(:unlink_reason) }
 
   it { is_expected.to respond_to(:code, :description, :text_required, :text_required?) }
 

--- a/spec/services/cd_api/hearing_details/defence_counsels_list_service_spec.rb
+++ b/spec/services/cd_api/hearing_details/defence_counsels_list_service_spec.rb
@@ -6,21 +6,21 @@ RSpec.describe CdApi::HearingDetails::DefenceCounselsListService do
 
     let(:defence_counsels) { [defence_counsel1, defence_counsel2] }
     let(:defence_counsel1) do
-      build :defence_counsel, defendants: [hearing_defendant1, hearing_defendant2], first_name: 'Jane',
-                              last_name: 'Doe'
+      build(:defence_counsel, defendants: [hearing_defendant1, hearing_defendant2], first_name: 'Jane',
+                              last_name: 'Doe')
     end
-    let(:defence_counsel2) { build :defence_counsel }
+    let(:defence_counsel2) { build(:defence_counsel) }
 
-    let(:hearing_defendant1) { build :hearing_defendant, :with_defendant_details }
-    let(:hearing_defendant2) { build :hearing_defendant, :with_defendant_details }
+    let(:hearing_defendant1) { build(:hearing_defendant, :with_defendant_details) }
+    let(:hearing_defendant2) { build(:hearing_defendant, :with_defendant_details) }
 
     context 'when defence counsel has multiple defendants' do
       let(:defence_counsels) { [defence_counsel1, defence_counsel2, defence_counsel3, defence_counsel4] }
       let(:defence_counsel3) do
-        build :defence_counsel, first_name: 'Jim', last_name: 'Cleo',
-                                defendants: [hearing_defendant1, hearing_defendant2]
+        build(:defence_counsel, first_name: 'Jim', last_name: 'Cleo',
+                                defendants: [hearing_defendant1, hearing_defendant2])
       end
-      let(:defence_counsel4) { build :defence_counsel, first_name: 'Ab', last_name: 'Ba', status: 'QC' }
+      let(:defence_counsel4) { build(:defence_counsel, first_name: 'Ab', last_name: 'Ba', status: 'QC') }
 
       it 'returns list of defence_counsels paired with their defendants' do
         expect(case_service_call).to eq(['Jane Doe (Junior) for Vince James',
@@ -31,15 +31,15 @@ RSpec.describe CdApi::HearingDetails::DefenceCounselsListService do
     end
 
     context 'when names are lower case' do
-      let(:hearing_defendant1) { build :hearing_defendant, defendant_details: }
-      let(:defendant_details) { build :hearing_defendant_details, person_details: }
+      let(:hearing_defendant1) { build(:hearing_defendant, defendant_details:) }
+      let(:defendant_details) { build(:hearing_defendant_details, person_details:) }
       let(:person_details) do
-        build :hearing_person_details, first_name: 'john', middle_name: 'doe', last_name: 'smith'
+        build(:hearing_person_details, first_name: 'john', middle_name: 'doe', last_name: 'smith')
       end
 
       let(:defence_counsel1) do
-        build :defence_counsel, defendants: [hearing_defendant1, hearing_defendant2], first_name: 'jane',
-                                last_name: 'doe', status: 'junior'
+        build(:defence_counsel, defendants: [hearing_defendant1, hearing_defendant2], first_name: 'jane',
+                                last_name: 'doe', status: 'junior')
       end
 
       it 'capitalizes the names' do
@@ -58,7 +58,7 @@ RSpec.describe CdApi::HearingDetails::DefenceCounselsListService do
 
     context 'when there are no defendants' do
       let(:defence_counsels) { [defence_counsel] }
-      let(:defence_counsel) { build :defence_counsel, first_name: 'John', last_name: 'Doe', status: 'QC' }
+      let(:defence_counsel) { build(:defence_counsel, first_name: 'John', last_name: 'Doe', status: 'QC') }
 
       it 'returns empty list' do
         expect(case_service_call).to eq(['John Doe (QC)'])
@@ -68,8 +68,8 @@ RSpec.describe CdApi::HearingDetails::DefenceCounselsListService do
     context 'when defendant is an id' do
       let(:defence_counsels) { [defence_counsel1] }
       let(:defence_counsel1) do
-        build :defence_counsel, defendants: [hearing_defendant1.id, hearing_defendant2.id],
-                                first_name: 'Jane', last_name: 'Doe', status: 'QC'
+        build(:defence_counsel, defendants: [hearing_defendant1.id, hearing_defendant2.id],
+                                first_name: 'Jane', last_name: 'Doe', status: 'QC')
       end
 
       it 'returns defence counsel list with unavailable defendant details' do

--- a/spec/support/shared_examples_for_hearings_sorters_v2.rb
+++ b/spec/support/shared_examples_for_hearings_sorters_v2.rb
@@ -8,26 +8,27 @@ RSpec.shared_context 'with multiple v2 hearings to sort' do
   let(:hearing1) do
     # TODO: defence_counsel_list is not an actual attribute of hearing_summary but a decorated method
     # Use a decorated hearing_summary to test defence_counsel_list instead of altering the model
-    build :hearing_summary, id: 'hearing-uuid-1', hearing_type: 'Trial',
+    build(:hearing_summary, id: 'hearing-uuid-1', hearing_type: 'Trial',
                             hearing_days: [hearing1_day1, hearing1_day2],
-                            defence_counsel_list: hearing1_defence_counsel_list
+                            defence_counsel_list: hearing1_defence_counsel_list)
   end
 
   let(:hearing2) do
-    build :hearing_summary, id: 'hearing-uuid-2', hearing_type: 'Pre-Trial Review',
-                            hearing_days: [hearing2_day1], defence_counsel_list: hearing2_defence_counsel_list
+    build(:hearing_summary, id: 'hearing-uuid-2', hearing_type: 'Pre-Trial Review',
+                            hearing_days: [hearing2_day1],
+                            defence_counsel_list: hearing2_defence_counsel_list)
   end
 
   let(:hearing3) do
-    build :hearing_summary, id: 'hearing-uuid-3', hearing_type: 'Mention', hearing_days: [hearing3_day1],
-                            defence_counsel_list: hearing3_defence_counsel_list
+    build(:hearing_summary, id: 'hearing-uuid-3', hearing_type: 'Mention', hearing_days: [hearing3_day1],
+                            defence_counsel_list: hearing3_defence_counsel_list)
   end
 
-  let(:hearing1_day1) { build :hearing_day, sitting_day: '2021-01-19T10:45:00.000Z' }
-  let(:hearing1_day2) { build :hearing_day, sitting_day: '2021-01-20T10:45:00.0s00Z' }
+  let(:hearing1_day1) { build(:hearing_day, sitting_day: '2021-01-19T10:45:00.000Z') }
+  let(:hearing1_day2) { build(:hearing_day, sitting_day: '2021-01-20T10:45:00.0s00Z') }
 
-  let(:hearing2_day1) { build :hearing_day, sitting_day: '2021-01-20T10:00:00.000Z' }
-  let(:hearing3_day1) { build :hearing_day, sitting_day: '2021-01-18T11:00:00.000Z' }
+  let(:hearing2_day1) { build(:hearing_day, sitting_day: '2021-01-20T10:00:00.000Z') }
+  let(:hearing3_day1) { build(:hearing_day, sitting_day: '2021-01-18T11:00:00.000Z') }
 
   let(:hearing1_defence_counsel_list) { 'Jammy Dodger (Junior)' }
   let(:hearing2_defence_counsel_list) { 'Hob Nob (QC)<br>Malted Milk (Junior)' }

--- a/spec/views/hearings/show_v2.html.haml_spec.rb
+++ b/spec/views/hearings/show_v2.html.haml_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe 'hearings/show', type: :view, stub_v2_hearing_data: true,
 
   let(:case_reference) { 'TEST12345' }
   let(:prosecution_case) do
-    build :case_summary, :with_hearing_summaries,
-          prosecution_case_reference: case_reference
+    build(:case_summary, :with_hearing_summaries,
+          prosecution_case_reference: case_reference)
   end
   let(:decorated_prosecution_case) { view.decorate(prosecution_case, CdApi::CaseSummaryDecorator) }
   let(:hearing_id) { '844a6542-ffcb-4cd0-94ce-fda3ffc3081b' }

--- a/spec/views/prosecution_cases/cd_api/_hearing_summaries.html.haml_spec.rb
+++ b/spec/views/prosecution_cases/cd_api/_hearing_summaries.html.haml_spec.rb
@@ -8,32 +8,32 @@ RSpec.describe 'prosecution_cases/cd_api/_hearing_summaries.html.haml', type: :v
   end
 
   let(:decorated_case_summary) { view.decorate(case_summary, CdApi::CaseSummaryDecorator) }
-  let(:case_summary) { build :case_summary, prosecution_case_reference: 'THECASEURN', hearing_summaries: }
+  let(:case_summary) { build(:case_summary, prosecution_case_reference: 'THECASEURN', hearing_summaries:) }
 
   let(:hearing_summaries) { [] }
 
   let(:hearing_summary) do
-    build :hearing_summary, id: 'hearing-uuid', hearing_type: 'First hearing', hearing_days: [hearing_day],
-                            defence_counsels:
+    build(:hearing_summary, id: 'hearing-uuid', hearing_type: 'First hearing', hearing_days: [hearing_day],
+                            defence_counsels:)
   end
 
   let(:hearing_summary1) do
-    build :hearing_summary, id: 'hearing1-uuid', hearing_type: 'Trial', hearing_days: [hearing1_day],
-                            defence_counsels:
+    build(:hearing_summary, id: 'hearing1-uuid', hearing_type: 'Trial', hearing_days: [hearing1_day],
+                            defence_counsels:)
   end
 
   let(:hearing_summary2) do
-    build :hearing_summary, id: 'hearing2-uuid', hearing_type: 'Sentence', hearing_days: [hearing2_day],
-                            defence_counsels:
+    build(:hearing_summary, id: 'hearing2-uuid', hearing_type: 'Sentence', hearing_days: [hearing2_day],
+                            defence_counsels:)
   end
 
-  let(:hearing_day) { build :hearing_day, sitting_day: '2021-01-17T10:30:00.000Z' }
-  let(:hearing1_day) { build :hearing_day, sitting_day: '2021-01-18T13:00:00.000Z' }
-  let(:hearing2_day) { build :hearing_day, sitting_day: '2021-01-19T15:19:15.000Z' }
+  let(:hearing_day) { build(:hearing_day, sitting_day: '2021-01-17T10:30:00.000Z') }
+  let(:hearing1_day) { build(:hearing_day, sitting_day: '2021-01-18T13:00:00.000Z') }
+  let(:hearing2_day) { build(:hearing_day, sitting_day: '2021-01-19T15:19:15.000Z') }
 
   let(:defence_counsels) { [defence_counsel] }
   let(:defence_counsel) do
-    build :defence_counsel, first_name: 'Fred', last_name: 'Dibnah', status: 'QC', attendance_days:
+    build(:defence_counsel, first_name: 'Fred', last_name: 'Dibnah', status: 'QC', attendance_days:)
   end
   let(:attendance_days) { %w[2021-01-17 2021-01-18 2021-01-19] }
 
@@ -94,14 +94,14 @@ RSpec.describe 'prosecution_cases/cd_api/_hearing_summaries.html.haml', type: :v
     end
 
     context 'with multiple hearing days per hearing' do
-      let(:hearing_day) { build :hearing_day, sitting_day: '2021-01-17T13:30:15.000Z' }
-      let(:hearing2_day) { build :hearing_day, sitting_day: '2021-01-20T16:00:00.000Z' }
+      let(:hearing_day) { build(:hearing_day, sitting_day: '2021-01-17T13:30:15.000Z') }
+      let(:hearing2_day) { build(:hearing_day, sitting_day: '2021-01-20T16:00:00.000Z') }
 
-      let(:hearing1_day1) { build :hearing_day, sitting_day: '2021-01-19T10:45:00.000Z' }
-      let(:hearing1_day2) { build :hearing_day, sitting_day: '2021-01-20T10:45:00.000Z' }
+      let(:hearing1_day1) { build(:hearing_day, sitting_day: '2021-01-19T10:45:00.000Z') }
+      let(:hearing1_day2) { build(:hearing_day, sitting_day: '2021-01-20T10:45:00.000Z') }
       let(:hearing_summary1) do
-        build :hearing_summary, id: 'hearing1-uuid', hearing_type: 'Trial',
-                                hearing_days: [hearing1_day1, hearing1_day2], defence_counsels:
+        build(:hearing_summary, id: 'hearing1-uuid', hearing_type: 'Trial',
+                                hearing_days: [hearing1_day1, hearing1_day2], defence_counsels:)
       end
 
       it 'sorts hearings by hearing_days collection then by hearing day datetime' do
@@ -115,11 +115,11 @@ RSpec.describe 'prosecution_cases/cd_api/_hearing_summaries.html.haml', type: :v
 
     context 'with estimated duration on multiday hearings' do
       let(:hearing_summaries) { [hearing_summary] }
-      let(:hearing1_day1) { build :hearing_day, sitting_day: '2021-01-19T10:45:00.000Z' }
-      let(:hearing1_day2) { build :hearing_day, sitting_day: '2021-01-20T10:45:00.000Z' }
+      let(:hearing1_day1) { build(:hearing_day, sitting_day: '2021-01-19T10:45:00.000Z') }
+      let(:hearing1_day2) { build(:hearing_day, sitting_day: '2021-01-20T10:45:00.000Z') }
       let(:hearing_summary) do
-        build :hearing_summary, id: 'hearing1-uuid', hearing_type: 'Trial',
-                                hearing_days: [hearing1_day1, hearing1_day2], defence_counsels:
+        build(:hearing_summary, id: 'hearing1-uuid', hearing_type: 'Trial',
+                                hearing_days: [hearing1_day1, hearing1_day2], defence_counsels:)
       end
 
       it 'renders formated estimated duration on the first hearing day' do

--- a/spec/views/prosecution_cases/cd_api/_overall_defendants.html.haml_spec.rb
+++ b/spec/views/prosecution_cases/cd_api/_overall_defendants.html.haml_spec.rb
@@ -8,15 +8,15 @@ RSpec.describe 'prosecution_cases/cd_api/_overall_defendants.html.haml', type: :
   let(:results) { [case_summary] }
 
   let(:case_summary) do
-    build :case_summary, prosecution_case_reference: 'THECASEURN', overall_defendants:
+    build(:case_summary, prosecution_case_reference: 'THECASEURN', overall_defendants:)
   end
 
   let(:hearings) { [] }
   let(:overall_defendants) { [overall_defendant] }
   let(:defendant_name) { 'Joe Bloggs' }
   let(:overall_defendant) do
-    build :overall_defendant, id: 'a-defendant-uuid', first_name: 'Joe', last_name: 'Bloggs',
-                              maat_reference: '1234567', date_of_birth: '1968-07-14', name: ''
+    build(:overall_defendant, id: 'a-defendant-uuid', first_name: 'Joe', last_name: 'Bloggs',
+                              maat_reference: '1234567', date_of_birth: '1968-07-14', name: '')
   end
 
   before do

--- a/spec/views/prosecution_cases/cd_api/_show_v2.html.haml_spec.rb
+++ b/spec/views/prosecution_cases/cd_api/_show_v2.html.haml_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'prosecution_cases/cd_api/_show_v2.html.haml', type: :view do
 
   let(:decorated_case_summary) { view.decorate(case_summary, CdApi::CaseSummaryDecorator) }
   let(:case_summary) do
-    build :case_summary, prosecution_case_reference: ''
+    build(:case_summary, prosecution_case_reference: '')
   end
 
   before do


### PR DESCRIPTION
#### What

Fix Rubocop issues for [`RSpec/FactoryBot/ConsistentParenthesesStyle`](https://docs.rubocop.org/rubocop-rspec/cops_rspec_factorybot.html#rspecfactorybotconsistentparenthesesstyle)

#### Ticket

[Fix Rubocop Issues: RSpec/FactoryBot/ConsistentParenthesesStyle](https://dsdmoj.atlassian.net/browse/CTSKF-53)

#### Why

Maintain consistent coding style.

#### How

All of the changes have been auto-fixed. In one place, in `spec/support/shared_examples_for_hearings_sorters_v2.rb`, a line has been broken to keep within the line length limit.

#### For discussion

By default, parentheses are preferred so

```ruby
let(:case_summary) { build :case_summary }
```

becomes

```ruby
let(:case_summary) { build(:case_summary) }
```

It is possible to change the behaviour so that the former version, without parenthesis, is enforced. Which is preferred? Using this options (`EnforcedStyle: omit_parentheses`) results in 106 offenses, compared with 120 with the default behaviour.

Secondly, the auto-correction has resulted in code like this,

```ruby
      build(:defence_counsel, first_name: 'Bob', last_name: 'Smith', status: 'QC',
                              defendants: mapped_defendants)
```

It may be preferable to have this instead;

```ruby
      build(
        :defence_counsel,
        first_name: 'Bob',
        last_name: 'Smith',
        status: 'QC',
        defendants: mapped_defendants
      )
```

This is a matter of opinion and (I think) both are acceptable.