### PR TITLE
CTSKF-476 BUGFIX Default error_messages parameter during MAAT unlinking

### DIFF
--- a/app/controllers/defendants_controller.rb
+++ b/app/controllers/defendants_controller.rb
@@ -112,7 +112,7 @@ class DefendantsController < ApplicationController
   def handle_server_error(exception)
     logger.error 'SERVER_ERROR_OCCURRED'
     log_sentry_error(exception, @laa_reference.errors)
-    render_edit(I18n.t('defendants.unlink.failure'), I18n.t('error.it_helpdesk'))
+    render_edit(I18n.t('defendants.unlink.failure', error_messages: ''), I18n.t('error.it_helpdesk'))
   end
 
   def unlink_laa_reference_and_redirect

--- a/spec/requests/unlinking/unlink_defendant_maat_reference_v2_spec.rb
+++ b/spec/requests/unlinking/unlink_defendant_maat_reference_v2_spec.rb
@@ -66,9 +66,7 @@ RSpec.describe 'unlink defendant maat reference', type: :request, stub_unlink_v2
   end
   let(:maat_invalid_request) do
     {
-      # rubocop:disable Style/FormatStringToken
-      title: 'The link to the court data source could not be removed. %{error_messages}',
-      # rubocop:enable Style/FormatStringToken
+      title: 'The link to the court data source could not be removed. ',
       message: 'If this problem persists, please contact the IT Helpdesk on 0800 9175148.'
     }
   end


### PR DESCRIPTION

#### What

Update the use of the 'defendants.unlink.failure' translation to use an empty string if there are no error_messages passed to it.

#### Ticket

[CTSKF-476](https://dsdmoj.atlassian.net/browse/CTSKF-476)

#### Why

This fixes an issue with code is seen in the error message when CDA does not return an error message in its response

#### How

use an empty string in the parameter of error_messages `I18n.t('defendants.unlink.failure', error_messages: '')`

--------

![current unlinking error message](https://github.com/ministryofjustice/laa-court-data-ui/assets/25043924/f253ec7c-a1bd-40e9-bc52-997f812e084a)


[CTSKF-476]: https://dsdmoj.atlassian.net/browse/CTSKF-476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ