### PR TITLE
ACD-594: Disallow indexing

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -190,6 +190,7 @@ GEM
     faraday_middleware (1.2.1)
       faraday (~> 1.0)
     ffi (1.17.0-arm64-darwin)
+    ffi (1.17.0-x86_64-darwin)
     ffi (1.17.0-x86_64-linux-gnu)
     ffi (1.17.0-x86_64-linux-musl)
     foreman (0.88.1)
@@ -296,6 +297,8 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.4)
+    nokogiri (1.16.8-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.18.3-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.18.3-x86_64-linux-gnu)
@@ -553,6 +556,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-23
+  x86_64-darwin-24
   x86_64-linux
   x86_64-linux-musl
 

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -13,6 +13,7 @@
     %meta{ content: "width=device-width, initial-scale=1, viewport-fit=cover", name: "viewport" }/
     %meta{ content: "blue", name: "theme-color" }/
     %meta{ content: "IE=edge", "http-equiv" => "X-UA-Compatible" }/
+    %meta{ content: "noindex", name: "robots" }/
     %link{ href: asset_path("favicon.ico"), rel: "shortcut icon", sizes: "16x16 32x32 48x48", type: "image/x-icon" }/
     %link{ color: "blue", href: "govuk-mask-icon.svg", rel: "mask-icon" }/
     %link{ href: asset_path("govuk-apple-touch-icon-180x180.png"), rel: "apple-touch-icon", sizes: "180x180" }/

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,1 +1,2 @@
-# See https://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
+User-agent: *
+Disallow: /

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,1 @@
-User-agent: *
-Disallow: /
+# See https://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file


### PR DESCRIPTION
#### What
Instruct Google and other crawlers not to index the site in any environment. 

#### Ticket

[Hide VCD from search engines](https://dsdmoj.atlassian.net/browse/ACD-594)

#### Why
Because these pages are not for public consumption and their presence on Google may cause confusion.

"VCD’s intended users have other ways of getting the link (from emails, intranet, bookmarks etc) so the downsides of it being on search engines outweigh any benefits."

#### How
Do this by:
~- Adding a global directive in robots.txt~
- Adding a `meta` tag on each individual page

(robots.txt tells crawlers whether they can crawl pages. SInce Google already has crawled our pages and believes the content is indexable, we want to allow the crawlers to keep crawling so they at some point crawl back and notice that the pages are now `noindex`.)

Note that these directives _ask_ Google not to index us. We cannot _force_ Google not to unless we make it impossible for Googlebot to load any pages on the site.

Finally, note that for me to run bundler, given my processor on my laptop, certain adjustments to the Gemfile are necessary. These aren't directly relevant to the ticket, but I hope they're small enough it's OK to include here rather than a separate PR.