### PR TITLE
Group related dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@ updates:
     interval: daily
     time: "03:00"
     timezone: Europe/London
+  groups:
+    rubocop:
+      patterns:
+        - "rubocop*"
   open-pull-requests-limit: 15
 - package-ecosystem: npm
   directory: "/"
@@ -13,6 +17,10 @@ updates:
     interval: daily
     time: "03:00"
     timezone: Europe/London
+  groups:
+    babel:
+      patterns:
+        - "*babel*"
   open-pull-requests-limit: 15
 - package-ecosystem: github-actions
   directory: "/"


### PR DESCRIPTION
#### What

Adds `group` definitions for `rubocop` bundle updates and `babel` npm updates. 

#### Why

By defining groups for those dependencies, when updates are a vailable a single PR will be opened resulting in fewer pipeline runs and making it easier to cherry-pick commits into a single PR by reducing the possibility of merge conflicts.
