### PR TITLE
Remove warnings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 inherit_from: .rubocop_todo.yml
 
-require:
+plugins:
   - rubocop-capybara
   - rubocop-factory_bot
   - rubocop-performance

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,10 @@ gem 'bootsnap', '>= 1.7.0', require: false
 
 gem 'breadcrumbs_on_rails'
 gem 'cancancan'
+
+# csv was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.4.0
+gem 'csv', require: false
+
 gem 'devise', '~> 4.9'
 gem 'govuk_notify_rails', '~> 3.0.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,6 +136,7 @@ GEM
       bigdecimal
       rexml
     crass (1.0.6)
+    csv (3.3.2)
     date (3.4.1)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
@@ -588,6 +589,7 @@ DEPENDENCIES
   capybara
   capybara_table
   colorize
+  csv
   devise (~> 4.9)
   dotenv-rails
   factory_bot_rails

--- a/config/application.rb
+++ b/config/application.rb
@@ -48,5 +48,6 @@ module LaaCourtDataUi
     config.x.court_data_api_config.uri = ENV.fetch("COURT_DATA_API_URL", nil)
     config.x.court_data_api_config.user = ENV.fetch("COURT_DATA_API_USERNAME", nil)
     config.x.court_data_api_config.secret = ENV.fetch("COURT_DATA_API_SECRET", nil)
+    config.active_support.to_time_preserves_timezone = :zone
   end
 end


### PR DESCRIPTION
#### What
- Remove CSV and Timezone warnings.
- Specify plugins instead of require: rubocop-capybara
    For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.

#### Ticket
no ticket

#### Why
to keep VCD udpated
