### PR TITLE
CTSKF-590 Add gem selenium-webdriver

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ group :test do
   gem 'shoulda-matchers'
   gem 'simplecov', require: false
   gem 'vcr'
-  gem 'webdrivers'
+  gem 'selenium-webdriver', '~> 4.14'
   gem 'webmock'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -417,7 +417,7 @@ GEM
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
-    selenium-webdriver (4.10.0)
+    selenium-webdriver (4.14.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
@@ -489,16 +489,12 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (5.3.1)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0, < 4.11)
     webmock (3.19.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    websocket (1.2.9)
+    websocket (1.2.10)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -556,6 +552,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   rubocop-rspec
+  selenium-webdriver (~> 4.14)
   sentry-rails (~> 5.11.0)
   sentry-sidekiq (~> 5.11.0)
   shoulda-matchers
@@ -569,7 +566,6 @@ DEPENDENCIES
   tzinfo-data
   vcr
   web-console (>= 4.2.0)
-  webdrivers
   webmock
 
 RUBY VERSION


### PR DESCRIPTION
#### What

Add gem selenium-webdriver and remove webdrivers

#### Ticket

[CTSKF-590](https://dsdmoj.atlassian.net/browse/CTSKF-590)

#### Why

This will unblock the dependency update https://github.com/ministryofjustice/laa-court-data-ui/pull/1738

Also, it will mean we are using the latest selenium driver technology to run our capybara tests as the webdrivers gem goes end of life for us as described in their readme:

> If you can update to the latest version of Selenium (4.11+), please do so and stop requiring this gem

#### How

Add gem selenium-webdriver
Remove gem webdrivers
