### PR TITLE
Upgrade json_api_client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,10 +14,12 @@ gem 'cancancan'
 gem 'devise', '~> 4.9'
 gem 'govuk_notify_rails', '~> 3.0.0'
 
+# Faraday middleware gem is required until Faraday is upgraded to version 2
+gem 'faraday_middleware', '~> 1.2.1'
 # rails GDS design system form builder
 gem 'govuk_design_system_formbuilder', '~> 5.6'
 gem 'haml-rails', '~> 2.1.0'
-gem 'json_api_client', '~> 1.22'
+gem 'json_api_client', '~> 1.23'
 gem 'json-schema', '~> 5.0'
 gem 'logstasher'
 gem 'oauth2', '~> 2.0.9'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,6 +166,9 @@ GEM
     faraday-em_http (1.0.0)
     faraday-em_synchrony (1.0.0)
     faraday-excon (1.1.0)
+    faraday-gzip (2.0.1)
+      faraday (>= 1.0)
+      zlib (~> 3.0)
     faraday-httpclient (1.0.1)
     faraday-multipart (1.0.4)
       multipart-post (~> 2)
@@ -174,8 +177,9 @@ GEM
     faraday-patron (1.0.0)
     faraday-rack (1.0.0)
     faraday-retry (1.0.3)
-    faraday_middleware (1.2.0)
+    faraday_middleware (1.2.1)
       faraday (~> 1.0)
+    ffi (1.17.0-arm64-darwin)
     ffi (1.17.0-x86_64-linux-gnu)
     foreman (0.88.1)
     globalid (1.2.1)
@@ -229,12 +233,12 @@ GEM
     json (2.7.2)
     json-schema (5.0.0)
       addressable (~> 2.8)
-    json_api_client (1.22.0)
-      activemodel (>= 3.2.0)
-      activesupport (>= 3.2.0)
+    json_api_client (1.23.0)
+      activemodel (>= 6.0.0)
+      activesupport (>= 6.0.0)
       addressable (~> 2.2)
-      faraday (>= 0.15.2, < 2.0)
-      faraday_middleware (>= 0.9.0, < 2.0)
+      faraday (>= 1.10, < 3.0)
+      faraday-gzip (>= 1.0, < 3.0)
       rack (>= 0.2)
     jwt (2.9.0)
       base64
@@ -276,6 +280,8 @@ GEM
     net-smtp (0.5.0)
       net-protocol
     nio4r (2.7.3)
+    nokogiri (1.16.7-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.16.7-x86_64-linux)
       racc (~> 1.4)
     notifications-ruby-client (6.2.0)
@@ -508,8 +514,10 @@ GEM
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.6.18)
+    zlib (3.1.1)
 
 PLATFORMS
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES
@@ -527,6 +535,7 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails
   faker
+  faraday_middleware (~> 1.2.1)
   foreman
   govuk_design_system_formbuilder (~> 5.6)
   govuk_notify_rails (~> 3.0.0)
@@ -535,7 +544,7 @@ DEPENDENCIES
   i18n-tasks (~> 1.0.14)
   jsbundling-rails (~> 1.3)
   json-schema (~> 5.0)
-  json_api_client (~> 1.22)
+  json_api_client (~> 1.23)
   launchy
   listen (>= 3.0.5, < 3.10)
   logstasher


### PR DESCRIPTION
#### What

Upgrade `json_api_client` and `faraday_middleware` together.

#### Ticket

N/A

#### Why

`json_api_client` has been updated to allow compatibility with both version 1 and 2 of Faraday. To do this the `faraday_middleware` gem was removed as this is not compatible with Faraday version 2. To facilitate this some middleware has been built in to Faraday 1 to mirror the behaviour of version 2. This has been done for the JSON firmware, which `json_api_client` uses, but not for the OAuth2 middleware, which we still require. Simply adding `faraday_middleware` back in for the OAuth2 middleware causes conflicts as the JSON middleware exists twice.

#### How

Add `faraday_middleware` and require at least version 1.2.1. This version has been fixed (https://github.com/lostisland/faraday/pull/1595) to resolve conflicts and favours the built in version of any middleware that also exists in `faraday_middleware`.