### PR TITLE
CTSKF-511 BugFix Temporarily set the webdriver chrome version to fix capybara tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -271,6 +271,7 @@ jobs:
       - browser-tools/install-chrome:
           chrome-version: 114.0.5735.90
           replace-existing: true
+      - run: sudo apt autoremove
       - rspec
       - persist_to_workspace:
           root: tmp

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   aws-cli: circleci/aws-cli@4.0.0
-  browser-tools: circleci/browser-tools@1.1
+  browser-tools: circleci/browser-tools@1.4.3
   slack: circleci/slack@3.4.2
   snyk: snyk/snyk@1.1.2
 
@@ -266,7 +266,9 @@ jobs:
       - checkout
       - restore-dependencies
       - *attach-tmp-workspace
-      - browser-tools/install-browser-tools
+      - browser-tools/install-chrome:
+          chrome-version: 114.0.5735.90
+          replace-existing: true
       - rspec
       - persist_to_workspace:
           root: tmp

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -266,6 +266,8 @@ jobs:
       - checkout
       - restore-dependencies
       - *attach-tmp-workspace
+      # TODO: Remove the apt-get update and install-chrome steps after webdriver gem has fixed its chrome compatibility issue.
+      - run: sudo apt-get update
       - browser-tools/install-chrome:
           chrome-version: 114.0.5735.90
           replace-existing: true

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -30,6 +30,8 @@ module Capybara
   Node::Simple.include CapybaraExtensions::Matchers
 end
 
+Webdrivers::Chromedriver.required_version = "114.0.5735.90"
+
 Capybara.configure do |config|
   # https://www.rubydoc.info/github/jnicklas/capybara/Capybara.configure
   config.automatic_label_click = true

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -30,6 +30,7 @@ module Capybara
   Node::Simple.include CapybaraExtensions::Matchers
 end
 
+# TODO: Remove this line when the latest stable version of chrome works with our rspec/capybara tests
 Webdrivers::Chromedriver.required_version = '114.0.5735.90'
 
 Capybara.configure do |config|

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -30,7 +30,7 @@ module Capybara
   Node::Simple.include CapybaraExtensions::Matchers
 end
 
-Webdrivers::Chromedriver.required_version = "114.0.5735.90"
+Webdrivers::Chromedriver.required_version = '114.0.5735.90'
 
 Capybara.configure do |config|
   # https://www.rubydoc.info/github/jnicklas/capybara/Capybara.configure


### PR DESCRIPTION
#### What

Fix our automated feature tests by setting the version of the chrome browser for our WebDriver gem to a previous version `114.0.5735.90` temporarily until they fix their gem issue.

This fixes an error in our [CircleCI rspec tests](https://app.circleci.com/pipelines/github/ministryofjustice/laa-court-data-ui/8587/workflows/1a079992-76bb-4d36-8ecd-22d2ee987fa5/jobs/34156) that returns 404 for the latest version of chrome
```
Installed version of Google Chrome is 115.0.5790.102
curl: (22) The requested URL returned error: 404
```

#### Ticket

[CTSKF-511](https://dsdmoj.atlassian.net/browse/CTSKF-511)

#### Why

This will unblock our CI/CD pipeline so we can ship dependency updates and keep our application up to date, secure and reliable.

#### How

Set the version of the webdriver's chrome to `114.0.5735.90`

```
apt-get update adds a new package called 'google-chrome-stable' which  fixed the browser-tools issue around being unable to install version 114 of chrome. Now it's fixed, it does say `324 MB of additional disk space will be used`

i'll look into how that can be reduced. maybe it's automatically cached by circleci after the first install 🤞🏾 
```

#### More information

chrome release versions
https://chromedriver.chromium.org/downloads

Breaking change by chrome
https://groups.google.com/g/chromedriver-users/c/clpipqvOGjE/m/5NxzS_SRAgAJ

CircleCi browser-tools orb release:
https://github.com/CircleCI-Public/browser-tools-orb/releases


[CTSKF-511]: https://dsdmoj.atlassian.net/browse/CTSKF-511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ