### PR TITLE
Update CircleCI parallelism to split by timings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,7 +175,7 @@ commands:
           command: |
             mkdir /tmp/test-results
             tmp/cc-test-reporter before-build
-            TESTFILES=$(circleci tests glob "spec/**/*_spec.rb" | circleci tests split)
+            TESTFILES=$(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
             RUBYOPT=-W:no-deprecated \
             bundle exec rspec \
               --format progress \


### PR DESCRIPTION
#### What

Improve the performance of CircleCI parallel testing

#### Ticket

no ticket

#### Why

This should provide performance benefits / optimize with each test suite run
more info: https://circleci.com/docs/parallelism-faster-jobs/#how-test-splitting-works

#### How

Update the circleci config for parallelism to split tests by timings rather than the default of splitting tests by name

