### PR TITLE
CTSKF-475 BugFix Show any error messages provided during a LAA Reference unlinking exception

### DIFF
--- a/app/controllers/defendants_controller.rb
+++ b/app/controllers/defendants_controller.rb
@@ -105,14 +105,21 @@ class DefendantsController < ApplicationController
 
   def handle_client_error(exception)
     logger.info 'CLIENT_ERROR_OCCURRED'
-    @laa_reference.errors.from_json(exception.response.body)
+    exception_body_message(exception)
     render_edit(I18n.t('defendants.unlink.unprocessable'), @laa_reference.errors.full_messages.join(', '))
   end
 
   def handle_server_error(exception)
     logger.error 'SERVER_ERROR_OCCURRED'
-    log_sentry_error(exception, @laa_reference.errors)
-    render_edit(I18n.t('defendants.unlink.failure', error_messages: ''), I18n.t('error.it_helpdesk'))
+    log_sentry_error(exception, exception_body_message(exception))
+    render_edit(
+      I18n.t('defendants.unlink.failure',
+             error_messages: @laa_reference.errors.full_messages.join(', ')), I18n.t('error.it_helpdesk')
+    )
+  end
+
+  def exception_body_message(exception)
+    @laa_reference.errors.from_json(exception.response.body)
   end
 
   def unlink_laa_reference_and_redirect

--- a/app/controllers/defendants_controller.rb
+++ b/app/controllers/defendants_controller.rb
@@ -112,7 +112,7 @@ class DefendantsController < ApplicationController
   def handle_server_error(exception)
     logger.error 'SERVER_ERROR_OCCURRED'
     log_sentry_error(exception, @laa_reference.errors)
-    render_edit(I18n.t('defendants.unlink.failure'), I18n.t('error.it_helpdesk'))
+    render_edit(I18n.t('defendants.unlink.failure', error_messages: ''), I18n.t('error.it_helpdesk'))
   end
 
   def unlink_laa_reference_and_redirect

--- a/spec/requests/unlinking/unlink_defendant_maat_reference_v2_spec.rb
+++ b/spec/requests/unlinking/unlink_defendant_maat_reference_v2_spec.rb
@@ -66,9 +66,7 @@ RSpec.describe 'unlink defendant maat reference', type: :request, stub_unlink_v2
   end
   let(:maat_invalid_request) do
     {
-      # rubocop:disable Style/FormatStringToken
-      title: 'The link to the court data source could not be removed. %{error_messages}',
-      # rubocop:enable Style/FormatStringToken
+      title: 'The link to the court data source could not be removed. ',
       message: 'If this problem persists, please contact the IT Helpdesk on 0800 9175148.'
     }
   end

--- a/spec/requests/unlinking/unlink_defendant_maat_reference_v2_spec.rb
+++ b/spec/requests/unlinking/unlink_defendant_maat_reference_v2_spec.rb
@@ -70,6 +70,12 @@ RSpec.describe 'unlink defendant maat reference', type: :request, stub_unlink_v2
       message: 'If this problem persists, please contact the IT Helpdesk on 0800 9175148.'
     }
   end
+  let(:maat_invalid_request_with_message) do
+    {
+      title: 'The link to the court data source could not be removed. MAAT reference Fake error message here',
+      message: 'If this problem persists, please contact the IT Helpdesk on 0800 9175148.'
+    }
+  end
   let(:maat_invalid_username) do
     {
       title: 'Unable to unlink this defendant',
@@ -200,7 +206,7 @@ RSpec.describe 'unlink defendant maat reference', type: :request, stub_unlink_v2
       end
     end
 
-    context 'with Downstream error', stub_v2_unlink_cda_failure: true do
+    context 'with Downstream error and no error message', stub_v2_unlink_cda_failure: true do
       let(:query) { hash_including({ filter: { arrest_summons_number: defendant_asn_from_fixture } }) }
 
       before do
@@ -210,6 +216,23 @@ RSpec.describe 'unlink defendant maat reference', type: :request, stub_unlink_v2
 
       it 'flashes alert' do
         expect(flash.now[:alert]).to match(maat_invalid_request)
+      end
+
+      it 'renders edit_defendant_path' do
+        expect(response).to render_template('edit')
+      end
+    end
+
+    context 'with Downstream error and error message', stub_v2_unlink_cda_failure_with_message: true do
+      let(:query) { hash_including({ filter: { arrest_summons_number: defendant_asn_from_fixture } }) }
+
+      before do
+        patch "/defendants/#{defendant_id}?urn=#{prosecution_case_reference_from_fixture}",
+              params:
+      end
+
+      it 'flashes alert with error message' do
+        expect(flash.now[:alert]).to match(maat_invalid_request_with_message)
       end
 
       it 'renders edit_defendant_path' do

--- a/spec/support/webmock/court_data_api/webmock.rb
+++ b/spec/support/webmock/court_data_api/webmock.rb
@@ -167,6 +167,15 @@ RSpec.configure do |config|
     )
   end
 
+  config.before(:each, stub_v2_unlink_cda_failure_with_message: true) do
+    stub_request(
+      :patch, %r{/v2/laa_references/#{defendant_id}/}
+    ).to_return(
+      status: 500,
+      body: { 'errors' => { 'maat_reference' => ['Fake error message here'] } }.to_json
+    )
+  end
+
   config.before(:each, stub_v2_hearing_events: true) do
     stub_request(
       :get, %r{/v2/hearings/#{hearing_id}/hearing_events}


### PR DESCRIPTION
#### What

Fix exception handling for server/client error exceptions and embed the CDA error message into the default error message.

#### Ticket

[CTSKF-475](https://dsdmoj.atlassian.net/browse/CTSKF-475)

#### Why

This is so that if CDA decide to send a 404 with no error message for example then it doesn't show: `The link to the court data source could not be removed. %{error_messages}`

Also, if CDA sends an error message with the 4xx or 5xx error then we can display it within the error message. The code to implement it was there but it was just broken. This PR fixes it and assumes we want to show the CDA response error message to users.

#### How





What it looks like after the fix:
![What it looks like after the fix:](https://github.com/ministryofjustice/laa-court-data-ui/assets/25043924/2da5a9dd-b263-495b-b217-1c3384ea6d24)


What it looks like after the fix with an error message is in the exceptions body:
![What it looks like after the fix with an error message is in the exceptions body](https://github.com/ministryofjustice/laa-court-data-ui/assets/25043924/8d082a61-f8ab-4c90-82b0-e30770f5a3bb)


[CTSKF-475]: https://dsdmoj.atlassian.net/browse/CTSKF-475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ