### PR TITLE
ACD-688: ENV expects a stringy value

### DIFF
--- a/helm_deploy/values/production.yaml
+++ b/helm_deploy/values/production.yaml
@@ -9,6 +9,6 @@ env: production
 host: view-court-data.service.justice.gov.uk
 cdaHost: https://court-data-adaptor.service.justice.gov.uk/api/internal/v1
 googleAnalyticsId: 'UA-131160087-15'
-displayRawResponses: false
+displayRawResponses: "false"
 identifier: laa-court-data-ui-app-ingress-laa-court-data-ui-production-green
 cert: laa-court-data-ui-production-cert


### PR DESCRIPTION
We need the env var to have the string value "false" in production (because all env vars are strings). I accidentally set it as a boolean in yaml, and prod deployments are failing with "cannot unmarshal bool into Go struct field EnvVar.spec.template.spec.containers.env.value of type string"
