### PR TITLE
CTSKF-511 Undo the fixing of the chrome webdriver version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -268,9 +268,7 @@ jobs:
       - *attach-tmp-workspace
       # TODO: Remove the apt-get update and install-chrome steps after webdriver gem has fixed its chrome compatibility issue.
       - run: sudo apt-get update
-      - browser-tools/install-chrome:
-          chrome-version: 114.0.5735.90
-          replace-existing: true
+      - browser-tools/install-chrome
       - run: sudo apt autoremove
       - rspec
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -266,7 +266,6 @@ jobs:
       - checkout
       - restore-dependencies
       - *attach-tmp-workspace
-      # TODO: Remove the apt-get update and install-chrome steps after webdriver gem has fixed its chrome compatibility issue.
       - run: sudo apt-get update
       - browser-tools/install-chrome
       - run: sudo apt autoremove

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -30,9 +30,6 @@ module Capybara
   Node::Simple.include CapybaraExtensions::Matchers
 end
 
-# TODO: Remove this line when the latest stable version of chrome works with our rspec/capybara tests
-Webdrivers::Chromedriver.required_version = '114.0.5735.90'
-
 Capybara.configure do |config|
   # https://www.rubydoc.info/github/jnicklas/capybara/Capybara.configure
   config.automatic_label_click = true


### PR DESCRIPTION
#### What

- Use the latests chrome webdriver version as part of tests
- Remove the fixed older version of chrome
- This reverts the temporary fix of this PR https://github.com/ministryofjustice/laa-court-data-ui/pull/1623

#### Ticket

[CTSKF-511](https://dsdmoj.atlassian.net/browse/CTSKF-511)

#### Why

So that the chrome web driver is using the latest version and thus the feature tests run on something more akin to what users are using atm.

#### How

Remove the fixing of the chrome web driver version in the circle config and the capybara config file


[CTSKF-511]: https://dsdmoj.atlassian.net/browse/CTSKF-511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ