### PR TITLE
[DRAFT] Proof of concept to reduce 404 http errors by blocking bot attack endpoint

### DIFF
--- a/.k8s/live/dev/ingress.yaml
+++ b/.k8s/live/dev/ingress.yaml
@@ -28,6 +28,11 @@ metadata:
         if ($http_spider_name ~* "crawlergo") {
           return 403;
         }
+
+        location ~* /wp-content {
+          deny all;
+          return 403;
+        }
 spec:
   ingressClassName: modsec
   rules:
@@ -39,7 +44,7 @@ spec:
             backend:
               service:
                 name: laa-court-data-ui-app-service
-                port: 
+                port:
                   number: 80
   tls:
     - hosts:


### PR DESCRIPTION
Block the endpoint /wp-content and return 403 Forbidden http status

We sometimes get spikes in 404 http errors due to
invalid endpoints and this will reduce those errors by immediately blocking and forbidding these endpoint calls.

We are super unlikely to use /wp-content endpoint as it is a php related endpoint and we use ruby/rails

#### What

#### Ticket

[board ticket description](link)

#### Why

#### How

--------

#### TODO (wip)

 - [ ] item 1
 - [X] item 2
 - [X] Has the Acceptance Criteria been met
