### PR TITLE
Get the Defendant MAAT Reference from the offence_summaries array

### DIFF
--- a/app/models/cd_api/defendant.rb
+++ b/app/models/cd_api/defendant.rb
@@ -8,6 +8,10 @@ module CdApi
       maat_references.first.present? && maat_references.first.first != 'Z'
     end
 
+    def maat_reference
+      maat_references.first
+    end
+
     private
 
     def maat_references

--- a/app/views/defendants/_defendant.html.haml
+++ b/app/views/defendants/_defendant.html.haml
@@ -26,6 +26,6 @@
       %th.govuk-table__header{ scope: 'row' }
         = t('search.result.defendant.maat_number')
       %td.govuk-table__cell
-        = Feature.enabled?(:defendants_page) ? defendant.representation_order.laa_application_reference : defendant.maat_reference
+        = defendant.maat_reference
 
 = link_to 'View case', prosecution_case_path(prosecution_case_reference), class: 'govuk-button govuk-button--secondary govuk-!-margin-bottom-9'

--- a/spec/models/cd_api/defendant_spec.rb
+++ b/spec/models/cd_api/defendant_spec.rb
@@ -31,4 +31,23 @@ RSpec.describe CdApi::Defendant, type: :model do
       it { is_expected.to be_falsey }
     end
   end
+
+  describe '#maat_reference' do
+    subject { defendant.maat_reference }
+
+    let(:defendant) { build(:defendant, offence_summaries:) }
+    let(:offence_summaries) { [build(:offence_summary, laa_application:)] }
+
+    context 'when maat_reference present' do
+      let(:laa_application) { build(:laa_application, reference: '2123456') }
+
+      it { is_expected.to be_truthy }
+    end
+
+    context 'when maat_reference not present' do
+      let(:laa_application) { build(:laa_application, reference: '') }
+
+      it { is_expected.to be_empty }
+    end
+  end
 end


### PR DESCRIPTION
### 


#### What

Get the V2 Defendant **MAAT Reference** from the `defendant_summaries["offence_summaries"]` array

#### Ticket

[board ticket description](link)

#### Why

The true source of maat_reference in the V2 API is from the `defendant_summaries["offence_summaries"]` data not from the `defendant_summaries["representation_order"]`.

#### How

- Add maat_reference method to CDAPI::Defendant model
- Get the maat_reference from the offence_summaries not the representation_order object in the defendant results json
- Update test for the new public method CDAPI::Defendant#maat_reference
