### PR TITLE
Update ECR login mechanism

### DIFF
--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -23,8 +23,7 @@ function _circleci_build() {
   printf "\e[33mRegistry tag: $docker_registry_tag\e[0m\n"
   printf "\e[33m------------------------------------------------------------------------\e[0m\n"
   printf '\e[33mDocker login to registry (ECR)...\e[0m\n'
-  login="$(AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION} AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} aws ecr get-login --no-include-email)"
-  ${login}
+  AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION} AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} aws ecr get-login-password | docker login --username AWS --password-stdin ${ECR_ENDPOINT}
 
   docker build \
     --build-arg BUILD_DATE=$(date +%Y-%m-%dT%H:%M:%S%z) \

--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -59,8 +59,7 @@ function _circleci_deploy() {
   printf "\e[33mBranch: $CIRCLE_BRANCH\e[0m\n"
   printf "\e[33m--------------------------------------------------\e[0m\n"
   printf '\e[33mDocker login to registry (ECR)...\e[0m\n'
-  login="$(AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION} AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} aws ecr get-login --no-include-email)"
-  ${login}
+  AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION} AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} aws ecr get-login-password | docker login --username AWS --password-stdin ${ECR_ENDPOINT}
 
   printf '\e[33mK8S Login...\e[0m\n'
   echo -n ${K8S_CLUSTER_CERT} | base64 -d > ./ca.crt


### PR DESCRIPTION
#### What

Use `get-login` instead of `get-login-password`

#### Ticket

[Deployment fails with deprecated AWS login message](https://dsdmoj.atlassian.net/browse/CTSKF-165)

#### Why

`get-login` has been deprecated and is now causing deployments to fail.