### PR TITLE
ACD-668: Switch to AWS secrets

### DIFF
--- a/.k8s/live/dev/deployment-worker.yaml
+++ b/.k8s/live/dev/deployment-worker.yaml
@@ -55,17 +55,17 @@ spec:
             - name: COURT_DATA_ADAPTOR_API_UID
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: COURT_DATA_ADAPTOR_API_UID
             - name: COURT_DATA_ADAPTOR_API_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: COURT_DATA_ADAPTOR_API_SECRET
             - name: SECRET_KEY_BASE
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: SECRET_KEY_BASE
             - name: DATABASE_URL
               valueFrom:
@@ -85,7 +85,7 @@ spec:
             - name: GOVUK_NOTIFY_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: GOVUK_NOTIFY_API_KEY
         - name: laa-court-data-ui-metrics
           image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/laa-get-paid/laa-court-data-ui:set-me

--- a/.k8s/live/dev/deployment.yaml
+++ b/.k8s/live/dev/deployment.yaml
@@ -68,17 +68,17 @@ spec:
             - name: COURT_DATA_ADAPTOR_API_UID
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: COURT_DATA_ADAPTOR_API_UID
             - name: COURT_DATA_ADAPTOR_API_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: COURT_DATA_ADAPTOR_API_SECRET
             - name: SECRET_KEY_BASE
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: SECRET_KEY_BASE
             - name: DATABASE_URL
               valueFrom:
@@ -98,42 +98,42 @@ spec:
             - name: ADMIN_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: ADMIN_PASSWORD
             - name: CASEWORKER_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: CASEWORKER_PASSWORD
             - name: MANAGER_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: MANAGER_PASSWORD
             - name: GOVUK_NOTIFY_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: GOVUK_NOTIFY_API_KEY
             - name: SLACK_ALERTS_WEBHOOK
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: SLACK_ALERTS_WEBHOOK
             - name: COURT_DATA_API_URL
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: COURT_DATA_API_URL
             - name: COURT_DATA_API_USERNAME
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: COURT_DATA_API_USERNAME
             - name: COURT_DATA_API_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: COURT_DATA_API_SECRET
         - name: laa-court-data-ui-metrics
           image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/laa-get-paid/laa-court-data-ui:set-me

--- a/.k8s/live/production/deployment-worker.yaml
+++ b/.k8s/live/production/deployment-worker.yaml
@@ -51,17 +51,17 @@ spec:
             - name: COURT_DATA_ADAPTOR_API_UID
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: COURT_DATA_ADAPTOR_API_UID
             - name: COURT_DATA_ADAPTOR_API_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: COURT_DATA_ADAPTOR_API_SECRET
             - name: SECRET_KEY_BASE
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: SECRET_KEY_BASE
             - name: DATABASE_URL
               valueFrom:
@@ -81,12 +81,12 @@ spec:
             - name: GOVUK_NOTIFY_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: GOVUK_NOTIFY_API_KEY
             - name: SENTRY_DSN
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: SENTRY_DSN
         - name: laa-court-data-ui-metrics
           image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/laa-get-paid/laa-court-data-ui:set-me

--- a/.k8s/live/production/deployment.yaml
+++ b/.k8s/live/production/deployment.yaml
@@ -66,17 +66,17 @@ spec:
             - name: COURT_DATA_ADAPTOR_API_UID
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: COURT_DATA_ADAPTOR_API_UID
             - name: COURT_DATA_ADAPTOR_API_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: COURT_DATA_ADAPTOR_API_SECRET
             - name: SECRET_KEY_BASE
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: SECRET_KEY_BASE
             - name: DATABASE_URL
               valueFrom:
@@ -96,47 +96,47 @@ spec:
             - name: ADMIN_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: ADMIN_PASSWORD
             - name: CASEWORKER_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: CASEWORKER_PASSWORD
             - name: MANAGER_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: MANAGER_PASSWORD
             - name: GOVUK_NOTIFY_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: GOVUK_NOTIFY_API_KEY
             - name: SENTRY_DSN
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: SENTRY_DSN
             - name: SLACK_ALERTS_WEBHOOK
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: SLACK_ALERTS_WEBHOOK
             - name: COURT_DATA_API_URL
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: COURT_DATA_API_URL
             - name: COURT_DATA_API_USERNAME
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: COURT_DATA_API_USERNAME
             - name: COURT_DATA_API_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: COURT_DATA_API_SECRET
         - name: laa-court-data-ui-metrics
           image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/laa-get-paid/laa-court-data-ui:set-me

--- a/.k8s/live/staging/deployment-worker.yaml
+++ b/.k8s/live/staging/deployment-worker.yaml
@@ -55,17 +55,17 @@ spec:
             - name: COURT_DATA_ADAPTOR_API_UID
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: COURT_DATA_ADAPTOR_API_UID
             - name: COURT_DATA_ADAPTOR_API_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: COURT_DATA_ADAPTOR_API_SECRET
             - name: SECRET_KEY_BASE
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: SECRET_KEY_BASE
             - name: DATABASE_URL
               valueFrom:
@@ -85,12 +85,12 @@ spec:
             - name: GOVUK_NOTIFY_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: GOVUK_NOTIFY_API_KEY
             - name: SENTRY_DSN
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: SENTRY_DSN
         - name: laa-court-data-ui-metrics
           image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/laa-get-paid/laa-court-data-ui:set-me

--- a/.k8s/live/staging/deployment.yaml
+++ b/.k8s/live/staging/deployment.yaml
@@ -68,17 +68,17 @@ spec:
             - name: COURT_DATA_ADAPTOR_API_UID
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: COURT_DATA_ADAPTOR_API_UID
             - name: COURT_DATA_ADAPTOR_API_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: COURT_DATA_ADAPTOR_API_SECRET
             - name: SECRET_KEY_BASE
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: SECRET_KEY_BASE
             - name: DATABASE_URL
               valueFrom:
@@ -98,47 +98,47 @@ spec:
             - name: ADMIN_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: ADMIN_PASSWORD
             - name: CASEWORKER_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: CASEWORKER_PASSWORD
             - name: MANAGER_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: MANAGER_PASSWORD
             - name: GOVUK_NOTIFY_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: GOVUK_NOTIFY_API_KEY
             - name: SENTRY_DSN
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: SENTRY_DSN
             - name: SLACK_ALERTS_WEBHOOK
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: SLACK_ALERTS_WEBHOOK
             - name: COURT_DATA_API_URL
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: COURT_DATA_API_URL
             - name: COURT_DATA_API_USERNAME
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: COURT_DATA_API_USERNAME
             - name: COURT_DATA_API_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: COURT_DATA_API_SECRET
         - name: laa-court-data-ui-metrics
           image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/laa-get-paid/laa-court-data-ui:set-me

--- a/.k8s/live/uat/deployment-worker.yaml
+++ b/.k8s/live/uat/deployment-worker.yaml
@@ -55,17 +55,17 @@ spec:
             - name: COURT_DATA_ADAPTOR_API_UID
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: COURT_DATA_ADAPTOR_API_UID
             - name: COURT_DATA_ADAPTOR_API_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: COURT_DATA_ADAPTOR_API_SECRET
             - name: SECRET_KEY_BASE
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: SECRET_KEY_BASE
             - name: DATABASE_URL
               valueFrom:
@@ -85,12 +85,12 @@ spec:
             - name: GOVUK_NOTIFY_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: GOVUK_NOTIFY_API_KEY
             - name: SENTRY_DSN
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: SENTRY_DSN
         - name: laa-court-data-ui-metrics
           image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/laa-get-paid/laa-court-data-ui:set-me

--- a/.k8s/live/uat/deployment.yaml
+++ b/.k8s/live/uat/deployment.yaml
@@ -68,17 +68,17 @@ spec:
             - name: COURT_DATA_ADAPTOR_API_UID
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: COURT_DATA_ADAPTOR_API_UID
             - name: COURT_DATA_ADAPTOR_API_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: COURT_DATA_ADAPTOR_API_SECRET
             - name: SECRET_KEY_BASE
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: SECRET_KEY_BASE
             - name: DATABASE_URL
               valueFrom:
@@ -98,47 +98,47 @@ spec:
             - name: ADMIN_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: ADMIN_PASSWORD
             - name: CASEWORKER_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: CASEWORKER_PASSWORD
             - name: MANAGER_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: MANAGER_PASSWORD
             - name: GOVUK_NOTIFY_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: GOVUK_NOTIFY_API_KEY
             - name: SENTRY_DSN
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: SENTRY_DSN
             - name: SLACK_ALERTS_WEBHOOK
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: SLACK_ALERTS_WEBHOOK
             - name: COURT_DATA_API_URL
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: COURT_DATA_API_URL
             - name: COURT_DATA_API_USERNAME
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: COURT_DATA_API_USERNAME
             - name: COURT_DATA_API_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: lcdui-secrets
+                  name: aws-secrets
                   key: COURT_DATA_API_SECRET
         - name: laa-court-data-ui-metrics
           image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/laa-get-paid/laa-court-data-ui:set-me


### PR DESCRIPTION
#### What
We are creating new `aws-secrets` which are backed by AWS secret manager, giving us accidental deletion protection as well as a nice UI for secret access and rotation. This PR updates VCD to pull secret values from the new secret

#### Ticket

[Migrate VCD secrets to AWS secret manager](https://dsdmoj.atlassian.net/browse/ACD-668)

