### PR TITLE
ACD-635: Speed up defendants page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ cypress.env.json
 
 /app/assets/builds/*
 !/app/assets/builds/.keep
+
+spec/examples.txt

--- a/lib/court_data_adaptor/query/defendant/by_uuid.rb
+++ b/lib/court_data_adaptor/query/defendant/by_uuid.rb
@@ -11,6 +11,7 @@ module CourtDataAdaptor
 
           resource
             .includes('offences')
+            .where(full_hearing_data: false)
             .find(id)
             .first
         end

--- a/spec/fixtures/vcr_cassettes/spec/lib/court_data_adaptor/query/defendant/by_uuid_spec.yml
+++ b/spec/fixtures/vcr_cassettes/spec/lib/court_data_adaptor/query/defendant/by_uuid_spec.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:9292/api/internal/v1/defendants/b3221b46-b98c-47b7-a285-be681d2cac4e?include=offences
+    uri: http://localhost:9292/api/internal/v1/defendants/b3221b46-b98c-47b7-a285-be681d2cac4e?filter%5Bfull_hearing_data%5D=false&include=offences
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/lib/court_data_adaptor/query/defendant/by_uuid_spec.rb
+++ b/spec/lib/court_data_adaptor/query/defendant/by_uuid_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe CourtDataAdaptor::Query::Defendant::ByUuid do
       allow(instance).to receive(:refresh_token_if_required!)
       allow(resource).to receive(:includes).and_return(resultset)
       allow(resultset).to receive(:includes).with('offences').and_return(resultset)
+      allow(resultset).to receive(:where).with(full_hearing_data: false).and_return(resultset)
       allow(resultset).to receive_messages(find: resultset, first: resultset, each_with_object: Array)
       call
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -60,7 +60,7 @@ RSpec.configure do |config|
   # Allows RSpec to persist some state between runs in order to support
   # the `--only-failures` and `--next-failure` CLI options. We recommend
   # you configure your source control system to ignore this file.
-  # config.example_status_persistence_file_path = "spec/examples.txt"
+  config.example_status_persistence_file_path = "spec/examples.txt"
 
   # Limits the available syntax to the non-monkey patched syntax that is
   # recommended. For more details, see:

--- a/spec/support/webmock/court_data_adaptor/webmock.rb
+++ b/spec/support/webmock/court_data_adaptor/webmock.rb
@@ -79,7 +79,7 @@ RSpec.configure do |config|
 
     stub_request(
       :get,
-      %r{http.*/api/internal/v1/defendants/#{defendant_id}\?include=offences}
+      %r{http.*/api/internal/v1/defendants/#{defendant_id}\?filter\[full_hearing_data\]=false&include=offences}
     ).to_return(
       status: 200,
       body: load_json_stub('unlinked_defendant.json'),

--- a/spec/support/webmock/court_data_api/webmock.rb
+++ b/spec/support/webmock/court_data_api/webmock.rb
@@ -112,7 +112,7 @@ RSpec.configure do |config|
   config.before(:each, :stub_unlink_v2) do
     stub_request(
       :get,
-      %r{http.*/api/internal/v1/defendants/#{defendant_id}\?include=offences}
+      %r{http.*/api/internal/v1/defendants/#{defendant_id}\?filter\[full_hearing_data\]=false&include=offences}
     ).to_return(
       status: 200,
       body: load_json_stub('linked_defendant.json'),


### PR DESCRIPTION
#### What
Request the faster version of the defendants endpoint

#### Ticket

[Link to story](https://dsdmoj.atlassian.net/browse/ACD-434)

#### Why
To populate the VCD UI we don't need every field in the defendants payload. By saying we don't need full hearing data, we allow CDA to reduce the number of HTTP requests it makes to retrieve individual hearing day payloads, without impacting what gets shown on screen.

#### How
A new `filter[full_hearing_data]` querystring param allows us to tell CDA we don't need every hearing to be retrieved.