### PR TITLE
CTSKF-393 Update ruby dependencies by grouping Dependabot updates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ group :test do
   gem 'rspec-html-matchers', '~> 0.10.0'
   gem 'rspec_junit_formatter'
   gem 'rspec-rails', '~> 6.0'
-  gem 'rubocop', '~> 1.50', require: false
+  gem 'rubocop', '~> 1.51', require: false
   gem 'rubocop-performance', require: false
   gem 'rubocop-rails', require: false
   gem 'rubocop-rspec', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -428,7 +428,7 @@ GEM
       connection_pool (>= 2.3.0)
       rack (>= 2.2.4)
       redis-client (>= 0.14.0)
-    sidekiq_alive (2.2.0)
+    sidekiq_alive (2.2.1)
       rack (< 3)
       sidekiq (>= 5, < 8)
       webrick (>= 1, < 2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,7 +106,7 @@ GEM
     builder (3.2.4)
     byebug (11.1.3)
     cancancan (3.5.0)
-    capybara (3.39.0)
+    capybara (3.39.1)
       addressable
       matrix
       mini_mime (>= 0.1.3)
@@ -272,7 +272,7 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.9)
-    nokogiri (1.14.3)
+    nokogiri (1.14.4)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     notifications-ruby-client (5.3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -285,8 +285,8 @@ GEM
       snaky_hash (~> 2.0)
       version_gem (~> 1.1)
     orm_adapter (0.5.0)
-    parallel (1.22.1)
-    parser (3.2.2.0)
+    parallel (1.23.0)
+    parser (3.2.2.1)
       ast (~> 2.4.1)
     pg (1.5.3)
     prometheus_exporter (2.0.8)
@@ -381,7 +381,7 @@ GEM
     rspec-support (3.12.0)
     rspec_junit_formatter (0.6.0)
       rspec-core (>= 2, < 4, != 2.12.0)
-    rubocop (1.50.2)
+    rubocop (1.51.0)
       json (~> 2.3)
       parallel (~> 1.10)
       parser (>= 3.2.0.0)
@@ -391,7 +391,7 @@ GEM
       rubocop-ast (>= 1.28.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.28.0)
+    rubocop-ast (1.28.1)
       parser (>= 3.2.1.0)
     rubocop-capybara (2.17.1)
       rubocop (~> 1.41)
@@ -544,7 +544,7 @@ DEPENDENCIES
   rspec-html-matchers (~> 0.10.0)
   rspec-rails (~> 6.0)
   rspec_junit_formatter
-  rubocop (~> 1.50)
+  rubocop (~> 1.51)
   rubocop-performance
   rubocop-rails
   rubocop-rspec


### PR DESCRIPTION
#### What

Group Dependabot updates on ruby gemfiles for the below PRs:

[Bump sidekiq_alive from 2.2.0 to 2.2.1](https://github.com/ministryofjustice/laa-court-data-ui/pull/1501)
[Bump rubocop from 1.50.2 to 1.51.0](https://github.com/ministryofjustice/laa-court-data-ui/pull/1500)
[Bump capybara from 3.39.0 to 3.39.1](https://github.com/ministryofjustice/laa-court-data-ui/pull/1499)

#### Ticket

[CTSKF-393](https://dsdmoj.atlassian.net/browse/CTSKF-393)

#### Why

- Updating our dependencies keeps our application secure and functioning.
- Grouping the Dependabot updates makes the whole dependency management process quicker instead of testing each one in separate deployments, we can deploy and test in groups.

#### How

Update the Gemfile and/or Gemfile.lock version numbers of the dependencies.


[CTSKF-393]: https://dsdmoj.atlassian.net/browse/CTSKF-393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ