### PR TITLE
BUG: Fix typo

### DIFF
--- a/app/models/cd_api/defendant.rb
+++ b/app/models/cd_api/defendant.rb
@@ -2,7 +2,7 @@
 
 module CdApi
   class Defendant < BaseModel
-    has_many :offence_summary, class_name: 'cd_api/offence_summary'
+    has_many :offence_summaries, class_name: 'cd_api/offence_summary'
 
     def linked?
       maat_references.first.present? && maat_references.first.first != 'Z'

--- a/spec/factories/cd_api/defendant.rb
+++ b/spec/factories/cd_api/defendant.rb
@@ -13,7 +13,6 @@ FactoryBot.define do
     date_of_birth { '1994-03-02' }
     proceedings_concluded { false }
     representation_order { {} }
-    offence_summaries { [] }
     prosecution_case_reference { 'PKTEST22345' }
 
     trait :with_offence_summaries do

--- a/spec/models/cd_api/defendant_spec.rb
+++ b/spec/models/cd_api/defendant_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe CdApi::Defendant, type: :model do
   end
 
   describe '#maat_reference' do
-    subject { defendant.maat_reference }
+    subject(:maat_reference) { defendant.maat_reference }
 
     let(:defendant) { build(:defendant, offence_summaries:) }
     let(:offence_summaries) { [build(:offence_summary, laa_application:)] }
@@ -48,6 +48,14 @@ RSpec.describe CdApi::Defendant, type: :model do
       let(:laa_application) { build(:laa_application, reference: '') }
 
       it { is_expected.to be_empty }
+    end
+
+    context 'when defendant is not instantiated with any offence summaries' do
+      let(:defendant) { build(:defendant) }
+
+      it 'does not raise an error' do
+        expect { maat_reference }.not_to raise_error
+      end
     end
   end
 end


### PR DESCRIPTION
On UAT, when trying to establish if a defendant is linked by MAAT ID when showing the "raw data" in the UI, we hit an error looking for "offence_summaries" when we've only defined "offence_summary". Note that this doesn't show up in the test suite because our FactoryBot factory plus ActiveResource combine to make our test fixtures actually have an "offence_summaries" attribute even though it's not defined on the class.
