### PR TITLE
CTSKF-511 grouped ruby dependency updates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'devise', '~> 4.9'
 gem 'govuk_notify_rails', '~> 2.2.0'
 
 # rails GDS design system form builder
-gem 'govuk_design_system_formbuilder', '~> 4.0'
+gem 'govuk_design_system_formbuilder', '~> 4.1'
 gem 'haml-rails', '~> 2.1.0'
 gem 'json_api_client', '~> 1.21'
 gem 'json-schema', '~> 4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,7 +182,7 @@ GEM
     foreman (0.87.2)
     globalid (1.1.0)
       activesupport (>= 5.0)
-    govuk_design_system_formbuilder (4.0.0)
+    govuk_design_system_formbuilder (4.1.0)
       actionview (>= 6.1)
       activemodel (>= 6.1)
       activesupport (>= 6.1)
@@ -258,7 +258,7 @@ GEM
     matrix (0.4.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
-    mini_portile2 (2.8.2)
+    mini_portile2 (2.8.4)
     minitest (5.18.1)
     msgpack (1.6.0)
     multi_xml (0.6.0)
@@ -525,7 +525,7 @@ DEPENDENCIES
   factory_bot_rails
   faker
   foreman
-  govuk_design_system_formbuilder (~> 4.0)
+  govuk_design_system_formbuilder (~> 4.1)
   govuk_notify_rails (~> 2.2.0)
   haml-rails (~> 2.1.0)
   haml_lint

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -199,7 +199,7 @@ GEM
       activesupport (>= 5.1)
       haml (>= 4.0.6)
       railties (>= 5.1)
-    haml_lint (0.47.0)
+    haml_lint (0.49.0)
       haml (>= 4.0, < 6.2)
       parallel (~> 1.10)
       rainbow

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -385,7 +385,7 @@ GEM
     rspec-support (3.12.0)
     rspec_junit_formatter (0.6.0)
       rspec-core (>= 2, < 4, != 2.12.0)
-    rubocop (1.54.1)
+    rubocop (1.54.2)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -436,7 +436,7 @@ GEM
       connection_pool (>= 2.3.0)
       rack (>= 2.2.4)
       redis-client (>= 0.14.0)
-    sidekiq_alive (2.2.2)
+    sidekiq_alive (2.2.3)
       rack (< 3)
       sidekiq (>= 5, < 8)
       webrick (>= 1, < 2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,7 +100,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.16.0)
       msgpack (~> 1.2)
-    brakeman (6.0.0)
+    brakeman (6.0.1)
     breadcrumbs_on_rails (4.1.0)
       railties (>= 5.0)
     builder (3.2.4)

--- a/app/views/layouts/_phase_banner.html.haml
+++ b/app/views/layouts/_phase_banner.html.haml
@@ -7,5 +7,3 @@
         = ENV.fetch('ENV', 'local')
     %span.govuk-phase-banner__text
       = t('layouts.application.header.phase_banner_html', feedback: new_feedback_path)
-
-


### PR DESCRIPTION
#### What

Group Ruby Dependabot minor and patch updates

#### Ticket

[CTSKF-511](https://dsdmoj.atlassian.net/browse/CTSKF-511)

#### Why

Updating our dependencies helps to keep our application secure and working as expected

Grouping the Dependabot saves a lot of time testing and deploying.

#### How

[Bump sidekiq_alive from 2.2.2 to 2.2.3](https://github.com/ministryofjustice/laa-court-data-ui/pull/1620)
[Bump brakeman from 6.0.0 to 6.0.1](https://github.com/ministryofjustice/laa-court-data-ui/pull/1619)
[Bump rubocop from 1.54.1 to 1.54.2](https://github.com/ministryofjustice/laa-court-data-ui/pull/1611)
[Bump haml_lint from 0.47.0 to 0.49.0](https://github.com/ministryofjustice/laa-court-data-ui/pull/1612)
[Bump govuk_design_system_formbuilder from 4.0.0 to 4.1.0](https://github.com/ministryofjustice/laa-court-data-ui/pull/1610)

[CTSKF-511]: https://dsdmoj.atlassian.net/browse/CTSKF-511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ