### PR TITLE
ACD-522 Show user appeal court application link within the search results

### DIFF
--- a/app/models/cd_api/application_summary.rb
+++ b/app/models/cd_api/application_summary.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module CdApi
+  class ApplicationSummary < BaseModel
+    belongs_to :defendant, class_name: 'cd_api/defendant'
+  end
+end

--- a/app/models/cd_api/defendant.rb
+++ b/app/models/cd_api/defendant.rb
@@ -3,6 +3,7 @@
 module CdApi
   class Defendant < BaseModel
     has_many :offence_summaries, class_name: 'cd_api/offence_summary'
+    has_many :application_summaries, class_name: 'cd_api/application_summary'
 
     def linked?
       maat_references.first.present? && maat_references.first.first != 'Z'

--- a/app/views/results/_defendant_appeals.html.haml
+++ b/app/views/results/_defendant_appeals.html.haml
@@ -1,0 +1,27 @@
+%table.govuk-table
+  %caption.govuk-table__caption.govuk-visually-hidden
+    = t('search.result.caption')
+  %thead.govuk-table__head
+    %tr.govuk-table__row
+      %th.govuk-table__header{ scope: 'col' }= t('search.result.defendant.name')
+      %th.govuk-table__header{ scope: 'col' }= t('search.result.defendant.date_of_birth')
+      %th.govuk-table__header{ scope: 'col' }= t('search.result.defendant.prosecution_case_reference')
+      %th.govuk-table__header{ scope: 'col' }= t('search.result.defendant.arrest_summons_number')
+      %th.govuk-table__header{ scope: 'col' }= t('search.result.defendant.court_application_title')
+  %tbody.govuk-table__body
+    - results.each do |defendant|
+      %tr.govuk-table__row
+        %td.govuk-table__cell
+          = link_to defendant.name, defendant_link_path(defendant, defendant.prosecution_case_reference), class: 'govuk-link'
+        %td.govuk-table__cell
+          = l(defendant.date_of_birth&.to_date)
+        %td.govuk-table__cell
+          = link_to defendant.prosecution_case_reference, prosecution_case_path(defendant.prosecution_case_reference), class: 'govuk-link'
+
+        %td.govuk-table__cell
+          = defendant.arrest_summons_number
+        %td.govuk-table__cell
+          - if defendant&.application_summaries&.present?
+            = render partial: 'results/defendant_court_applications', locals: { results: defendant.application_summaries }
+          - else 
+            = t('search.result.defendant.no_court_application_title')

--- a/app/views/results/_defendant_court_applications.html.haml
+++ b/app/views/results/_defendant_court_applications.html.haml
@@ -1,0 +1,4 @@
+- results.each do |defendant_court_applications|
+  
+  -# = link_to defendant_court_applications.title, court_application_path(defendant_court_applications.id), class: 'govuk-link'
+  = link_to defendant_court_applications.title, "#{'#' + defendant_court_applications.id}", class: 'govuk-link'

--- a/app/views/searches/_results.html.haml
+++ b/app/views/searches/_results.html.haml
@@ -1,8 +1,10 @@
 = render partial: 'results_header', locals: { term: term, dob: dob }
-
 - if results.empty?
   = render 'results/none'
 - elsif results.first.is_a? CourtDataAdaptor::Resource::ProsecutionCase
   = render partial: 'results/prosecution_case', locals: { results: results }
 - else
-  = render partial: 'results/defendant', locals: { cookies_preferences_set: cookies_preferences_set, results: results }
+  - if ENV['SHOW_APPEALS'].to_s.downcase == 'true'
+    = render partial: 'results/defendant_appeals', locals: { cookies_preferences_set: cookies_preferences_set, results: results }
+  - else
+    = render partial: 'results/defendant', locals: { cookies_preferences_set: cookies_preferences_set, results: results }

--- a/config/locales/en/views/searches.yml
+++ b/config/locales/en/views/searches.yml
@@ -20,11 +20,13 @@ en:
       defendant:
         arrest_summons_number: ASN
         caption: Defendants
+        court_application_title: Related Applications
         date_of_birth: Date of birth
         heading: Defendants
         maat_number: MAAT number
         name: Name
         national_insurance_number: NI number
+        no_court_application_title: No Related Application
         prosecution_case_reference: Case URN
         unlinked: Not linked
       heading: Search results for "%{term}"

--- a/spec/factories/cd_api/application_summary.rb
+++ b/spec/factories/cd_api/application_summary.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  # ActiveResource Factory, use :build not :create to prevent HTTP calls
+  factory :application_summary, class: 'CdApi::ApplicationSummary' do
+    id { 'f38d0030-0b4a-4fa5-9484-bb37b1e6ab39' }
+    short_id { 'A25ULRHLVC7S' }
+    reference { 'Assisting prisoners to escape' }
+    title { 'Firearms Act 1968 s.3' }
+    received_date { '2019-10-17' }
+  end
+end

--- a/spec/fixtures/stubs/cd_api/defendants_body.json
+++ b/spec/fixtures/stubs/cd_api/defendants_body.json
@@ -92,7 +92,23 @@
                 }
               }
             ],
-            "prosecution_case_reference": "TEST12345"
+            "prosecution_case_reference": "TEST12345",
+            "application_summaries": [
+                {
+                    "id": "f38d0030-0b4a-4fa5-9484-bb37b1e6ab39",
+                    "short_id": "A25ULRHLVC7S",
+                    "reference": "Random_string",
+                    "title": "Appeal for conviction",
+                    "received_date": "2025-04-11"
+                },
+                {
+                    "id": "a3f937c8-f098-49db-b9be-941c0deb1390",
+                    "short_id": "A25P5N2QPDLU",
+                    "reference": "Random_string",
+                    "title": "Appeal for conviction",
+                    "received_date": "2025-04-11"
+                }
+            ]
         },
         {
             "id": "e4df41b4-92c7-476e-8ccc-014b30997978",
@@ -149,7 +165,23 @@
                     }
                 }
             ],
-            "prosecution_case_reference": "TEST12345"
+            "prosecution_case_reference": "TEST12345",
+            "application_summaries": [
+                {
+                    "id": "f38d0030-0b4a-4fa5-9484-bb37b1e6ab39",
+                    "short_id": "A25ULRHLVC7S",
+                    "reference": "Random_string",
+                    "title": "Appeal for conviction",
+                    "received_date": "2025-04-11"
+                },
+                {
+                    "id": "a3f937c8-f098-49db-b9be-941c0deb1390",
+                    "short_id": "A25P5N2QPDLU",
+                    "reference": "Random_string",
+                    "title": "Appeal for conviction",
+                    "received_date": "2025-04-11"
+                }
+            ]
         },
         {
             "id": "c443af48-79f2-4e55-b25d-fa936616d830",
@@ -206,7 +238,23 @@
                     }
                 }
             ],
-            "prosecution_case_reference": "TEST12345"
+            "prosecution_case_reference": "TEST12345",
+            "application_summaries": [
+                {
+                    "id": "f38d0030-0b4a-4fa5-9484-bb37b1e6ab39",
+                    "short_id": "A25ULRHLVC7S",
+                    "reference": "Random_string",
+                    "title": "Appeal for conviction",
+                    "received_date": "2025-04-11"
+                },
+                {
+                    "id": "a3f937c8-f098-49db-b9be-941c0deb1390",
+                    "short_id": "A25P5N2QPDLU",
+                    "reference": "Random_string",
+                    "title": "Appeal for conviction",
+                    "received_date": "2025-04-11"
+                }
+            ]
         },
         {
             "id": "5ec49191-bf63-416e-9b77-11e61613be6e",
@@ -263,7 +311,23 @@
                     }
                 }
             ],
-            "prosecution_case_reference": "TEST12345"
+            "prosecution_case_reference": "TEST12345",
+            "application_summaries": [
+                {
+                    "id": "f38d0030-0b4a-4fa5-9484-bb37b1e6ab39",
+                    "short_id": "A25ULRHLVC7S",
+                    "reference": "Random_string",
+                    "title": "Appeal for conviction",
+                    "received_date": "2025-04-11"
+                },
+                {
+                    "id": "a3f937c8-f098-49db-b9be-941c0deb1390",
+                    "short_id": "A25P5N2QPDLU",
+                    "reference": "Random_string",
+                    "title": "Appeal for conviction",
+                    "received_date": "2025-04-11"
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
#### What
This ticket is about adding a court application link to kick off the user journey for new appeals.
#### Ticket

[ACD-522](https://dsdmoj.atlassian.net/browse/ACD-522)

#### Why
So that the user can start the appeals journey by clicking the provided link.

#### How
When the search page is run, the VCD API responds with a defendant_summaries payload, which includes an embedded application_summaries payload.

