### PR TITLE
CTSKF-615 BugFix Alert box not appearing in tests after deleting a user

### DIFF
--- a/spec/features/users/delete_user_spec.rb
+++ b/spec/features/users/delete_user_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature 'Delete user', :js, type: :feature do
       within row do
         find_link('Delete').click
       end
-
+      sleep 1.second
       warning = page.driver.browser.switch_to.alert
       expect(warning.text).to eql "Are you sure you want to delete #{other_user.name}'s account?"
       warning.accept

--- a/spec/features/users/delete_user_spec.rb
+++ b/spec/features/users/delete_user_spec.rb
@@ -14,12 +14,10 @@ RSpec.feature 'Delete user', :js, type: :feature do
 
       row = page.find(%(tr[data-user-id="#{other_user.id}"]))
       within row do
-        find_link('Delete').click
+        accept_alert("Are you sure you want to delete #{other_user.name}'s account?", wait: 2) do
+          find_link('Delete').click
+        end
       end
-      sleep 1.second
-      warning = page.driver.browser.switch_to.alert
-      expect(warning.text).to eql "Are you sure you want to delete #{other_user.name}'s account?"
-      warning.accept
 
       expect(page).to have_current_path(users_path)
       expect(page).to have_govuk_flash(:notice, text: 'User successfully deleted')


### PR DESCRIPTION
#### What

Wait for up to 2 seconds for the modal/alert box to appear.

#### Ticket

[CTSKF-615](https://dsdmoj.atlassian.net/browse/CTSKF-615)

#### Why

This should hopefully fix the flickering test in our CI/CD tests:

Failures:

  1) Delete user when manager can index and delete users
     Failure/Error: warning = page.driver.browser.switch_to.alert

     Selenium::WebDriver::Error::NoSuchAlertError:
       no such alert
         (Session info: headless chrome=[redacted])

#### How

Use [Capybara::Session#accept_alert](https://www.rubydoc.info/gems/capybara/Capybara%2FSession:accept_alert) to wait for the alert box for up to 2 seconds.

[CTSKF-615]: https://dsdmoj.atlassian.net/browse/CTSKF-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ