### PR TITLE
Ctskf 705 dependabot pr

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,7 @@ group :test do
   gem 'rubocop-performance', require: false
   gem 'rubocop-rails', require: false
   gem 'rubocop-rspec', require: false
-  gem 'selenium-webdriver', '~> 4.17'
+  gem 'selenium-webdriver', '~> 4.18'
   gem 'shoulda-matchers'
   gem 'simplecov', require: false
   gem 'vcr'

--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ gem 'sentry-rails', '~> 5.16.1'
 gem 'sentry-sidekiq', '~> 5.16.1'
 gem 'sidekiq', '~> 7.2.2'
 gem 'sidekiq_alive'
-gem 'turbo-rails', '~> 2.0.1'
+gem 'turbo-rails', '~> 2.0.3'
 
 group :test do
   gem 'axe-core-rspec', '~> 4.8'

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'devise', '~> 4.9'
 gem 'govuk_notify_rails', '~> 2.2.0'
 
 # rails GDS design system form builder
-gem 'govuk_design_system_formbuilder', '~> 5.0'
+gem 'govuk_design_system_formbuilder', '~> 5.1'
 gem 'haml-rails', '~> 2.1.0'
 gem 'json_api_client', '~> 1.22'
 gem 'json-schema', '~> 4.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -185,7 +185,7 @@ GEM
     foreman (0.87.2)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    govuk_design_system_formbuilder (5.0.0)
+    govuk_design_system_formbuilder (5.1.0)
       actionview (>= 6.1)
       activemodel (>= 6.1)
       activesupport (>= 6.1)
@@ -525,7 +525,7 @@ DEPENDENCIES
   factory_bot_rails
   faker
   foreman
-  govuk_design_system_formbuilder (~> 5.0)
+  govuk_design_system_formbuilder (~> 5.1)
   govuk_notify_rails (~> 2.2.0)
   haml-rails (~> 2.1.0)
   haml_lint

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -421,7 +421,7 @@ GEM
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
-    selenium-webdriver (4.17.0)
+    selenium-webdriver (4.18.1)
       base64 (~> 0.2)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
@@ -556,7 +556,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   rubocop-rspec
-  selenium-webdriver (~> 4.17)
+  selenium-webdriver (~> 4.18)
   sentry-rails (~> 5.16.1)
   sentry-sidekiq (~> 5.16.1)
   shoulda-matchers

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -473,7 +473,7 @@ GEM
     thread_safe (0.3.6)
     tilt (2.3.0)
     timeout (0.4.1)
-    turbo-rails (2.0.1)
+    turbo-rails (2.0.3)
       actionpack (>= 6.0.0)
       activejob (>= 6.0.0)
       railties (>= 6.0.0)
@@ -566,7 +566,7 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.1.0)
   sprockets-rails (~> 3.4)
-  turbo-rails (~> 2.0.1)
+  turbo-rails (~> 2.0.3)
   tzinfo-data
   vcr
   web-console (>= 4.2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,7 +128,7 @@ GEM
     colorize (1.1.0)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
-    crack (0.4.6)
+    crack (1.0.0)
       bigdecimal
       rexml
     crass (1.0.6)
@@ -493,7 +493,7 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webmock (3.20.0)
+    webmock (3.21.2)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "postcss": "^8.4.35",
     "sass": "^1.71.0",
     "sass-loader": "^13.3.3",
-    "webpack": "^5.90.1",
+    "webpack": "^5.90.3",
     "webpack-cli": "^5.1.4",
     "webpack-remove-empty-scripts": "^1.0.4"
   },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "jquery": "3.7.1",
     "mini-css-extract-plugin": "^2.8.0",
     "postcss": "^8.4.35",
-    "sass": "^1.70.0",
+    "sass": "^1.71.0",
     "sass-loader": "^13.3.3",
     "webpack": "^5.90.1",
     "webpack-cli": "^5.1.4",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@babel/plugin-proposal-private-methods": "^7.18.6",
     "@babel/plugin-transform-runtime": "^7.23.9",
     "@babel/preset-env": "^7.23.9",
-    "@hotwired/turbo-rails": "^8.0.1",
+    "@hotwired/turbo-rails": "^8.0.2",
     "@ministryofjustice/frontend": "^1.8.1",
     "@rails/ujs": "^7.1.3",
     "babel-loader": "^9.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4912,10 +4912,10 @@ sass-loader@^13.3.3:
   dependencies:
     neo-async "^2.6.2"
 
-sass@^1.70.0:
-  version "1.70.0"
-  resolved "https://registry.yarnpkg.com/sass/-/sass-1.70.0.tgz#761197419d97b5358cb25f9dd38c176a8a270a75"
-  integrity sha512-uUxNQ3zAHeAx5nRFskBnrWzDUJrrvpCPD5FNAoRvTi0WwremlheES3tg+56PaVtCs5QDRX5CBLxxKMDJMEa1WQ==
+sass@^1.71.0:
+  version "1.71.0"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.71.0.tgz#b3085759b9b2ab503a977aecb7e91153bf941117"
+  integrity sha512-HKKIKf49Vkxlrav3F/w6qRuPcmImGVbIXJ2I3Kg0VMA+3Bav+8yE9G5XmP5lMj6nl4OlqbPftGAscNaNu28b8w==
   dependencies:
     chokidar ">=3.0.0 <4.0.0"
     immutable "^4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5660,10 +5660,10 @@ webpack-sources@^3.2.3:
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.3.tgz#2d4daab8451fd4b240cc27055ff6a0c2ccea0cde"
   integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
 
-webpack@^5.90.1:
-  version "5.90.1"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.90.1.tgz#62ab0c097d7cbe83d32523dbfbb645cdb7c3c01c"
-  integrity sha512-SstPdlAC5IvgFnhiRok8hqJo/+ArAbNv7rhU4fnWGHNVfN59HSQFaxZDSAL3IFG2YmqxuRs+IU33milSxbPlog==
+webpack@^5.90.3:
+  version "5.90.3"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.90.3.tgz#37b8f74d3ded061ba789bb22b31e82eed75bd9ac"
+  integrity sha512-h6uDYlWCctQRuXBs1oYpVe6sFcWedl0dpcVaTf/YF67J9bKvwJajFulMVSYKHrksMB3I/pIagRzDxwxkebuzKA==
   dependencies:
     "@types/eslint-scope" "^3.7.3"
     "@types/estree" "^1.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1252,18 +1252,18 @@
   dependencies:
     "@hapi/hoek" "^9.0.0"
 
-"@hotwired/turbo-rails@^8.0.1":
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/@hotwired/turbo-rails/-/turbo-rails-8.0.1.tgz#361544d73bb70ab157578cd2ad7b32159fe017ec"
-  integrity sha512-E4um0sxC3d4Tts7HCDMjwFILs3FBsuv0hI7MU9srseFgOZLoRVJHI8aAa46ws9sdXOuOjbjeH38d5affhd7shg==
+"@hotwired/turbo-rails@^8.0.2":
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/@hotwired/turbo-rails/-/turbo-rails-8.0.2.tgz#c43d54d9346bcf14c897166556bfed92ed4c1d17"
+  integrity sha512-j+6THPc+CsaUdUXZTg6wQ+YcStO9kn6CuGzElqFxUmV/vyd1Jfm0RLZMIbaY8w9Qse7u6JBcrm4AcRxhIhYmaQ==
   dependencies:
-    "@hotwired/turbo" "^8.0.1"
+    "@hotwired/turbo" "^8.0.2"
     "@rails/actioncable" "^7.0"
 
-"@hotwired/turbo@^8.0.1":
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/@hotwired/turbo/-/turbo-8.0.1.tgz#0f4be48f43e96237181b31879258498b9f0d15d6"
-  integrity sha512-6DdRoFV8p1qM2YxieZ0McSzFfdKHH85FQn3C8UpLDgyD1UDb3ERhUsXg65M6nPuZeHtBZLY4hUumMdaAP0N1+w==
+"@hotwired/turbo@^8.0.2":
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/@hotwired/turbo/-/turbo-8.0.2.tgz#c31cdadfe66b98983066a94073b26fc7e15835f0"
+  integrity sha512-3K6QZkwWfosAV8zuM5bY+kKF02jp1lMQGsWfSE6wXdZBRBP3ah+Vj26YNqYtkEomBwRWA0QKhZgyJP7xOQkVEg==
 
 "@humanwhocodes/config-array@^0.11.8":
   version "0.11.8"


### PR DESCRIPTION
#### What
Bump @hotwired/turbo-rails from 8.0.1 to 8.0.2 #1912
Bump sass from 1.70.0 to 1.71.0 #1921
Bump turbo-rails from 2.0.1 to 2.0.3 #1924
[Bump govuk_design_system_formbuilder from 5.0.0 to 5.1.0](https://github.com/ministryofjustice/laa-court-data-ui/pull/1927)
Bump selenium-webdriver from 4.17.0 to 4.18.1 #1928
Bump webpack from 5.90.1 to 5.90.3 #1929
Bump webmock from 3.20.0 to 3.21.2 #1931

#### Ticket
Release of dependency and security updates - Sprint I[CTSKF-705](https://dsdmoj.atlassian.net/browse/CTSKF-705)

#### Why
Update dependencies by grouping Dependabot updates in order to keep our app up to date with security fixes/patches and feature updates so that it continues to run successfully, accurately and securely.