### PR TITLE
Dependency updates - 20240425

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ group :test do
   gem 'rspec-html-matchers', '~> 0.10.0'
   gem 'rspec_junit_formatter'
   gem 'rspec-rails', '~> 6.1'
-  gem 'rubocop', '~> 1.62', require: false
+  gem 'rubocop', '~> 1.63', require: false
   gem 'rubocop-performance', require: false
   gem 'rubocop-rails', require: false
   gem 'rubocop-rspec', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'devise', '~> 4.9'
 gem 'govuk_notify_rails', '~> 2.2.0'
 
 # rails GDS design system form builder
-gem 'govuk_design_system_formbuilder', '~> 5.2'
+gem 'govuk_design_system_formbuilder', '~> 5.3'
 gem 'haml-rails', '~> 2.1.0'
 gem 'json_api_client', '~> 1.22'
 gem 'json-schema', '~> 4.2'

--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,7 @@ group :test do
   gem 'rubocop-performance', require: false
   gem 'rubocop-rails', require: false
   gem 'rubocop-rspec', require: false
-  gem 'selenium-webdriver', '~> 4.18'
+  gem 'selenium-webdriver', '~> 4.20'
   gem 'shoulda-matchers'
   gem 'simplecov', require: false
   gem 'vcr'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -457,7 +457,7 @@ GEM
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
-    spring (4.1.3)
+    spring (4.2.1)
     spring-watcher-listen (2.1.0)
       listen (>= 2.7, < 4.0)
       spring (>= 4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -423,7 +423,7 @@ GEM
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
-    selenium-webdriver (4.18.1)
+    selenium-webdriver (4.20.0)
       base64 (~> 0.2)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
@@ -559,7 +559,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   rubocop-rspec
-  selenium-webdriver (~> 4.18)
+  selenium-webdriver (~> 4.20)
   sentry-rails (~> 5.17.1)
   sentry-sidekiq (~> 5.17.1)
   shoulda-matchers

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -231,7 +231,7 @@ GEM
     ice_nine (0.11.2)
     jsbundling-rails (1.3.0)
       railties (>= 6.0.0)
-    json (2.7.1)
+    json (2.7.2)
     json-schema (4.2.0)
       addressable (>= 2.8)
     json_api_client (1.22.0)
@@ -391,7 +391,7 @@ GEM
     rspec-support (3.13.1)
     rspec_junit_formatter (0.6.0)
       rspec-core (>= 2, < 4, != 2.12.0)
-    rubocop (1.62.1)
+    rubocop (1.63.3)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
@@ -555,7 +555,7 @@ DEPENDENCIES
   rspec-html-matchers (~> 0.10.0)
   rspec-rails (~> 6.1)
   rspec_junit_formatter
-  rubocop (~> 1.62)
+  rubocop (~> 1.63)
   rubocop-performance
   rubocop-rails
   rubocop-rspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -186,7 +186,7 @@ GEM
     foreman (0.87.2)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    govuk_design_system_formbuilder (5.2.0)
+    govuk_design_system_formbuilder (5.3.3)
       actionview (>= 6.1)
       activemodel (>= 6.1)
       activesupport (>= 6.1)
@@ -264,7 +264,7 @@ GEM
     matrix (0.4.2)
     method_source (1.0.0)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.5)
+    mini_portile2 (2.8.6)
     minitest (5.22.3)
     msgpack (1.7.2)
     multi_xml (0.6.0)
@@ -279,7 +279,7 @@ GEM
     net-smtp (0.4.0.1)
       net-protocol
     nio4r (2.7.0)
-    nokogiri (1.16.3)
+    nokogiri (1.16.4)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     notifications-ruby-client (5.3.0)
@@ -528,7 +528,7 @@ DEPENDENCIES
   factory_bot_rails
   faker
   foreman
-  govuk_design_system_formbuilder (~> 5.2)
+  govuk_design_system_formbuilder (~> 5.3)
   govuk_notify_rails (~> 2.2.0)
   haml-rails (~> 2.1.0)
   haml_lint

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "axe-core": "^4.8.4",
-    "cypress": "^13.6.6",
+    "cypress": "^13.8.1",
     "cypress-axe": "^1.5.0",
     "standard": "^17.1.0",
     "stylelint": "^15.11.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "file-loader": "^6.2.0",
     "govuk-frontend": "^4.7.0",
     "jquery": "3.7.1",
-    "mini-css-extract-plugin": "^2.8.1",
+    "mini-css-extract-plugin": "^2.9.0",
     "postcss": "^8.4.35",
     "sass": "^1.71.1",
     "sass-loader": "^13.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2330,10 +2330,10 @@ cypress-axe@^1.5.0:
   resolved "https://registry.yarnpkg.com/cypress-axe/-/cypress-axe-1.5.0.tgz#95082734583da77b51ce9b7784e14a442016c7a1"
   integrity sha512-Hy/owCjfj+25KMsecvDgo4fC/781ccL+e8p+UUYoadGVM2ogZF9XIKbiM6KI8Y3cEaSreymdD6ZzccbI2bY0lQ==
 
-cypress@^13.6.6:
-  version "13.6.6"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-13.6.6.tgz#5133f231ed1c6e57dc8dcbf60aade220bcd6884b"
-  integrity sha512-S+2S9S94611hXimH9a3EAYt81QM913ZVA03pUmGDfLTFa5gyp85NJ8dJGSlEAEmyRsYkioS1TtnWtbv/Fzt11A==
+cypress@^13.8.1:
+  version "13.8.1"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-13.8.1.tgz#f558e51b770a409e2360031bbd36c3f4fb3f2db4"
+  integrity sha512-Uk6ovhRbTg6FmXjeZW/TkbRM07KPtvM5gah1BIMp4Y2s+i/NMxgaLw0+PbYTOdw1+egE0FP3mWRiGcRkjjmhzA==
   dependencies:
     "@cypress/request" "^3.0.0"
     "@cypress/xvfb" "^1.2.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4141,10 +4141,10 @@ min-indent@^1.0.1:
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
-mini-css-extract-plugin@^2.8.1:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-2.8.1.tgz#75245f3f30ce3a56dbdd478084df6fe475f02dc7"
-  integrity sha512-/1HDlyFRxWIZPI1ZpgqlZ8jMw/1Dp/dl3P0L1jtZ+zVcHqwPhGwaJwKL00WVgfnBy6PWCde9W65or7IIETImuA==
+mini-css-extract-plugin@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-2.9.0.tgz#c73a1327ccf466f69026ac22a8e8fd707b78a235"
+  integrity sha512-Zs1YsZVfemekSZG+44vBsYTLQORkPMwnlv+aehcxK/NLKC+EGhDB39/YePYYqx/sTk6NnYpuqikhSn7+JIevTA==
   dependencies:
     schema-utils "^4.0.0"
     tapable "^2.2.1"


### PR DESCRIPTION
#### What

Combines the following six dependabot updates:

[Bump mini-css-extract-plugin from 2.8.1 to 2.9.0](https://github.com/ministryofjustice/laa-court-data-ui/commit/1f3e84afc2e7959efcd3e7fe203b1d77b42fb469) 
[Bump rubocop from 1.62.1 to 1.63.3](https://github.com/ministryofjustice/laa-court-data-ui/commit/7b200c94cd1b662a3dfa3966590af99e664c3f0c) 
[Bump spring from 4.1.3 to 4.2.1](https://github.com/ministryofjustice/laa-court-data-ui/commit/e2d4186ef11f1816e32a5f682c39afa84b87c491) 
[Bump govuk_design_system_formbuilder from 5.2.0 to 5.3.3](https://github.com/ministryofjustice/laa-court-data-ui/commit/6bafe36530d2cfdc7b59a0dbcc9e338c9e50e2fd) 
[Bump cypress from 13.6.6 to 13.8.1](https://github.com/ministryofjustice/laa-court-data-ui/commit/665c05b67f8dcd02b637a8a956fe6bc2c37f67da) 
[Bump selenium-webdriver from 4.18.1 to 4.20.0](https://github.com/ministryofjustice/laa-court-data-ui/commit/7fb88796217145293a29034eff13a1fd6a1bb8f8)