### PR TITLE
[CTSKF-819] Change the phase banner from Alpha to Beta

### DIFF
--- a/app/views/layouts/_phase_banner.html.haml
+++ b/app/views/layouts/_phase_banner.html.haml
@@ -2,7 +2,7 @@
   %p.govuk-phase-banner__content
     %strong.govuk-tag.govuk-phase-banner__content__tag
       - if ENV.fetch('ENV', 'local') == 'production'
-        = t('generic.alpha')
+        = t('generic.beta')
       - else
         = ENV.fetch('ENV', 'local')
     %span.govuk-phase-banner__text

--- a/config/locales/en/generic.yml
+++ b/config/locales/en/generic.yml
@@ -1,7 +1,7 @@
 ---
 en:
   generic:
-    alpha: alpha
+    beta: beta
     case: Case
     continue: Continue
     defendant: Defendant

--- a/spec/features/layout_spec.rb
+++ b/spec/features/layout_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature 'Gov UK Layout', type: :feature do
       end
 
       within '.govuk-phase-banner' do
-        expect(page).to have_css('.govuk-phase-banner__content', text: 'alpha')
+        expect(page).to have_css('.govuk-phase-banner__content', text: 'beta')
         expect(page).to have_css('.govuk-phase-banner__text', text: 'This is a new service')
       end
     end


### PR DESCRIPTION
#### What

Change the phase banner from Alpha to Beta

#### Ticket

[Change Alpha label to 'Beta' for VCD](https://dsdmoj.atlassian.net/browse/CTSKF-819)

#### Why

VCD is a live system that has been in production since 2021, yet it shows an ‘Alpha’ label on the user interface. It ought instead to show ‘Beta’.

#### How

See https://design-system.service.gov.uk/components/phase-banner/

Note that 'Alpha' and 'Beta' only appear in the production environment. In other test environments the name of the environment appears instead.