### PR TITLE
CTSKF-398 - Be explicit in error catch and handle in cleaner method

### DIFF
--- a/spec/features/defendants_view_spec.rb
+++ b/spec/features/defendants_view_spec.rb
@@ -5,41 +5,111 @@ RSpec.feature 'defendants view', type: :feature, stub_defendants_uuid_urn_search
   let(:case_urn) { 'TEST12345' }
   let(:defendant_id) { '844a6542-ffcb-4cd0-94ce-fda3ffc3081b' }
 
-  before do
-    allow(Feature).to receive(:enabled?).with(:defendants_page).and_return(true)
-    sign_in user
-  end
+  context 'when version 2 is enabled' do
+    before do
+      allow(Feature).to receive(:enabled?).with(:defendants_page).and_return(true)
+      sign_in user
+    end
 
-  context 'when visting laa_references page' do
-    scenario 'laa_references page shows data' do
-      visit "laa_references/new?id=#{defendant_id}&urn=#{case_urn}"
-      expect(page).to have_title('Maxie Turcotte Raynor')
-      expect(page).to have_css('th.govuk-table__header', text: 'Date of birth')
-      expect(page).to have_css('th.govuk-table__header', text: 'Case URN')
-      expect(page).to have_css('th.govuk-table__header', text: 'NI number')
-      expect(page).to have_css('th.govuk-table__header', text: 'ASN')
-      expect(page).to have_link('View case')
-      expect(page).to have_css('div.govuk-heading-l', text: 'Offences')
-      expect(page).to have_css('th.govuk-table__header', text: 'Offence and legislation')
-      expect(page).to have_css('th.govuk-table__header', text: 'Plea')
-      expect(page).to have_css('th.govuk-table__header', text: 'Mode of trial')
+    context 'when visting laa_references page' do
+      scenario 'laa_references page shows data' do
+        visit "laa_references/new?id=#{defendant_id}&urn=#{case_urn}"
+        expect(page).to have_title('Maxie Turcotte Raynor')
+        expect(page).to have_css('th.govuk-table__header', text: 'Date of birth')
+        expect(page).to have_css('th.govuk-table__header', text: 'Case URN')
+        expect(page).to have_css('th.govuk-table__header', text: 'NI number')
+        expect(page).to have_css('th.govuk-table__header', text: 'ASN')
+        expect(page).to have_link('View case')
+        expect(page).to have_css('div.govuk-heading-l', text: 'Offences')
+        expect(page).to have_css('th.govuk-table__header', text: 'Offence and legislation')
+        expect(page).to have_css('th.govuk-table__header', text: 'Plea')
+        expect(page).to have_css('th.govuk-table__header', text: 'Mode of trial')
+      end
+    end
+
+    context 'when visting defendants page' do
+      scenario 'defendants page shows data' do
+        visit "defendants/#{defendant_id}/edit?urn=#{case_urn}"
+        expect(page).to have_title('Maxie Turcotte Raynor')
+        expect(page).to have_css('th.govuk-table__header', text: 'Date of birth')
+        expect(page).to have_css('th.govuk-table__header', text: 'Case URN')
+        expect(page).to have_css('th.govuk-table__header', text: 'NI number')
+        expect(page).to have_css('th.govuk-table__header', text: 'ASN')
+        expect(page).to have_link('View case')
+        expect(page).to have_css('div.govuk-heading-l', text: 'Offences')
+        expect(page).to have_css('th.govuk-table__header', text: 'Date')
+        expect(page).to have_css('th.govuk-table__header', text: 'Offence and legislation')
+        expect(page).to have_css('th.govuk-table__header', text: 'Plea')
+        expect(page).to have_css('th.govuk-table__header', text: 'Mode of trial')
+      end
     end
   end
 
-  context 'when visting defendants page' do
-    scenario 'defendants page shows data' do
-      visit "defendants/#{defendant_id}/edit?urn=#{case_urn}"
-      expect(page).to have_title('Maxie Turcotte Raynor')
-      expect(page).to have_css('th.govuk-table__header', text: 'Date of birth')
-      expect(page).to have_css('th.govuk-table__header', text: 'Case URN')
-      expect(page).to have_css('th.govuk-table__header', text: 'NI number')
-      expect(page).to have_css('th.govuk-table__header', text: 'ASN')
-      expect(page).to have_link('View case')
-      expect(page).to have_css('div.govuk-heading-l', text: 'Offences')
-      expect(page).to have_css('th.govuk-table__header', text: 'Date')
-      expect(page).to have_css('th.govuk-table__header', text: 'Offence and legislation')
-      expect(page).to have_css('th.govuk-table__header', text: 'Plea')
-      expect(page).to have_css('th.govuk-table__header', text: 'Mode of trial')
+  context 'when version 2 is disabled' do
+    before do
+      allow(Feature).to receive(:enabled?).with(:defendants_page).and_return(false)
+      sign_in user
+
+      stub_request(:get, %r{#{api_url}/prosecution_cases.*})
+        .to_return(
+          body: defendant_fixture,
+          headers: { 'Content-Type' => 'application/vnd.api+json' }
+        )
+
+      stub_request(:get, %r{#{api_url}/defendants/#{defendant_id}})
+        .to_return(
+          body: defendant_by_id_fixture,
+          headers: { 'Content-Type' => 'application/vnd.api+json' }
+        )
+
+        stub_request(:get, %r{#{api_url}/defendants/500})
+        .to_return(
+          status: 422
+        )
+    end
+
+    context 'when visting laa_references page' do
+      let(:defendant_fixture) { load_json_stub('unlinked/defendant_by_reference_body.json') }
+      let(:defendant_by_id_fixture) { load_json_stub('unlinked_defendant.json') }
+
+      scenario 'laa_references page shows data' do
+        visit "laa_references/new?id=#{defendant_id}&urn=#{case_urn}"
+        expect(page).to have_title('Jammy Dodger')
+        expect(page).to have_css('th.govuk-table__header', text: 'Date of birth')
+        expect(page).to have_css('th.govuk-table__header', text: 'Case URN')
+        expect(page).to have_css('th.govuk-table__header', text: 'NI number')
+        expect(page).to have_css('th.govuk-table__header', text: 'ASN')
+        expect(page).to have_link('View case')
+        expect(page).to have_css('div.govuk-heading-l', text: 'Offences')
+        expect(page).to have_css('th.govuk-table__header', text: 'Offence and legislation')
+        expect(page).to have_css('th.govuk-table__header', text: 'Plea')
+        expect(page).to have_css('th.govuk-table__header', text: 'Mode of trial')
+      end
+
+      scenario 'laa_references page returns to previous page' do
+        visit "laa_references/new?id=500&urn=#{case_urn}"
+        expect(page.current_path).to eq "/"
+      end
+    end
+
+    context 'when visting defendants page' do
+      let(:defendant_fixture) { load_json_stub('linked/defendant_by_reference_body.json') }
+      let(:defendant_by_id_fixture) { load_json_stub('linked_defendant.json') }
+
+      scenario 'defendants page shows data' do
+        visit "defendants/#{defendant_id}/edit?urn=#{case_urn}"
+        expect(page).to have_title('Jammy Dodger')
+        expect(page).to have_css('th.govuk-table__header', text: 'Date of birth')
+        expect(page).to have_css('th.govuk-table__header', text: 'Case URN')
+        expect(page).to have_css('th.govuk-table__header', text: 'NI number')
+        expect(page).to have_css('th.govuk-table__header', text: 'ASN')
+        expect(page).to have_link('View case')
+        expect(page).to have_css('div.govuk-heading-l', text: 'Offences')
+        expect(page).to have_css('th.govuk-table__header', text: 'Date')
+        expect(page).to have_css('th.govuk-table__header', text: 'Offence and legislation')
+        expect(page).to have_css('th.govuk-table__header', text: 'Plea')
+        expect(page).to have_css('th.govuk-table__header', text: 'Mode of trial')
+      end
     end
   end
 end

--- a/spec/features/defendants_view_spec.rb
+++ b/spec/features/defendants_view_spec.rb
@@ -62,7 +62,7 @@ RSpec.feature 'defendants view', type: :feature, stub_defendants_uuid_urn_search
           headers: { 'Content-Type' => 'application/vnd.api+json' }
         )
 
-        stub_request(:get, %r{#{api_url}/defendants/500})
+      stub_request(:get, %r{#{api_url}/defendants/500})
         .to_return(
           status: 422
         )
@@ -88,7 +88,7 @@ RSpec.feature 'defendants view', type: :feature, stub_defendants_uuid_urn_search
 
       scenario 'laa_references page returns to previous page' do
         visit "laa_references/new?id=500&urn=#{case_urn}"
-        expect(page.current_path).to eq "/"
+        expect(page).to have_current_path '/'
       end
     end
 

--- a/spec/requests/defendants_spec.rb
+++ b/spec/requests/defendants_spec.rb
@@ -28,6 +28,11 @@ RSpec.describe 'defendants', type: :request do
           body: defendant_by_id_fixture,
           headers: { 'Content-Type' => 'application/vnd.api+json' }
         )
+
+      stub_request(:get, %r{#{api_url}/defendants/500})
+        .to_return(
+          status: 424
+        )
     end
 
     context 'with unlinked defendant' do
@@ -54,6 +59,16 @@ RSpec.describe 'defendants', type: :request do
       include_examples 'renders common defendant details'
 
       it { expect(response).to render_template('defendants/_form') }
+    end
+
+    context 'with error from CDA' do
+      before do
+        get "/defendants/500/edit?urn=#{case_reference_from_fixture}"
+      end
+
+      it 'redirects to the previous page' do
+        expect(response).to redirect_to :back
+      end
     end
   end
 

--- a/spec/requests/defendants_spec.rb
+++ b/spec/requests/defendants_spec.rb
@@ -28,11 +28,6 @@ RSpec.describe 'defendants', type: :request do
           body: defendant_by_id_fixture,
           headers: { 'Content-Type' => 'application/vnd.api+json' }
         )
-
-      stub_request(:get, %r{#{api_url}/defendants/500})
-        .to_return(
-          status: 424
-        )
     end
 
     context 'with unlinked defendant' do
@@ -59,16 +54,6 @@ RSpec.describe 'defendants', type: :request do
       include_examples 'renders common defendant details'
 
       it { expect(response).to render_template('defendants/_form') }
-    end
-
-    context 'with error from CDA' do
-      before do
-        get "/defendants/500/edit?urn=#{case_reference_from_fixture}"
-      end
-
-      it 'redirects to the previous page' do
-        expect(response).to redirect_to :back
-      end
     end
   end
 


### PR DESCRIPTION
#### What

Provide cleaner method of displaying an error when there are multiple MAAT errors on the V1 endpoint. CDA had changed the error from a 500 to the 422 which provided unuseful errors

#### Ticket

[CD UI: Misleading Error Message Shows When Trying to Access Defendant Page ](https://dsdmoj.atlassian.net/browse/CTSKF-398)

#### Why

Provide better feedback to the end user

#### How

Explicitly catch the error occuring and returning them back to the search results rather than throw error pages. 
