### PR TITLE
ACD-527: Hearing overview

### DIFF
--- a/app/controllers/court_applications_controller.rb
+++ b/app/controllers/court_applications_controller.rb
@@ -6,6 +6,7 @@ class CourtApplicationsController < ApplicationController
 
   def show
     add_breadcrumb @application.application_title
+    @date_sort_direction = params.fetch(:date_sort_direction, "asc")
   end
 
   private

--- a/app/views/court_applications/show.html.haml
+++ b/app/views/court_applications/show.html.haml
@@ -17,3 +17,41 @@
         = l(@application.subject_summary.date_of_birth)
       %td.govuk-table__cell
         = @application.subject_summary.maat_reference.presence ||t('search.result.defendant.unlinked')
+
+%h2.govuk-heading-l
+  = t('.hearings')
+%table.govuk-table.app-sortable-table
+  %caption.govuk-table__caption.govuk-visually-hidden
+    = t('.hearings')
+  %thead.govuk-table__head
+    %tr.govuk-table__row
+      %th.govuk-table__header{ scope: 'col' }
+        - direction = @date_sort_direction == 'asc' ? 'desc' : 'asc'
+        = link_to(court_application_path(id: @application.application_id, date_sort_direction: direction),
+                  class: 'govuk-link govuk-link--no-visited-state', "aria-label": "Sort date #{direction}") do
+
+          = t('.hearing.date')
+          = @date_sort_direction == 'asc' ? "\u25B2" : "\u25BC"
+      %th.govuk-table__header{ scope: 'col' }
+        = t('.hearing.type')
+      %th.govuk-table__header{ scope: 'col' }
+        = t('.hearing.providers')
+  %tbody.govuk-table__body
+    - @application.hearing_days_sorted_by(@date_sort_direction).each_with_index do |hearing_day|
+      %tr.govuk-table__row
+        %td.govuk-table__cell
+          = link_to hearing_day.day_string,
+                    court_application_hearing_path(@application.application_id,
+                                                   hearing_day.hearing.id,
+                                                   day: hearing_day.date),
+                    class: 'govuk-link'
+        %td.govuk-table__cell
+          = hearing_day.hearing.hearing_type
+        %td.govuk-table__cell
+          - if hearing_day.hearing.defence_counsels_on(hearing_day.date).any?
+            - hearing_day.hearing.defence_counsels_on(hearing_day.date).each_with_index do |counsel, idx|
+              - unless idx.zero?
+                %br
+              = counsel.name
+          - else
+            = t('generic.not_available')

--- a/config/locales/en/views/court_applications.yml
+++ b/config/locales/en/views/court_applications.yml
@@ -7,3 +7,8 @@ en:
         maat_number: MAAT number
         name: Name
       defendants: Defendants
+      hearing:
+        date: Date
+        providers: Providers attending
+        type: Hearing type
+      hearings: Hearings

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,7 @@ Rails.application.routes.draw do
   resources :hearings, only: %i[show]
   resources :court_applications, only: %i[show] do
     resource :subject, only: %i[show]
+    resources :hearings, only: %i[show]
   end
 
   devise_for :users, controllers: {

--- a/lib/court_data_adaptor/resource/application_hearing.rb
+++ b/lib/court_data_adaptor/resource/application_hearing.rb
@@ -1,0 +1,19 @@
+module CourtDataAdaptor
+  module Resource
+    class ApplicationHearing < V2
+      def hearing_days
+        @hearing_days ||= super.map do |day_payload|
+          HearingDay.new(day_payload).tap { _1.hearing = self }
+        end
+      end
+
+      def defence_counsels
+        @defence_counsels ||= super.map { DefenceCounsel.new(_1) }
+      end
+
+      def defence_counsels_on(date)
+        defence_counsels.select { _1.attended_on?(date) }
+      end
+    end
+  end
+end

--- a/lib/court_data_adaptor/resource/application_summary.rb
+++ b/lib/court_data_adaptor/resource/application_summary.rb
@@ -12,6 +12,16 @@ module CourtDataAdaptor
       def subject_summary
         @subject_summary ||= SubjectSummary.new(super)
       end
+
+      def hearing_summary
+        @hearing_summary ||= super.map { ApplicationHearing.new(_1) }
+      end
+
+      def hearing_days_sorted_by(date_sort_direction)
+        ascending = hearing_summary.flat_map(&:hearing_days).sort_by(&:sitting_day)
+
+        date_sort_direction == "desc" ? ascending.reverse : ascending
+      end
     end
   end
 end

--- a/lib/court_data_adaptor/resource/defence_counsel.rb
+++ b/lib/court_data_adaptor/resource/defence_counsel.rb
@@ -1,0 +1,17 @@
+module CourtDataAdaptor
+  module Resource
+    class DefenceCounsel < V2
+      def attended_on?(date)
+        attendance_dates.include?(date)
+      end
+
+      def name
+        "#{title.capitalize} #{first_name} #{last_name} (#{status})"
+      end
+
+      def attendance_dates
+        @attendance_dates ||= attendance_days.map(&:to_date)
+      end
+    end
+  end
+end

--- a/lib/court_data_adaptor/resource/hearing_day.rb
+++ b/lib/court_data_adaptor/resource/hearing_day.rb
@@ -1,0 +1,15 @@
+module CourtDataAdaptor
+  module Resource
+    class HearingDay < V2
+      attr_accessor :hearing
+
+      def day_string
+        sitting_day.to_date.strftime('%d/%m/%Y')
+      end
+
+      def date
+        sitting_day.to_date
+      end
+    end
+  end
+end

--- a/spec/features/court_applications_spec.rb
+++ b/spec/features/court_applications_spec.rb
@@ -2,10 +2,12 @@ RSpec.feature 'Court Applications', :vcr do
   let(:user) { create(:user) }
   let(:missing_court_application_id) { 'not-found-uuid' }
   let(:erroring_court_application_id) { 'erroring-court-application-id' }
-  let(:found_court_application_id) { 'd174af7f-75da-428b-9875-c823eb182a23' }
+  let(:found_court_application_id) { 'e174af7f-75da-428b-9875-c823eb182a23' }
   let(:linked_court_application_id) { 'af7fc823e-428b-75da-9875-b182a23d174' }
+  let(:id_with_hearings) { 'd174af7f-75da-428b-9875-c823eb182a23' }
   let(:prosecution_case_urn_from_vcr) { 'EPAYAQECKM' }
   let(:maat_id_from_vcr) { '1234567' }
+  let(:hearing_id_from_vcr) { '0304d126-d773-41fd-af01-83e017cecd80' }
 
   scenario 'I am not signed in' do
     visit court_application_path(found_court_application_id)
@@ -40,5 +42,22 @@ RSpec.feature 'Court Applications', :vcr do
     sign_in user
     visit court_application_path(linked_court_application_id)
     expect(page).to have_content maat_id_from_vcr
+  end
+
+  scenario 'I view and sort an application with hearings' do
+    sign_in user
+    visit court_application_path(id_with_hearings)
+    expect(page).to have_content "23/10/2019 Mention - Defendant to Attend (MDA) Not available"
+    expect(page).to have_content "10/04/2025 Pre-Trial Review (PTR) Mr Leone Spinka (Direct counsel)"
+
+    node = find("a", text: "23/10/2019")
+    expect(node["href"]).to eq court_application_hearing_path(id_with_hearings, hearing_id_from_vcr,
+                                                              day: "2019-10-23")
+
+    expect(page.body.index("23/10/2019")).to be < page.body.index("10/04/2025")
+    click_on "Date"
+    expect(page.body.index("23/10/2019")).to be > page.body.index("10/04/2025")
+    click_on "Date"
+    expect(page.body.index("23/10/2019")).to be < page.body.index("10/04/2025")
   end
 end

--- a/spec/fixtures/vcr_cassettes/spec/features/court_applications_spec.yml
+++ b/spec/fixtures/vcr_cassettes/spec/features/court_applications_spec.yml
@@ -104,7 +104,7 @@ http_interactions:
   recorded_at: Fri, 11 Apr 2025 09:52:23 GMT
 - request:
     method: get
-    uri: http://localhost:9292/api/internal/v2/court_applications/d174af7f-75da-428b-9875-c823eb182a23
+    uri: http://localhost:9292/api/internal/v2/court_applications/e174af7f-75da-428b-9875-c823eb182a23
     body:
       encoding: US-ASCII
       string: ''
@@ -153,7 +153,7 @@ http_interactions:
       - '1164'
     body:
       encoding: UTF-8
-      string: '{"application_id":"d174af7f-75da-428b-9875-c823eb182a23","short_id":"A25LO1OU0KE3","application_reference":"MyString","application_status":"DRAFT","application_title":"Appeal
+      string: '{"application_id":"e174af7f-75da-428b-9875-c823eb182a23","short_id":"A25LO1OU0KE3","application_reference":"MyString","application_status":"DRAFT","application_title":"Appeal
         against a conviction","application_type":"String","received_date":"2025-04-11","case_summary":[{"case_status":"ACTIVE","prosecution_case_id":"2c646634-9f24-42fd-865e-ef1e282b5953","prosecution_case_reference":"EPAYAQECKM"}],"hearing_summary":[],"subject_summary":{"subject_id":"6c3eded6-a6d6-4156-940d-e3b5f02deb96","date_of_next_hearing":null,"defendant_asn":"KQJXI10ZJXCI","defendant_dob":"1994-05-06","defendant_first_name":"Mauricio","defendant_last_name":"Rath","master_defendant_id":null,"offence_summary":[{"id":"d6aba7f2-51b3-483c-a5f9-35f49a36a4bb","code":"PT00011","order_index":1,"mode_of_trial":"Indictable
         only","start_date":"2019-10-17","title":"Trafficking into UK for sexual exploitation","wording":"Random
         string","proceedings_concluded":false,"legislation":"Theft Act 1978 s.2","arrest_date":"2019-10-17","charge_date":"2019-10-17","laa_application":{},"verdict":{},"plea":{},"pleas":[]}],"proceedings_concluded":false,"organisation_name":null,"representation_order":{}}}'
@@ -214,4 +214,199 @@ http_interactions:
         only","start_date":"2019-10-17","title":"Trafficking into UK for sexual exploitation","wording":"Random
         string","proceedings_concluded":false,"legislation":"Theft Act 1978 s.2","arrest_date":"2019-10-17","charge_date":"2019-10-17","laa_application":{ "reference": "1234567"},"verdict":{},"plea":{},"pleas":[]}],"proceedings_concluded":false,"organisation_name":null,"representation_order":{ "application_reference": "1234567"}}}'
   recorded_at: Fri, 11 Apr 2025 09:52:23 GMT
+- request:
+    method: get
+    uri: http://localhost:9292/api/internal/v2/court_applications/d174af7f-75da-428b-9875-c823eb182a23
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.10.4
+      Content-Type:
+      - application/vnd.api+json
+      Accept:
+      - application/vnd.api+json
+      Authorization:
+      - Bearer <BEARER_TOKEN>
+      Accept-Encoding:
+      - gzip,deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Request-Id:
+      - 3a46602a-9570-4aa1-81ab-10d49ccea623
+      Content-Type:
+      - application/vnd.api+json; charset=utf-8
+      Vary:
+      - Accept
+      Etag:
+      - W/"4510c50540b47e066a6a1b0d981683e1"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Runtime:
+      - '0.296177'
+      Server-Timing:
+      - start_processing.action_controller;dur=0.01, sql.active_record;dur=4.63, instantiation.active_record;dur=0.16,
+        process_action.action_controller;dur=279.33
+      Content-Length:
+      - '2972'
+    body:
+      encoding: UTF-8
+      string: '{"application_id":"d174af7f-75da-428b-9875-c823eb182a23","short_id":"A25LO1OU0KE3","application_reference":"MyString","application_status":"DRAFT","application_title":"Appeal
+        against a conviction","application_type":"String","received_date":"2025-04-11","case_summary":[{"case_status":"ACTIVE","prosecution_case_id":"2c646634-9f24-42fd-865e-ef1e282b5953","prosecution_case_reference":"EPAYAQECKM"}],"hearing_summary":[{"id":"e36d5c82-a0c7-43af-9a6c-9f52f9659aa0","hearing_type":"Pre-Trial
+        Review (PTR)","estimated_duration":null,"defendant_ids":["ecca893f-0928-4fc6-ae50-6a8794b78c5c"],"jurisdiction_type":"CROWN","court_centre":{"id":"68c7e9af-2db7-3fc3-b6e8-e51653120790","name":"Maidstone
+        Magistrates'' Court","welsh_name":"Llys Ynadon Maidstone","room_id":null,"room_name":null,"welsh_room_name":null,"welsh_court_centre":null,"short_oucode":"B46IR","oucode_l2_code":"46","code":"B46IR00","address":{"address_1":"The
+        Court House","address_2":"Palace Avenue","address_3":"Maidstone","address_4":"Kent","address_5":"","postcode":"ME15
+        6LL"}},"hearing_days":[{"sitting_day":"2025-04-10T00:00:00.000Z","listing_sequence":6,"listed_duration_minutes":190,"has_shared_results":false}],"defence_counsels":[{"id":"82ab9ad9-73bc-49f2-8b9e-de68f5ed54ba","title":"MR","first_name":"Leone","middle_name":"McCullough","last_name":"Spinka","status":"Direct
+        counsel","attendance_days":["2025-04-10"],"defendants":["b1c388d1-b669-4eb6-a797-4170eb291726"]}]},{"id":"0304d126-d773-41fd-af01-83e017cecd80","hearing_type":"Mention
+        - Defendant to Attend (MDA)","estimated_duration":null,"defendant_ids":["ecca893f-0928-4fc6-ae50-6a8794b78c5c"],"jurisdiction_type":"CROWN","court_centre":{"id":"6131bd34-33d9-3d1e-8152-8b5a2084f1bd","name":"Derby
+        Crown Court","welsh_name":"Llys Y Goron Derby","room_id":null,"room_name":null,"welsh_room_name":null,"welsh_court_centre":null,"short_oucode":"C30DE","oucode_l2_code":"30","code":"C30DE00","address":{"address_1":"Derby
+        Combined Court Centre","address_2":"Morledge","address_3":"Derby","address_4":"","address_5":"","postcode":"DE1
+        2XE"}},"hearing_days":[{"sitting_day":"2019-10-23T16:19:15.000Z","listing_sequence":1,"listed_duration_minutes":120,"has_shared_results":false}],"defence_counsels":[]}],"subject_summary":{"subject_id":"6c3eded6-a6d6-4156-940d-e3b5f02deb96","date_of_next_hearing":null,"defendant_asn":"KQJXI10ZJXCI","defendant_dob":"1994-05-06","defendant_first_name":"Mauricio","defendant_last_name":"Rath","master_defendant_id":null,"offence_summary":[{"id":"d6aba7f2-51b3-483c-a5f9-35f49a36a4bb","code":"PT00011","order_index":1,"mode_of_trial":"Indictable
+        only","start_date":"2019-10-17","title":"Trafficking into UK for sexual exploitation","wording":"Random
+        string","proceedings_concluded":false,"legislation":"Theft Act 1978 s.2","arrest_date":"2019-10-17","charge_date":"2019-10-17","laa_application":{},"verdict":{},"plea":{},"pleas":[]}],"proceedings_concluded":false,"organisation_name":null,"representation_order":{}}}'
+  recorded_at: Fri, 11 Apr 2025 15:00:23 GMT
+- request:
+    method: get
+    uri: http://localhost:9292/api/internal/v2/court_applications/d174af7f-75da-428b-9875-c823eb182a23
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.10.4
+      Content-Type:
+      - application/vnd.api+json
+      Accept:
+      - application/vnd.api+json
+      Authorization:
+      - Bearer <BEARER_TOKEN>
+      Accept-Encoding:
+      - gzip,deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Request-Id:
+      - 89a51705-57a0-45a8-8324-b26164b6e9d2
+      Content-Type:
+      - application/vnd.api+json; charset=utf-8
+      Vary:
+      - Accept
+      Etag:
+      - W/"4510c50540b47e066a6a1b0d981683e1"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Runtime:
+      - '0.139614'
+      Server-Timing:
+      - start_processing.action_controller;dur=0.01, sql.active_record;dur=1.38, instantiation.active_record;dur=0.11,
+        process_action.action_controller;dur=121.53
+      Content-Length:
+      - '2972'
+    body:
+      encoding: UTF-8
+      string: '{"application_id":"d174af7f-75da-428b-9875-c823eb182a23","short_id":"A25LO1OU0KE3","application_reference":"MyString","application_status":"DRAFT","application_title":"Appeal
+        against a conviction","application_type":"String","received_date":"2025-04-11","case_summary":[{"case_status":"ACTIVE","prosecution_case_id":"2c646634-9f24-42fd-865e-ef1e282b5953","prosecution_case_reference":"EPAYAQECKM"}],"hearing_summary":[{"id":"e36d5c82-a0c7-43af-9a6c-9f52f9659aa0","hearing_type":"Pre-Trial
+        Review (PTR)","estimated_duration":null,"defendant_ids":["ecca893f-0928-4fc6-ae50-6a8794b78c5c"],"jurisdiction_type":"CROWN","court_centre":{"id":"68c7e9af-2db7-3fc3-b6e8-e51653120790","name":"Maidstone
+        Magistrates'' Court","welsh_name":"Llys Ynadon Maidstone","room_id":null,"room_name":null,"welsh_room_name":null,"welsh_court_centre":null,"short_oucode":"B46IR","oucode_l2_code":"46","code":"B46IR00","address":{"address_1":"The
+        Court House","address_2":"Palace Avenue","address_3":"Maidstone","address_4":"Kent","address_5":"","postcode":"ME15
+        6LL"}},"hearing_days":[{"sitting_day":"2025-04-10T00:00:00.000Z","listing_sequence":6,"listed_duration_minutes":190,"has_shared_results":false}],"defence_counsels":[{"id":"82ab9ad9-73bc-49f2-8b9e-de68f5ed54ba","title":"MR","first_name":"Leone","middle_name":"McCullough","last_name":"Spinka","status":"Direct
+        counsel","attendance_days":["2025-04-10"],"defendants":["b1c388d1-b669-4eb6-a797-4170eb291726"]}]},{"id":"0304d126-d773-41fd-af01-83e017cecd80","hearing_type":"Mention
+        - Defendant to Attend (MDA)","estimated_duration":null,"defendant_ids":["ecca893f-0928-4fc6-ae50-6a8794b78c5c"],"jurisdiction_type":"CROWN","court_centre":{"id":"6131bd34-33d9-3d1e-8152-8b5a2084f1bd","name":"Derby
+        Crown Court","welsh_name":"Llys Y Goron Derby","room_id":null,"room_name":null,"welsh_room_name":null,"welsh_court_centre":null,"short_oucode":"C30DE","oucode_l2_code":"30","code":"C30DE00","address":{"address_1":"Derby
+        Combined Court Centre","address_2":"Morledge","address_3":"Derby","address_4":"","address_5":"","postcode":"DE1
+        2XE"}},"hearing_days":[{"sitting_day":"2019-10-23T16:19:15.000Z","listing_sequence":1,"listed_duration_minutes":120,"has_shared_results":false}],"defence_counsels":[]}],"subject_summary":{"subject_id":"6c3eded6-a6d6-4156-940d-e3b5f02deb96","date_of_next_hearing":null,"defendant_asn":"KQJXI10ZJXCI","defendant_dob":"1994-05-06","defendant_first_name":"Mauricio","defendant_last_name":"Rath","master_defendant_id":null,"offence_summary":[{"id":"d6aba7f2-51b3-483c-a5f9-35f49a36a4bb","code":"PT00011","order_index":1,"mode_of_trial":"Indictable
+        only","start_date":"2019-10-17","title":"Trafficking into UK for sexual exploitation","wording":"Random
+        string","proceedings_concluded":false,"legislation":"Theft Act 1978 s.2","arrest_date":"2019-10-17","charge_date":"2019-10-17","laa_application":{},"verdict":{},"plea":{},"pleas":[]}],"proceedings_concluded":false,"organisation_name":null,"representation_order":{}}}'
+  recorded_at: Fri, 11 Apr 2025 15:03:28 GMT
+- request:
+    method: get
+    uri: http://localhost:9292/api/internal/v2/court_applications/d174af7f-75da-428b-9875-c823eb182a23
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.10.4
+      Content-Type:
+      - application/vnd.api+json
+      Accept:
+      - application/vnd.api+json
+      Authorization:
+      - Bearer <BEARER_TOKEN>
+      Accept-Encoding:
+      - gzip,deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Request-Id:
+      - da1bb897-440a-4c4a-b601-b2688a6cb176
+      Content-Type:
+      - application/vnd.api+json; charset=utf-8
+      Vary:
+      - Accept
+      Etag:
+      - W/"4510c50540b47e066a6a1b0d981683e1"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Runtime:
+      - '0.086014'
+      Server-Timing:
+      - start_processing.action_controller;dur=0.01, sql.active_record;dur=1.12, instantiation.active_record;dur=0.11,
+        process_action.action_controller;dur=76.49
+      Content-Length:
+      - '2972'
+    body:
+      encoding: UTF-8
+      string: '{"application_id":"d174af7f-75da-428b-9875-c823eb182a23","short_id":"A25LO1OU0KE3","application_reference":"MyString","application_status":"DRAFT","application_title":"Appeal
+        against a conviction","application_type":"String","received_date":"2025-04-11","case_summary":[{"case_status":"ACTIVE","prosecution_case_id":"2c646634-9f24-42fd-865e-ef1e282b5953","prosecution_case_reference":"EPAYAQECKM"}],"hearing_summary":[{"id":"e36d5c82-a0c7-43af-9a6c-9f52f9659aa0","hearing_type":"Pre-Trial
+        Review (PTR)","estimated_duration":null,"defendant_ids":["ecca893f-0928-4fc6-ae50-6a8794b78c5c"],"jurisdiction_type":"CROWN","court_centre":{"id":"68c7e9af-2db7-3fc3-b6e8-e51653120790","name":"Maidstone
+        Magistrates'' Court","welsh_name":"Llys Ynadon Maidstone","room_id":null,"room_name":null,"welsh_room_name":null,"welsh_court_centre":null,"short_oucode":"B46IR","oucode_l2_code":"46","code":"B46IR00","address":{"address_1":"The
+        Court House","address_2":"Palace Avenue","address_3":"Maidstone","address_4":"Kent","address_5":"","postcode":"ME15
+        6LL"}},"hearing_days":[{"sitting_day":"2025-04-10T00:00:00.000Z","listing_sequence":6,"listed_duration_minutes":190,"has_shared_results":false}],"defence_counsels":[{"id":"82ab9ad9-73bc-49f2-8b9e-de68f5ed54ba","title":"MR","first_name":"Leone","middle_name":"McCullough","last_name":"Spinka","status":"Direct
+        counsel","attendance_days":["2025-04-10"],"defendants":["b1c388d1-b669-4eb6-a797-4170eb291726"]}]},{"id":"0304d126-d773-41fd-af01-83e017cecd80","hearing_type":"Mention
+        - Defendant to Attend (MDA)","estimated_duration":null,"defendant_ids":["ecca893f-0928-4fc6-ae50-6a8794b78c5c"],"jurisdiction_type":"CROWN","court_centre":{"id":"6131bd34-33d9-3d1e-8152-8b5a2084f1bd","name":"Derby
+        Crown Court","welsh_name":"Llys Y Goron Derby","room_id":null,"room_name":null,"welsh_room_name":null,"welsh_court_centre":null,"short_oucode":"C30DE","oucode_l2_code":"30","code":"C30DE00","address":{"address_1":"Derby
+        Combined Court Centre","address_2":"Morledge","address_3":"Derby","address_4":"","address_5":"","postcode":"DE1
+        2XE"}},"hearing_days":[{"sitting_day":"2019-10-23T16:19:15.000Z","listing_sequence":1,"listed_duration_minutes":120,"has_shared_results":false}],"defence_counsels":[]}],"subject_summary":{"subject_id":"6c3eded6-a6d6-4156-940d-e3b5f02deb96","date_of_next_hearing":null,"defendant_asn":"KQJXI10ZJXCI","defendant_dob":"1994-05-06","defendant_first_name":"Mauricio","defendant_last_name":"Rath","master_defendant_id":null,"offence_summary":[{"id":"d6aba7f2-51b3-483c-a5f9-35f49a36a4bb","code":"PT00011","order_index":1,"mode_of_trial":"Indictable
+        only","start_date":"2019-10-17","title":"Trafficking into UK for sexual exploitation","wording":"Random
+        string","proceedings_concluded":false,"legislation":"Theft Act 1978 s.2","arrest_date":"2019-10-17","charge_date":"2019-10-17","laa_application":{},"verdict":{},"plea":{},"pleas":[]}],"proceedings_concluded":false,"organisation_name":null,"representation_order":{}}}'
+  recorded_at: Fri, 11 Apr 2025 15:03:28 GMT
 recorded_with: VCR 6.3.1

--- a/spec/lib/court_data_adaptor/resource/application_hearing_spec.rb
+++ b/spec/lib/court_data_adaptor/resource/application_hearing_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe CourtDataAdaptor::Resource::ApplicationHearing do
+  subject(:hearing) do
+    described_class.new(
+      defence_counsels: [
+        { attendance_days: %w[2020-01-01 2020-01-02] },
+        { attendance_days: ["2020-01-01"] }
+      ]
+    )
+  end
+
+  describe "#defence_counsels_on" do
+    let(:date_to_filter_on) { Date.new(2020, 1, 2) }
+
+    it "returns only matching defence counsels" do
+      expect(hearing.defence_counsels_on(date_to_filter_on).length).to eq 1
+    end
+  end
+end

--- a/spec/lib/court_data_adaptor/resource/application_summary_spec.rb
+++ b/spec/lib/court_data_adaptor/resource/application_summary_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe CourtDataAdaptor::Resource::ApplicationSummary do
+  subject(:summary) do
+    described_class.new(
+      hearing_summary: [
+        { hearing_days: [{ sitting_day: "2020-01-01" }, { sitting_day: "2020-01-03" }] },
+        { hearing_days: [{ sitting_day: "2020-01-02" }] }
+      ]
+    )
+  end
+
+  describe "#hearing_days_sorted_by" do
+    let(:sort_direction) { "asc" }
+
+    it "flattens hearings with days into hearing days" do
+      expect(summary.hearing_days_sorted_by(sort_direction).length).to eq 3
+    end
+
+    it "sorts" do
+      expect(summary.hearing_days_sorted_by(sort_direction).map(&:sitting_day)).to eq %w[2020-01-01
+                                                                                         2020-01-02
+                                                                                         2020-01-03]
+    end
+
+    context "when order is reversed" do
+      let(:sort_direction) { "desc" }
+
+      it "sorts appropriately" do
+        expect(summary.hearing_days_sorted_by(sort_direction).map(&:sitting_day)).to eq %w[2020-01-03
+                                                                                           2020-01-02
+                                                                                           2020-01-01]
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What
Add a date-sortable hearings table that shows a row for each hearing day, with the hearing type defence counsels that attended on that day.

#### Ticket
[As a caseworker I want to see a hearings summary](https://dsdmoj.atlassian.net/browse/ACD-527)
