### PR TITLE
CTSKF-291 Update ip blocklist with bot ip

### DIFF
--- a/.k8s/live/dev/ingress.yaml
+++ b/.k8s/live/dev/ingress.yaml
@@ -24,6 +24,7 @@ metadata:
         deny 20.219.196.158;
         deny 162.55.51.218;
         deny 35.78.59.144;
+        deny 80.78.22.106;
         if ($http_spider_name ~* "crawlergo") {
           return 403;
         }

--- a/.k8s/live/production/ingress.yaml
+++ b/.k8s/live/production/ingress.yaml
@@ -24,6 +24,7 @@ metadata:
         deny 20.219.196.158;
         deny 162.55.51.218;
         deny 35.78.59.144;
+        deny 80.78.22.106;
         if ($http_spider_name ~* "crawlergo") {
           return 403;
         }

--- a/.k8s/live/staging/ingress.yaml
+++ b/.k8s/live/staging/ingress.yaml
@@ -24,6 +24,7 @@ metadata:
         deny 20.219.196.158;
         deny 162.55.51.218;
         deny 35.78.59.144;
+        deny 80.78.22.106;
         if ($http_spider_name ~* "crawlergo") {
           return 403;
         }

--- a/.k8s/live/uat/ingress.yaml
+++ b/.k8s/live/uat/ingress.yaml
@@ -24,6 +24,7 @@ metadata:
         deny 20.219.196.158;
         deny 162.55.51.218;
         deny 35.78.59.144;
+        deny 80.78.22.106;
         if ($http_spider_name ~* "crawlergo") {
           return 403;
         }


### PR DESCRIPTION
**What**
Update ingress deny list to prevent malicious [attempts](https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/discover#/doc/167701b0-f8c0-11ec-b95c-1d65c3682287/live_kubernetes_cluster-2023.03.06?id=ca11b54f-6dea-036b-af26-07ee7fbb358c) on our service by certain ip addresses

on all environments (DEV, UAT, Staging and Production).

**Ticket**
[CTSK291](https://dsdmoj.atlassian.net/browse/CTSKF-291)

**Why**
To prevent malicious hacks on our service.

**How**
Update the ingress files for each environment and deny the culprits/IP addresses.
