### PR TITLE
CTSKF-165 Update deprecated get-login AWS command

### DIFF
--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -23,7 +23,7 @@ function _circleci_build() {
   printf "\e[33mRegistry tag: $docker_registry_tag\e[0m\n"
   printf "\e[33m------------------------------------------------------------------------\e[0m\n"
   printf '\e[33mDocker login to registry (ECR)...\e[0m\n'
-  login="$(AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION} AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} aws ecr get-login --no-include-email)"
+  login="$(AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION} AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} aws ecr get-login-password | docker login --username AWS --password-stdin ${ECR_ENDPOINT})"
   ${login}
 
   docker build \

--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -59,7 +59,7 @@ function _circleci_deploy() {
   printf "\e[33mBranch: $CIRCLE_BRANCH\e[0m\n"
   printf "\e[33m--------------------------------------------------\e[0m\n"
   printf '\e[33mDocker login to registry (ECR)...\e[0m\n'
-  login="$(AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION} AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} aws ecr get-login --no-include-email)"
+  login="$(AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION} AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} aws ecr get-login-password | docker login --username AWS --password-stdin ${ECR_ENDPOINT})"
   ${login}
 
   printf '\e[33mK8S Login...\e[0m\n'


### PR DESCRIPTION
This work was completed in this PR https://github.com/ministryofjustice/laa-court-data-ui/pull/1321


#### What

Update deprecated `get-login` AWS command to `get-login-password`

#### Ticket

[CTSKF-165](https://dsdmoj.atlassian.net/browse/CTSKF-165)

#### Why

This fixes deployment issues around logging in to ECR

#### How

Use get-login-password instead of get-login because aws has deprecated the command get-login
in the build and deploy scripts that's used in CircleCI
