### PR TITLE
CTSKF-606 BugFix Revert @rails/ujs back to 7.0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@babel/preset-env": "^7.23.2",
     "@hotwired/turbo-rails": "^7.3.0",
     "@ministryofjustice/frontend": "^1.8.0",
-    "@rails/ujs": "^7.1.1",
+    "@rails/ujs": "7.0.8",
     "babel-loader": "^9.1.3",
     "babel-plugin-macros": "^3.1.0",
     "css-loader": "^6.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1386,10 +1386,10 @@
   resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-7.0.3.tgz#71f08e958883af64f6a20489318b5e95d2c6dc5b"
   integrity sha512-Iefl21FZD+ck1di6xSHMYzSzRiNJTHV4NrAzCfDfqc/wPz4xncrP8f2/fJ+2jzwKIaDn76UVMsALh7R5OzsF8Q==
 
-"@rails/ujs@^7.1.1":
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/@rails/ujs/-/ujs-7.1.1.tgz#f8df96e406a2a824084b637880e57c257073cb05"
-  integrity sha512-ywGwWNiqXN3Bb1BifVQTrkWEWcAGLHW3D0JNQMQeu57LsoluRzvnenNLPsmdoDPkrmSIASDXNsJiCIpUzFj8CA==
+"@rails/ujs@7.0.8":
+  version "7.0.8"
+  resolved "https://registry.yarnpkg.com/@rails/ujs/-/ujs-7.0.8.tgz#59853367d0827b3955d2c4bedfd5eba4a79d3422"
+  integrity sha512-tOQQBVH8LsUpGXqDnk+kaOGVsgZ8maHAhEiw3Git3p88q+c0Slgu47HuDnL6sVxeCfz24zbq7dOjsVYDiTpDIA==
 
 "@sideway/address@^4.1.3":
   version "4.1.4"


### PR DESCRIPTION
#### What

Revert @rails/ujs back to 7.0.8

#### Ticket

[CTSKF-606](https://dsdmoj.atlassian.net/browse/CTSKF-606)

#### Why

This is because of a breaking change introduced by rails/ujs version 7.1.1 that caused the user sign_out feature to not work / redirect them to a not found / 404 page

#### How

set the version to 7.0.8 temporarily because the next version 7.1.1 introduces a breaking change. On sign out, it sends users to a page not found.

--------

![image](https://github.com/ministryofjustice/laa-court-data-ui/assets/25043924/98587b4d-72ba-4ec3-88bd-4891235c630f)

I ran this locally and it looked like this:

![image](https://github.com/ministryofjustice/laa-court-data-ui/assets/25043924/15445198-bac4-4b94-bc54-b2ac7a4ef674)


[CTSKF-606]: https://dsdmoj.atlassian.net/browse/CTSKF-606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ