### PR TITLE
CTSKF-438 Use short-lived ECR credentials

### DIFF
--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -23,7 +23,7 @@ function _circleci_build() {
   printf "\e[33mRegistry tag: $docker_registry_tag\e[0m\n"
   printf "\e[33m------------------------------------------------------------------------\e[0m\n"
   printf '\e[33mDocker login to registry (ECR)...\e[0m\n'
-  AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION} AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} aws ecr get-login-password | docker login --username AWS --password-stdin ${ECR_ENDPOINT}
+  AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION} aws ecr get-login-password | docker login --username AWS --password-stdin ${ECR_ENDPOINT}
 
   docker build \
     --build-arg BUILD_DATE=$(date +%Y-%m-%dT%H:%M:%S%z) \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,10 @@
 version: 2.1
 
 orbs:
+  aws-cli: circleci/aws-cli@4.0.0
+  browser-tools: circleci/browser-tools@1.1
   slack: circleci/slack@3.4.2
   snyk: snyk/snyk@1.1.2
-  browser-tools: circleci/browser-tools@1.1
 
 references:
   _restore-bundle: &restore-bundle
@@ -118,6 +119,12 @@ commands:
       - install-compile-assets
       - install-codeclimate-tt
 
+  aws-cli-setup:
+    steps:
+     - aws-cli/setup:
+        role_arn: $ECR_ROLE_TO_ASSUME
+        region: $ECR_REGION
+
   db-setup:
     steps:
       - run:
@@ -223,6 +230,7 @@ commands:
     steps:
       - checkout
       - setup_remote_docker
+      - aws-cli-setup
       - run:
           name: deploying to << parameters.environment >>
           command: |
@@ -295,6 +303,7 @@ jobs:
       - checkout
       - setup_remote_docker:
           docker_layer_caching: true
+      - aws-cli-setup
       - *script-build-app-container
 
   deploy-dev:

--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -59,7 +59,7 @@ function _circleci_deploy() {
   printf "\e[33mBranch: $CIRCLE_BRANCH\e[0m\n"
   printf "\e[33m--------------------------------------------------\e[0m\n"
   printf '\e[33mDocker login to registry (ECR)...\e[0m\n'
-  AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION} AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} aws ecr get-login-password | docker login --username AWS --password-stdin ${ECR_ENDPOINT}
+  AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION} aws ecr get-login-password | docker login --username AWS --password-stdin ${ECR_ENDPOINT}
 
   printf '\e[33mK8S Login...\e[0m\n'
   echo -n ${K8S_CLUSTER_CERT} | base64 -d > ./ca.crt


### PR DESCRIPTION
#### What

Implements changes mandated by Cloud Platform to deprecate the use of long-lived ECR credentials:

https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/container-repositories/deprecating-long-lived-credentials.html#migrating-to-short-lived-credentials-for-circleci

#### Ticket

[CTSKF-438](https://dsdmoj.atlassian.net/browse/CTSKF-438)

#### Why

To allow the service to continue to be built and deployed to the MOJ Cloud Platform, while increasing the security of the process

#### How

* Adds the `aw-cli` orb to `.circleci/config.yml`
* Configures that orb to use the new `ECR_REGION` and `ECR_ROLE_TO_ASSUME` environment variables before building or deploying the app.
* Removes unnecessary references to the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables from the `.circleci/build.sh` and `.circleci/deploy.sh` scripts.

Steps outside of this PR:
* Merged PR in the Cloud Platform Environment repo to enable short-lived creds
* Added the four new environment variables to the `laa-court-data-ui` project in CircleCI.
* Deleted the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables from the `laa-court-data-ui` project in CircleCI.


[CTSKF-438]: https://dsdmoj.atlassian.net/browse/CTSKF-438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ