### PR TITLE
BUG: Handle nil offence summaries

### DIFF
--- a/app/models/cd_api/defendant.rb
+++ b/app/models/cd_api/defendant.rb
@@ -15,6 +15,8 @@ module CdApi
     private
 
     def maat_references
+      return [] unless offence_summaries
+
       offence_summaries.filter_map { |offence| offence&.laa_application&.reference }
     end
   end

--- a/spec/models/cd_api/defendant_spec.rb
+++ b/spec/models/cd_api/defendant_spec.rb
@@ -57,5 +57,13 @@ RSpec.describe CdApi::Defendant, type: :model do
         expect { maat_reference }.not_to raise_error
       end
     end
+
+    context 'when defendant is instantiated with explicitly nil for offence summaries' do
+      let(:defendant) { build(:defendant, offence_summaries: nil) }
+
+      it 'does not raise an error' do
+        expect { maat_reference }.not_to raise_error
+      end
+    end
   end
 end


### PR DESCRIPTION
#### What
When `GET <cd api>/v2/offence_summaries?defendant_id=<id>` returns a 404 (common on UAT), `CdApi::Defendant#offence_summaries` is nil, so `#maat_references` raises an error.

This is related to the previous bug where `offence_summaries` didn't exist at all, as it was only defined on the model as `offence_summary`. I should have checked more UAT cases before merging.
