### PR TITLE
ACD-255: Sorting hearing counsels

### DIFF
--- a/app/decorators/cd_api/hearing_summary_decorator.rb
+++ b/app/decorators/cd_api/hearing_summary_decorator.rb
@@ -44,8 +44,15 @@ module CdApi
     end
 
     def attended_defence_counsels
+      # Sometimes a hearing summary pertains to a specific day of a hearing.
+      # (c.f. CdApi::CaseSummaryDecorator.sorted_hearing_summaries_with_day)
+      # In those cases, we are only interested in the defence counsels who
+      # attended on that specific day. Otherwise, we are interested in
+      # all defence counsels
+      return defence_counsels unless day
+
       defence_counsels.select do |defence_counsel|
-        defence_counsel.attendance_days.include?(day.strftime('%Y-%m-%d'))
+        defence_counsel.attendance_days&.include?(day.strftime('%Y-%m-%d'))
       end
     end
   end

--- a/spec/decorators/cd_api/hearing_summary_decorator_spec.rb
+++ b/spec/decorators/cd_api/hearing_summary_decorator_spec.rb
@@ -30,119 +30,151 @@ RSpec.describe CdApi::HearingSummaryDecorator, type: :decorator do
   describe '#defence_counsel_list' do
     subject(:call) { decorator.defence_counsel_list }
 
-    before do
-      allow_any_instance_of(described_class).to receive(:day).and_return(sitting_day)
-    end
-
     let(:day) { '2022-05-17' }
     let(:formatted_date) { sitting_day.strftime('%Y-%m-%d') }
     let(:sitting_day) { DateTime.parse(day) }
 
     let(:hearing_summary) { build(:hearing_summary, defence_counsels:) }
 
-    context 'when there are multiple defendants in defence_counsels' do
-      let(:hearing_summary) { build(:hearing_summary, defence_counsels:, defendants:) }
-      let(:defence_counsels) { [defence_counsel1] }
-      let(:defence_counsel1) do
-        build(:defence_counsel, first_name: 'Jammy', last_name: 'Dodger', status: 'Junior',
-                                defendants: defendant_ids, attendance_days: [formatted_date])
-      end
-      let(:defendant_ids) do
-        [defendant1, defendant2].map(&:id)
-      end
-
-      let(:defendants) { [defendant1, defendant2] }
-
-      let(:defendant1) { build(:defendant, first_name: 'John', middle_name: '', last_name: 'Doe') }
-      let(:defendant2) { build(:defendant, first_name: 'Jane', middle_name: '', last_name: 'Doe') }
-
+    context 'when the summary has a specific day associated with it' do
       before do
-        allow_any_instance_of(described_class).to receive(:decorate_all).with(any_args).and_return([])
+        allow_any_instance_of(described_class).to receive(:day).and_return(sitting_day)
       end
 
-      it 'maps defence_counsels defendants' do
-        decorator.defence_counsel_list
-        decorator.defence_counsels.each do |defence_counsel|
-          expect(defence_counsel.defendants).to eq([defendant1, defendant2])
+      context 'when there are multiple defendants in defence_counsels' do
+        let(:hearing_summary) { build(:hearing_summary, defence_counsels:, defendants:) }
+        let(:defence_counsels) { [defence_counsel1] }
+        let(:defence_counsel1) do
+          build(:defence_counsel, first_name: 'Jammy', last_name: 'Dodger', status: 'Junior',
+                                  defendants: defendant_ids, attendance_days: [formatted_date])
+        end
+        let(:defendant_ids) do
+          [defendant1, defendant2].map(&:id)
+        end
+
+        let(:defendants) { [defendant1, defendant2] }
+
+        let(:defendant1) { build(:defendant, first_name: 'John', middle_name: '', last_name: 'Doe') }
+        let(:defendant2) { build(:defendant, first_name: 'Jane', middle_name: '', last_name: 'Doe') }
+
+        before do
+          allow_any_instance_of(described_class).to receive(:decorate_all).with(any_args).and_return([])
+        end
+
+        it 'maps defence_counsels defendants' do
+          decorator.defence_counsel_list
+          decorator.defence_counsels.each do |defence_counsel|
+            expect(defence_counsel.defendants).to eq([defendant1, defendant2])
+          end
+        end
+      end
+
+      context 'with no defence_counsels' do
+        let(:defence_counsels) { [] }
+
+        it { is_expected.to eql 'Not available' }
+      end
+
+      context 'when defence counsels defendant ids fail to match' do
+        let(:defence_counsels) { [defence_counsel] }
+        let(:defence_counsel) do
+          build(:defence_counsel, first_name: 'Bob', last_name: 'Smith', status: 'QC',
+                                  defendants: [defendant.id])
+        end
+        let(:defendant) { build(:defendant) }
+        let(:hearing_summary) { build(:hearing_summary, defence_counsels:, defendants: []) }
+
+        it 'returns defendant id' do
+          decorator.defence_counsel_list
+          decorator.defence_counsels.each do |defence_counsel|
+            expect(defence_counsel.defendants).to eq([defendant.id])
+          end
+        end
+      end
+
+      context 'when defence counsel did not attend on the hearing day' do
+        let(:hearing_summary) { build(:hearing_summary, defence_counsels:) }
+
+        let(:defence_counsels) { [defence_counsel1, defence_counsel2] }
+        let(:defence_counsel1) do
+          build(:defence_counsel, first_name: 'Jammy', last_name: 'Dodger', status: 'Junior',
+                                  attendance_days: [formatted_date])
+        end
+        let(:defence_counsel2) do
+          build(:defence_counsel, first_name: 'Jammy', last_name: 'Dodger', status: 'Junior',
+                                  attendance_days: ['2022-01-01'])
+        end
+
+        it 'returns defence counsels that attended on the hearing day' do
+          expect_any_instance_of(described_class).to receive(:decorate_all).with([defence_counsel1], any_args)
+          decorator.defence_counsel_list
+        end
+      end
+
+      context 'when no defence counsels attended the hearing day' do
+        let(:hearing_summary) { build(:hearing_summary, defence_counsels:) }
+
+        let(:defence_counsels) { [defence_counsel1] }
+        let(:defence_counsel1) do
+          build(:defence_counsel, first_name: 'Jammy', last_name: 'Dodger', status: 'Junior',
+                                  attendance_days: [])
+        end
+
+        it { is_expected.to eql 'Not available' }
+      end
+
+      context 'when called again after day has been altered' do
+        let(:hearing_summary) { build(:hearing_summary, defence_counsels:) }
+
+        let(:defence_counsels) { [defence_counsel1, defence_counsel2] }
+        let(:defence_counsel1) do
+          build(:defence_counsel, first_name: 'First', last_name: 'Counsel', status: 'Junior',
+                                  attendance_days: ['2022-01-01'])
+        end
+        let(:defence_counsel2) do
+          build(:defence_counsel, first_name: 'Second', last_name: 'Counsel', status: 'Junior',
+                                  attendance_days: ['2022-01-01'])
+        end
+
+        before { decorator.defence_counsel_list }
+
+        it 'returns new un-memoized defence counsel list' do
+          allow_any_instance_of(described_class).to receive(:day).and_return(DateTime.parse('2022-01-01'))
+          expect_any_instance_of(described_class).to receive(:decorate_all).with(
+            [defence_counsel1, defence_counsel2], any_args
+          )
+          decorator.defence_counsel_list
         end
       end
     end
 
-    context 'with no defence_counsels' do
-      let(:defence_counsels) { [] }
-
-      it { is_expected.to eql 'Not available' }
-    end
-
-    context 'when defence counsels defendant ids fail to match' do
-      let(:defence_counsels) { [defence_counsel] }
-      let(:defence_counsel) do
-        build(:defence_counsel, first_name: 'Bob', last_name: 'Smith', status: 'QC',
-                                defendants: [defendant.id])
+    context 'when there is no day associated with the hearing summary' do
+      before do
+        allow_any_instance_of(described_class).to receive(:day).and_return(nil)
       end
-      let(:defendant) { build(:defendant) }
-      let(:hearing_summary) { build(:hearing_summary, defence_counsels:, defendants: []) }
 
-      it 'returns defendant id' do
-        decorator.defence_counsel_list
-        decorator.defence_counsels.each do |defence_counsel|
-          expect(defence_counsel.defendants).to eq([defendant.id])
+      context 'with no defence_counsels' do
+        let(:defence_counsels) { [] }
+
+        it { is_expected.to eql 'Not available' }
+      end
+
+      context 'when defence counsels attended on different days' do
+        let(:hearing_summary) { build(:hearing_summary, defence_counsels:) }
+
+        let(:defence_counsels) { [defence_counsel1, defence_counsel2] }
+        let(:defence_counsel1) do
+          build(:defence_counsel, first_name: 'Jammy', last_name: 'Dodger', status: 'Junior',
+                                  attendance_days: [formatted_date])
         end
-      end
-    end
+        let(:defence_counsel2) do
+          build(:defence_counsel, first_name: 'Hammy', last_name: 'Rodger', status: 'Senior',
+                                  attendance_days: ['2022-01-01'])
+        end
 
-    context 'when defence counsel did not attend on the hearing day' do
-      let(:hearing_summary) { build(:hearing_summary, defence_counsels:) }
-
-      let(:defence_counsels) { [defence_counsel1, defence_counsel2] }
-      let(:defence_counsel1) do
-        build(:defence_counsel, first_name: 'Jammy', last_name: 'Dodger', status: 'Junior',
-                                attendance_days: [formatted_date])
-      end
-      let(:defence_counsel2) do
-        build(:defence_counsel, first_name: 'Jammy', last_name: 'Dodger', status: 'Junior',
-                                attendance_days: ['2022-01-01'])
-      end
-
-      it 'returns defence counsels that attended on the hearing day' do
-        expect_any_instance_of(described_class).to receive(:decorate_all).with([defence_counsel1], any_args)
-        decorator.defence_counsel_list
-      end
-    end
-
-    context 'when no defence counsels attended the hearing day' do
-      let(:hearing_summary) { build(:hearing_summary, defence_counsels:) }
-
-      let(:defence_counsels) { [defence_counsel1] }
-      let(:defence_counsel1) do
-        build(:defence_counsel, first_name: 'Jammy', last_name: 'Dodger', status: 'Junior',
-                                attendance_days: [])
-      end
-
-      it { is_expected.to eql 'Not available' }
-    end
-
-    context 'when called again after day has been altered' do
-      let(:hearing_summary) { build(:hearing_summary, defence_counsels:) }
-
-      let(:defence_counsels) { [defence_counsel1, defence_counsel2] }
-      let(:defence_counsel1) do
-        build(:defence_counsel, first_name: 'First', last_name: 'Counsel', status: 'Junior',
-                                attendance_days: ['2022-01-01'])
-      end
-      let(:defence_counsel2) do
-        build(:defence_counsel, first_name: 'Second', last_name: 'Counsel', status: 'Junior',
-                                attendance_days: ['2022-01-01'])
-      end
-
-      before { decorator.defence_counsel_list }
-
-      it 'returns new un-memoized defence counsel list' do
-        allow_any_instance_of(described_class).to receive(:day).and_return(DateTime.parse('2022-01-01'))
-        expect_any_instance_of(described_class).to receive(:decorate_all).with(
-          [defence_counsel1, defence_counsel2], any_args
-        )
-        decorator.defence_counsel_list
+        it 'returns all defence counsels that attended on the hearing day' do
+          expect(decorator.defence_counsel_list).to eq "Jammy Dodger (Junior)<br>Hammy Rodger (Senior)"
+        end
       end
     end
   end


### PR DESCRIPTION
#### What
When using the v2 endpoints/CDAPI, whenever the `/prosecution_cases/<id>` screen is accessed, `TableSorters::HearingsProviderSorter` sorts the hearings by the defence_counsel_list property. `HearingSummaryDecorator#defence_counsel_list` calls a method called `attended_defence_counsels` which assumes that the hearing summary has a `day` attribute set. _HOWEVER_, hearings do not have a "day" by default (because hearings can run over multiple days). The `day` attribute is only set when the hearing summary object is being used to display information about a specific day of the many which can be associated with a hearing (e.g. `CaseSummaryDecorator#sorted_hearing_summaries_with_day`). At the point of sorting, `day` has not been set, so `day.strftime` in `attended_defence_counsels` errors out.

This has happened 1.4k times in the last 30 days according to Sentry, and basically happens any time there are defence counsels associated with any of the hearings attached to a case.

Note that it's impossible to repro this locally without modifying our HMCTS mock because the mock hearing summary payload doesn't include the `defenceCounsel` attribute.
