### PR TITLE
CTSKF-685 Update ruby dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby '3.1.2'
 
-gem 'activeresource', '~> 6.0.0'
+gem 'activeresource', '~> 6.1.0'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.7.0', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,7 +58,7 @@ GEM
     activerecord (7.0.8)
       activemodel (= 7.0.8)
       activesupport (= 7.0.8)
-    activeresource (6.0.0)
+    activeresource (6.1.0)
       activemodel (>= 6.0)
       activemodel-serializers-xml (~> 1.0)
       activesupport (>= 6.0)
@@ -506,7 +506,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activeresource (~> 6.0.0)
+  activeresource (~> 6.1.0)
   awesome_print
   axe-core-rspec (~> 4.8)
   bootsnap (>= 1.7.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -199,8 +199,8 @@ GEM
       activesupport (>= 5.1)
       haml (>= 4.0.6)
       railties (>= 5.1)
-    haml_lint (0.52.0)
-      haml (>= 4.0)
+    haml_lint (0.55.0)
+      haml (>= 5.0)
       parallel (~> 1.10)
       rainbow
       rubocop (>= 1.0)
@@ -287,7 +287,7 @@ GEM
       version_gem (~> 1.1)
     orm_adapter (0.5.0)
     parallel (1.24.0)
-    parser (3.3.0.4)
+    parser (3.3.0.5)
       ast (~> 2.4.1)
       racc
     pg (1.5.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,7 +74,7 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-    addressable (2.8.5)
+    addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     awesome_print (1.9.2)
@@ -107,11 +107,11 @@ GEM
     builder (3.2.4)
     byebug (11.1.3)
     cancancan (3.5.0)
-    capybara (3.39.2)
+    capybara (3.40.0)
       addressable
       matrix
       mini_mime (>= 0.1.3)
-      nokogiri (~> 1.8)
+      nokogiri (~> 1.11)
       rack (>= 1.6.0)
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,10 +78,10 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     awesome_print (1.9.2)
-    axe-core-api (4.8.0)
+    axe-core-api (4.8.1)
       dumb_delegator
       virtus
-    axe-core-rspec (4.8.0)
+    axe-core-rspec (4.8.1)
       axe-core-api
       dumb_delegator
       virtus

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -374,7 +374,7 @@ GEM
     rspec-mocks (3.12.6)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-rails (6.1.0)
+    rspec-rails (6.1.1)
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       railties (>= 6.1)


### PR DESCRIPTION
#### What

1. Group Ruby Dependabot minor and patch updates

#### Ticket

[CTSKF-685](https://dsdmoj.atlassian.net/browse/CTSKF-685)

#### Why

Updating our dependencies helps to keep our application secure and working as expected

Grouping the Dependabot saves a lot of time testing and deploying.

#### How
[Bump capybara from 3.39.2 to 3.40.0](https://github.com/ministryofjustice/laa-court-data-ui/pull/1880)
[Bump rspec-rails from 6.1.0 to 6.1.1](https://github.com/ministryofjustice/laa-court-data-ui/pull/1875)
[Bump activeresource from 6.0.0 to 6.1.0](https://github.com/ministryofjustice/laa-court-data-ui/pull/1873)
[Bump haml_lint from 0.52.0 to 0.55.0](https://github.com/ministryofjustice/laa-court-data-ui/pull/1870)
[Bump axe-core-rspec from 4.8.0 to 4.8.1](https://github.com/ministryofjustice/laa-court-data-ui/pull/1863)

[CTSKF-685]: https://dsdmoj.atlassian.net/browse/CTSKF-685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ