### PR TITLE
Fixes for features/users spec tests on Local

### DIFF
--- a/spec/features/users/edit_user_spec.rb
+++ b/spec/features/users/edit_user_spec.rb
@@ -60,6 +60,7 @@ RSpec.feature 'Edit user', :js, type: :feature do
 
       expect do
         click_link_or_button 'Save'
+        sleep 0.1
       end.to have_enqueued_job.on_queue('mailers')
 
       expect(page).to have_current_path(user_path(other_user))

--- a/spec/features/users/new_user_spec.rb
+++ b/spec/features/users/new_user_spec.rb
@@ -59,6 +59,7 @@ RSpec.feature 'New user', type: :feature do
 
       expect do
         click_link_or_button 'Save'
+        sleep 0.1
       end.to have_enqueued_job.on_queue('mailers')
 
       new_user = User.find_by(email: 'jim.bob@example.com')

--- a/spec/features/users/password_change_spec.rb
+++ b/spec/features/users/password_change_spec.rb
@@ -34,6 +34,7 @@ RSpec.feature 'Password change', :js, type: :feature do
 
     expect do
       click_link_or_button 'Change password'
+      sleep 0.1
     end.to have_enqueued_job.on_queue('mailers')
     expect(page).to have_govuk_flash(:notice, text: 'Password successfully updated')
     expect(page).to have_current_path(user_path(user))

--- a/spec/features/users/password_reset_spec.rb
+++ b/spec/features/users/password_reset_spec.rb
@@ -27,6 +27,7 @@ RSpec.feature 'Password reset', :js, type: :feature do
     fill_in 'Email', with: user.email
     expect do
       click_link_or_button 'Send me reset password instructions'
+      sleep 0.1
     end.to have_enqueued_job.on_queue('mailers')
     expect(page).to have_current_path(new_user_session_path)
     expect(page).to have_govuk_flash(:notice, text: reset_flash_notice)

--- a/spec/features/users/password_unlock_spec.rb
+++ b/spec/features/users/password_unlock_spec.rb
@@ -25,6 +25,7 @@ RSpec.feature 'Password unlock', :js, type: :feature do
       if i + 1 == max_attempts
         expect do
           click_link_or_button 'Sign in'
+          sleep 0.1
         end.to have_enqueued_job.on_queue('mailers')
       else
         click_link_or_button 'Sign in'
@@ -47,6 +48,7 @@ RSpec.feature 'Password unlock', :js, type: :feature do
     fill_in 'Email', with: user.email
     expect do
       click_link_or_button 'Resend unlock instructions'
+      sleep 0.1
     end.to have_enqueued_job.on_queue('mailers')
     expect(page).to have_current_path(new_user_session_path)
     expect(page).to have_govuk_flash(:alert, text: resent_flash_notice)


### PR DESCRIPTION
What

This PR fixes most of the test failures when running feature specs for features/users locally.
All specs now pass reliably, except for password_unlock_spec.rb, which remains somewhat flaky.

The email job is enqueued asynchronously, so I introduced a small sleep(0.1) to allow time for the queue to process. This works in most cases.