### PR TITLE
[CTSKF-881] Upgrade the cypress npm package to 13.14.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -298,6 +298,7 @@ jobs:
           organization: "legal-aid-agency"
           severity-threshold: "critical"
           fail-on-issues: true
+          no-output-timeout: 20m
 
   build-app-container:
     executor: cloud-platform-executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
   aws-cli: circleci/aws-cli@4.0.0
   browser-tools: circleci/browser-tools@1.4.6
   slack: circleci/slack@3.4.2
-  snyk: snyk/snyk@1.7.0
+  snyk: snyk/snyk@2.2.0
 
 references:
   _restore-bundle: &restore-bundle

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,8 @@ updates:
       patterns:
         - "rubocop*"
   open-pull-requests-limit: 15
+  allow:
+    - dependency-type: "all"
 - package-ecosystem: npm
   directory: "/"
   schedule:
@@ -22,6 +24,8 @@ updates:
       patterns:
         - "*babel*"
   open-pull-requests-limit: 15
+  allow:
+    - dependency-type: "all"
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
@@ -30,3 +34,5 @@ updates:
     time: "03:00"
     timezone: Europe/London
   open-pull-requests-limit: 15
+  allow:
+    - dependency-type: "all"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "axe-core": "^4.9.1",
-    "cypress": "^13.13.1",
+    "cypress": "^13.14.1",
     "cypress-axe": "^1.5.0",
     "standard": "^17.1.0",
     "stylelint": "^15.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1190,10 +1190,10 @@
   resolved "https://registry.yarnpkg.com/@csstools/selector-specificity/-/selector-specificity-3.0.0.tgz#798622546b63847e82389e473fd67f2707d82247"
   integrity sha512-hBI9tfBtuPIi885ZsZ32IMEU/5nlZH/KOVYJCOh7gyMxaVLGmLedYqFN6Ui1LXkI8JlC8IsuC0rF0btcRZKd5g==
 
-"@cypress/request@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@cypress/request/-/request-3.0.0.tgz#7f58dfda087615ed4e6aab1b25fffe7630d6dd85"
-  integrity sha512-GKFCqwZwMYmL3IBoNeR2MM1SnxRIGERsQOTWeQKoYBt2JLqcqiy7JXqO894FLrpjZYqGxW92MNwRH2BN56obdQ==
+"@cypress/request@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@cypress/request/-/request-3.0.1.tgz#72d7d5425236a2413bd3d8bb66d02d9dc3168960"
+  integrity sha512-TWivJlJi8ZDx2wGOw1dbLuHJKUYX7bWySw377nlnGOW3hP9/MUKIsEdXT/YngWxVdgNCHRBmFlBipE+5/2ZZlQ==
   dependencies:
     aws-sign2 "~0.7.0"
     aws4 "^1.8.0"
@@ -1208,7 +1208,7 @@
     json-stringify-safe "~5.0.1"
     mime-types "~2.1.19"
     performance-now "^2.1.0"
-    qs "~6.10.3"
+    qs "6.10.4"
     safe-buffer "^5.1.2"
     tough-cookie "^4.1.3"
     tunnel-agent "^0.6.0"
@@ -2386,12 +2386,12 @@ cypress-axe@^1.5.0:
   resolved "https://registry.yarnpkg.com/cypress-axe/-/cypress-axe-1.5.0.tgz#95082734583da77b51ce9b7784e14a442016c7a1"
   integrity sha512-Hy/owCjfj+25KMsecvDgo4fC/781ccL+e8p+UUYoadGVM2ogZF9XIKbiM6KI8Y3cEaSreymdD6ZzccbI2bY0lQ==
 
-cypress@^13.13.1:
-  version "13.13.1"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-13.13.1.tgz#860c1142a6e58ea412a764f0ce6ad07567721129"
-  integrity sha512-8F9UjL5MDUdgC/S5hr8CGLHbS5gGht5UOV184qc2pFny43fnkoaKxlzH/U6//zmGu/xRTaKimNfjknLT8+UDFg==
+cypress@^13.14.1:
+  version "13.14.1"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-13.14.1.tgz#05875bbbf6333e858a92aed33ba67d7ddf8370d7"
+  integrity sha512-Wo+byPmjps66hACEH5udhXINEiN3qS3jWNGRzJOjrRJF3D0+YrcP2LVB1T7oYaVQM/S+eanqEvBWYc8cf7Vcbg==
   dependencies:
-    "@cypress/request" "^3.0.0"
+    "@cypress/request" "^3.0.1"
     "@cypress/xvfb" "^1.2.4"
     "@types/sinonjs__fake-timers" "8.1.1"
     "@types/sizzle" "^2.3.2"
@@ -4719,10 +4719,10 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-qs@~6.10.3:
-  version "6.10.5"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.5.tgz#974715920a80ff6a262264acd2c7e6c2a53282b4"
-  integrity sha512-O5RlPh0VFtR78y79rgcgKK4wbAI0C5zGVLztOIdpWX6ep368q5Hv6XRxDvXuZ9q3C6v+e3n8UfZZJw7IIG27eQ==
+qs@6.10.4:
+  version "6.10.4"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.4.tgz#6a3003755add91c0ec9eacdc5f878b034e73f9e7"
+  integrity sha512-OQiU+C+Ds5qiH91qh/mg0w+8nwQuLjM4F4M/PbmhDOoYehPh+Fb0bDjtR1sOvy7YKxvj28Y/M0PhP5uVX0kB+g==
   dependencies:
     side-channel "^1.0.4"
 


### PR DESCRIPTION
#### What

Upgrade the cypress package to 13.14.1

#### Ticket

[Investigate VCD Snyk Docker Image Security Alert](https://dsdmoj.atlassian.net/browse/CTSKF-881)

#### Why

Snyk is reporting issues and this is blocking the pipeline. This can be resolved by upgrading the cypress package to the latest version.

#### How

* Set the required version in `package.json`.
* Update the synk orb to version 2.2.0.
* Set the 'no output timeout' for the Snyk scan to 20 minutes. This seems to be the [recommendation in the README file.](https://github.com/snyk/snyk-orb)
* Update the dependabot configuration so that sub-dependencies get updated.