### PR TITLE
ACD-590 - Change email address to new team's address

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -42,7 +42,7 @@ module LaaCourtDataUi
     config.action_dispatch.signed_cookie_digest = 'SHA256'
     config.exceptions_app = routes
     config.active_job.queue_adapter = :sidekiq
-    config.x.support_email_address = 'assessaclaim@digital.justice.gov.uk'
+    config.x.support_email_address = 'access-court-data-team@digital.justice.gov.uk'
     config.x.display_raw_responses = %w[enabled true].include?(ENV.fetch('DISPLAY_RAW_RESPONSES', nil))
     config.action_mailer.deliver_later_queue_name = :mailers
     config.x.court_data_api_config.uri = ENV.fetch('COURT_DATA_API_URL', nil)

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -18,7 +18,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'assessaclaim@digital.justice.gov.uk'
+  config.mailer_sender = 'access-court-data-team@digital.justice.gov.uk'
 
   # Configure the class responsible to send e-mails.
   config.mailer = 'Devise::Mailer'

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM ruby:3.3.6-alpine3.20
 LABEL Organisation="Ministry of Justice"
-LABEL Team="LAA Get Paid"
-LABEL Contact="<assessaclaim@digital.justice.gov.uk>"
+LABEL Team="LAA Access Court Data"
+LABEL Contact="<access-court-data-team@digital.justice.gov.uk>"
 
 # fail early and print all commands
 RUN set -ex


### PR DESCRIPTION
#### What
Changes the email address listed on the contact page, the email address used by the email service, and the email address listed as the maintainer of the Docker image.

#### Ticket

[Change all instances of assess-a-claim email to Access-Court-Data where possible](https://dsdmoj.atlassian.net/browse/ACD-590)

#### Why
The old email address was that of the team that previously owned the service, as opposed to the one that now does.

#### How
The email address is set explicitly in the Docker file. The other two instances are variables used in places throughout the survey.
