### PR TITLE
CTSKF-606 BugFix Users are being sent to /404 page after sign out

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -3,6 +3,13 @@
 class Users::SessionsController < Devise::SessionsController
   skip_authorization_check only: %i[new create destroy update_cookies]
 
+  def destroy
+    super do
+      # Turbo requires redirects be :see_other (303); so override Devise default (302)
+      return redirect_to after_sign_out_path_for(resource_name), status: :see_other
+    end
+  end
+
   # before_action :configure_sign_in_params, only: [:create]
 
   # GET /resource/sign_in

--- a/app/views/layouts/_navigation.html.haml
+++ b/app/views/layouts/_navigation.html.haml
@@ -20,4 +20,5 @@
       = link_to t('layouts.application.header.navigation.sign_out'),
           destroy_user_session_path,
           method: :delete,
+          data: { turbo_method: :delete },
           class: 'govuk-header__link'


### PR DESCRIPTION
#### What

Fix the user sign out feature after a bug was introduced by this PR [@rails/ujs to 7.1.1]  (https://github.com/ministryofjustice/laa-court-data-ui/pull/1738) 

#### Ticket

[CTSKF-606](https://dsdmoj.atlassian.net/browse/CTSKF-606)

#### Why

In order to use Turbo for the link_to user destroy method. This was after upgrading [@rails/ujs to 7.1.1]  (https://github.com/ministryofjustice/laa-court-data-ui/pull/1738) which caused our cucumber tests to break around the alert box after deleting a user. The solution to that was to use Turbo - the new way of doing what @rails/ujs did. There may be a flickering cucumber test but not nearly as much as when we used rails/ujs for the alertboxes.


#### How

Override Devise destroy method to use the :see_other http status 303 because this will Turbo rails requires it to.


#### more info:
on github devise/issues/5458



[CTSKF-606]: https://dsdmoj.atlassian.net/browse/CTSKF-606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ