### PR TITLE
Increase the SNYK scan threshold to critical

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -286,7 +286,7 @@ jobs:
           docker-image-name: vcd:scan
           target-file: ./docker/Dockerfile
           organization: "legal-aid-agency"
-          severity-threshold: "high"
+          severity-threshold: "critical"
           fail-on-issues: true
 
   build-app-container:


### PR DESCRIPTION
#### What

Increase the SNYK scan threshold to `critical`

#### Ticket



#### Why

This is because there is a `high` vulnerability blocking the CI/CD pipeline. This is a temporary change until the venerability is resolved (relating to webpacker)

#### How

Update the Circlci config > snyk/scan --severity-threshold to "critical"

