### PR TITLE
CTSKF-403 - Return error flash when non 200 status code received

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -58,4 +58,11 @@ class ApplicationController < ActionController::Base
     Current.request_id = request.headers['laa-transaction-id'] || request.request_id
     response.set_header('laa-transaction-id', Current.request_id)
   end
+
+  def log_sentry_error(exception, errors)
+    Sentry.with_scope do |scope|
+      scope&.set_extra('error_message', errors)
+      Sentry.capture_exception(exception)
+    end
+  end
 end

--- a/app/controllers/defendants_controller.rb
+++ b/app/controllers/defendants_controller.rb
@@ -150,13 +150,6 @@ class DefendantsController < ApplicationController
     flash.now[:alert] = { title:, message: }
     render 'edit'
   end
-
-  def log_sentry_error(exception, errors)
-    Sentry.with_scope do |scope|
-      scope&.set_extra('error_message', errors)
-      Sentry.capture_exception(exception)
-    end
-  end
 end
 
 # rubocop:enable Metrics

--- a/app/controllers/laa_references_controller.rb
+++ b/app/controllers/laa_references_controller.rb
@@ -130,13 +130,6 @@ class LaaReferencesController < ApplicationController
     redirect_to edit_defendant_path(defendant.id, urn: prosecution_case_reference)
     flash[:notice] = I18n.t('laa_reference.link.success')
   end
-
-  def log_sentry_error(exception, errors)
-    Sentry.with_scope do |scope|
-      scope&.set_extra('error_message', errors)
-      Sentry.capture_exception(exception)
-    end
-  end
 end
 
 # rubocop:enable Metrics

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -83,7 +83,7 @@ class SearchesController < ApplicationController
 
   def handle_client_error(exception)
     logger.info 'CLIENT_ERROR_OCCURRED'
-    @laa_reference.errors.from_json(exception.response.body)
+    @laa_reference&.errors&.from_json(exception.response.body)
     render_error(I18n.t('search.error.unprocessable'), @laa_reference&.errors&.full_messages&.join(', '))
   end
 

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -16,6 +16,7 @@ class SearchesController < ApplicationController
     authorize! :create, @search
 
     @results = @search.execute if @search.valid?
+    render 'new'
   rescue ActiveResource::BadRequest => e
     Rails.logger.info 'CLIENT_ERROR_OCCURRED'
     handle_client_error e

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -16,7 +16,12 @@ class SearchesController < ApplicationController
     authorize! :create, @search
 
     @results = @search.execute if @search.valid?
-    render 'new'
+  rescue ActiveResource::BadRequest => e
+    Rails.logger.info 'CLIENT_ERROR_OCCURRED'
+    handle_client_error e
+  rescue ActiveResource::ServerError, ActiveResource::ClientError => e
+    Rails.logger.error 'SERVER_ERROR_OCCURRED'
+    handle_server_error e
   end
 
   private
@@ -73,5 +78,22 @@ class SearchesController < ApplicationController
              else
                I18n.t('search.term.case_reference_label')
              end
+  end
+
+  def handle_client_error(exception)
+    logger.info 'CLIENT_ERROR_OCCURRED'
+    @laa_reference.errors.from_json(exception.response.body)
+    render_error(I18n.t('search.error.unprocessable'), @laa_reference&.errors&.full_messages&.join(', '))
+  end
+
+  def handle_server_error(exception)
+    logger.error 'SERVER_ERROR_OCCURRED'
+    log_sentry_error(exception, @laa_reference&.errors)
+    render_error(I18n.t('search.error.failure'), I18n.t('error.it_helpdesk'))
+  end
+
+  def render_error(title, message)
+    flash.now[:alert] = { title:, message: }
+    render 'new'
   end
 end

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -59,17 +59,6 @@ class Search
 
   def query_cd_api
     CdApi::SearchService.call(filter:, term:, dob:)
-  rescue ActiveResource::BadRequest
-    Rails.logger.info 'CLIENT_ERROR_OCCURRED'
-    empty_collection
-  rescue ActiveResource::ServerError, ActiveResource::ClientError => e
-    Rails.logger.error 'SERVER_ERROR_OCCURRED'
-    Sentry.capture_exception(e)
-    empty_collection
-  end
-
-  def empty_collection
-    []
   end
 
   def query_cda

--- a/config/locales/en/views/searches.yml
+++ b/config/locales/en/views/searches.yml
@@ -4,6 +4,9 @@ en:
     breadcrumb: Search
     dob:
       legend_text: Defendant date of birth
+    error:
+      failure: Unable to complete the search. Please try again in a moment.
+      unprocessable: Unable to complete the search. Please adjust the search terms and try again.
     no_result:
       body: There are no matching results.
       body_guide: 'Improve your search results by:'
@@ -49,9 +52,6 @@ en:
       case_reference_label: Unique reference number
       defendant_name_label: Defendant name
       defendant_reference_label: Defendant ASN or National insurance number
-    error:
-      unprocessable: Unable to complete the search. Please adjust the search terms and try again.
-      failure: Unable to complete the search. Please try again in a moment.
   search_filter:
     breadcrumb: Home
     legend_text: Search for

--- a/config/locales/en/views/searches.yml
+++ b/config/locales/en/views/searches.yml
@@ -49,6 +49,9 @@ en:
       case_reference_label: Unique reference number
       defendant_name_label: Defendant name
       defendant_reference_label: Defendant ASN or National insurance number
+    error:
+      unprocessable: Unable to complete the search. Please adjust the search terms and try again.
+      failure: Unable to complete the search. Please try again in a moment.
   search_filter:
     breadcrumb: Home
     legend_text: Search for

--- a/spec/features/search/cd_api/case_reference_spec.rb
+++ b/spec/features/search/cd_api/case_reference_spec.rb
@@ -54,4 +54,21 @@ RSpec.feature 'Case reference search', type: :feature, vcr: true, js: true do
 
     expect(page).to be_accessible.within '#main-content'
   end
+
+  scenario 'with error from CDA', :stub_defendants_cda_failed do
+    visit '/'
+
+    choose 'A case by URN'
+    click_button 'Continue'
+    fill_in 'search-term-field', with: 'error'
+    click_button 'Search'
+
+    expect(page).not_to have_css('.govuk-body', text: 'There are no matching results')
+    expect(page).to have_css('.govuk-error-summary')
+    within '.govuk-error-summary' do
+      expect(page).to have_content('Unable to complete the search. Please try again in a moment.')
+    end
+
+    expect(page).to be_accessible.within '#main-content'
+  end
 end

--- a/spec/features/search/cd_api/case_reference_spec.rb
+++ b/spec/features/search/cd_api/case_reference_spec.rb
@@ -55,7 +55,7 @@ RSpec.feature 'Case reference search', type: :feature, vcr: true, js: true do
     expect(page).to be_accessible.within '#main-content'
   end
 
-  scenario 'with error from CDA', :stub_defendants_cda_failed do
+  scenario 'with error from common_platform', :stub_defendants_cda_failed do
     visit '/'
 
     choose 'A case by URN'
@@ -67,6 +67,23 @@ RSpec.feature 'Case reference search', type: :feature, vcr: true, js: true do
     expect(page).to have_css('.govuk-error-summary')
     within '.govuk-error-summary' do
       expect(page).to have_content('Unable to complete the search. Please try again in a moment.')
+    end
+
+    expect(page).to be_accessible.within '#main-content'
+  end
+
+  scenario 'with error from CDA', :stub_defendants_failed_search do
+    visit '/'
+
+    choose 'A case by URN'
+    click_button 'Continue'
+    fill_in 'search-term-field', with: 'error'
+    click_button 'Search'
+
+    expect(page).not_to have_css('.govuk-body', text: 'There are no matching results')
+    expect(page).to have_css('.govuk-error-summary')
+    within '.govuk-error-summary' do
+      expect(page).to have_content('Unable to complete the search. Please adjust the search terms and try again.')
     end
 
     expect(page).to be_accessible.within '#main-content'

--- a/spec/features/search/cd_api/case_reference_spec.rb
+++ b/spec/features/search/cd_api/case_reference_spec.rb
@@ -83,7 +83,8 @@ RSpec.feature 'Case reference search', type: :feature, vcr: true, js: true do
     expect(page).not_to have_css('.govuk-body', text: 'There are no matching results')
     expect(page).to have_css('.govuk-error-summary')
     within '.govuk-error-summary' do
-      expect(page).to have_content('Unable to complete the search. Please adjust the search terms and try again.')
+      expect(page)
+        .to have_content('Unable to complete the search. Please adjust the search terms and try again.')
     end
 
     expect(page).to be_accessible.within '#main-content'

--- a/spec/models/cd_api/search_spec.rb
+++ b/spec/models/cd_api/search_spec.rb
@@ -121,8 +121,8 @@ RSpec.describe Search, type: :model do
         )
       end
 
-      it 'returns empty array' do
-        expect(search_instance.execute).to eq []
+      it 'returns correct exception' do
+        expect { search_instance.execute }.to raise_error(ActiveResource::BadRequest)
       end
     end
 
@@ -138,16 +138,10 @@ RSpec.describe Search, type: :model do
         allow(cdapi_search_service).to receive(:call).with(any_args).and_raise(
           ActiveResource::ServerError, 'Failed.'
         )
-        allow(Sentry).to receive(:capture_exception)
       end
 
-      it 'returns empty array' do
-        expect(search_instance.execute).to eq []
-      end
-
-      it 'send exception to Sentry' do
-        search_instance.execute
-        expect(Sentry).to have_received(:capture_exception)
+      it 'returns correct exception' do
+        expect { search_instance.execute }.to raise_error(ActiveResource::ServerError)
       end
     end
   end

--- a/spec/support/webmock/court_data_api/webmock.rb
+++ b/spec/support/webmock/court_data_api/webmock.rb
@@ -100,6 +100,15 @@ RSpec.configure do |config|
       )
   end
 
+  config.before(:each, stub_defendants_cda_failed: true) do
+    stub_request(:get, %r{http.*/v2/defendants})
+      .to_return(
+        status: 424,
+        body: '',
+        headers: { 'Content-Type' => 'application/json' }
+      )
+  end
+
   config.before(:each, stub_unlink_v2: true) do
     stub_request(
       :get,


### PR DESCRIPTION
#### What

Update the search page so that we reflect the error code being given to us. This means users will know if they are getting no results or if errors are occuring on the page. It also means we log and react to these errors

#### Ticket

[CDUI - Handle 424 on searches page](https://dsdmoj.atlassian.net/browse/CTSKF-403)

