### PR TITLE
ACD-700: Do not crash if hearings are unresulted

### DIFF
--- a/app/decorators/cd_api/hearing_decorator.rb
+++ b/app/decorators/cd_api/hearing_decorator.rb
@@ -4,16 +4,24 @@ module CdApi
   class HearingDecorator < BaseDecorator
     attr_accessor :current_sitting_day, :skip_mapping_counsels_to_defendants
 
+    def loaded?
+      object.attributes.any?
+    end
+
     def cracked_ineffective_trial
       @cracked_ineffective_trial ||= decorate(object.hearing.cracked_ineffective_trial,
                                               CdApi::CrackedIneffectiveTrialDecorator)
     end
 
     def defence_counsels_list
+      return t('generic.not_available') unless loaded?
+
       safe_join(defence_counsel_sentences, tag.br)
     end
 
     def prosecution_counsels_list
+      return t('generic.not_available') unless loaded?
+
       formatted_prosecution_counsels = filter_prosecution_counsels.map { |pc| "#{pc.first_name&.capitalize} #{pc.last_name&.capitalize}" }
 
       return t('generic.not_available') if formatted_prosecution_counsels.blank?
@@ -22,7 +30,7 @@ module CdApi
     end
 
     def judiciary_list
-      return t('generic.not_available') if hearing.judiciary.none?
+      return t('generic.not_available') if !loaded? || hearing.judiciary.none?
 
       safe_join(hearing.judiciary.map { |jd| "#{jd.title} #{jd.first_name} #{jd.last_name}" }, tag.br)
     end

--- a/app/views/hearing_days/show.html.haml
+++ b/app/views/hearing_days/show.html.haml
@@ -82,7 +82,7 @@
       %p.govuk-body
         = t('.event.none')
 
-    = render partial: 'hearings/court_applications', locals: { hearing: @hearing_details.hearing }
+    = render partial: 'hearings/court_applications', locals: { hearing: (@hearing_details.hearing if @hearing_details.loaded?) }
 
     - if @application.subject_summary.proceedings_concluded
       .govuk-heading-l

--- a/spec/features/application_hearings_spec.rb
+++ b/spec/features/application_hearings_spec.rb
@@ -7,6 +7,7 @@ RSpec.feature 'Court Application Hearings', :vcr do
   let(:first_hearing_day) { '2019-10-23' }
   let(:problematic_application_id) { 'problematic-application-id' }
   let(:erroring_hearing_id) { 'erroring-hearing-id' }
+  let(:unresulted_hearing_id) { 'unresulted-hearing-id' }
   let(:problematic_hearing_id) { 'problematic-hearing-id' }
   let(:erroring_hearing_day) { '2025-04-10' }
   let(:missing_hearing_day) { '2025-04-11' }
@@ -89,6 +90,16 @@ RSpec.feature 'Court Application Hearings', :vcr do
                                                      erroring_hearing_id,
                                                      first_hearing_day)
     expect(page).to have_content "Sorry, something went wrong"
+  end
+
+  scenario 'Hearing is not resulted' do
+    sign_in user
+    visit court_application_hearing_hearing_day_path(problematic_application_id,
+                                                     unresulted_hearing_id,
+                                                     first_hearing_day)
+    # Page can be viewed, just missing data that is not returned
+    expect(page).to have_content "Appellant advocates\nNot available"
+    expect(page).to have_content "11:20 Est ut cum placeat"
   end
 
   scenario 'Hearing events are not available' do

--- a/spec/fixtures/vcr_cassettes/spec/features/application_hearings_spec.yml
+++ b/spec/fixtures/vcr_cassettes/spec/features/application_hearings_spec.yml
@@ -425,6 +425,10 @@ http_interactions:
         - Defendant to Attend (MDA)","estimated_duration":null,"defendant_ids":["ecca893f-0928-4fc6-ae50-6a8794b78c5c"],"jurisdiction_type":"CROWN","court_centre":{"id":"6131bd34-33d9-3d1e-8152-8b5a2084f1bd","name":"Derby
         Crown Court","welsh_name":"Llys Y Goron Derby","room_id":null,"room_name":null,"welsh_room_name":null,"welsh_court_centre":null,"short_oucode":"C30DE","oucode_l2_code":"30","code":"C30DE00","address":{"address_1":"Derby
         Combined Court Centre","address_2":"Morledge","address_3":"Derby","address_4":"","address_5":"","postcode":"DE1
+        2XE"}},"hearing_days":[{"sitting_day":"2019-10-23T16:19:15.000Z","listing_sequence":1,"listed_duration_minutes":120,"has_shared_results":false}],"defence_counsels":[]},{"id":"unresulted-hearing-id","hearing_type":"Mention
+        - Defendant to Attend (MDA)","estimated_duration":null,"defendant_ids":["ecca893f-0928-4fc6-ae50-6a8794b78c5c"],"jurisdiction_type":"CROWN","court_centre":{"id":"6131bd34-33d9-3d1e-8152-8b5a2084f1bd","name":"Derby
+        Crown Court","welsh_name":"Llys Y Goron Derby","room_id":null,"room_name":null,"welsh_room_name":null,"welsh_court_centre":null,"short_oucode":"C30DE","oucode_l2_code":"30","code":"C30DE00","address":{"address_1":"Derby
+        Combined Court Centre","address_2":"Morledge","address_3":"Derby","address_4":"","address_5":"","postcode":"DE1
         2XE"}},"hearing_days":[{"sitting_day":"2019-10-23T16:19:15.000Z","listing_sequence":1,"listed_duration_minutes":120,"has_shared_results":false}],"defence_counsels":[]},{"id":"problematic-hearing-id","hearing_type":"Pre-Trial
         Review (PTR)","estimated_duration":null,"defendant_ids":["ecca893f-0928-4fc6-ae50-6a8794b78c5c"],"jurisdiction_type":"CROWN","court_centre":{"id":"68c7e9af-2db7-3fc3-b6e8-e51653120790","name":"Maidstone
         Magistrates'' Court","welsh_name":"Llys Ynadon Maidstone","room_id":null,"room_name":null,"welsh_room_name":null,"welsh_court_centre":null,"short_oucode":"B46IR","oucode_l2_code":"46","code":"B46IR00","address":{"address_1":"The
@@ -513,6 +517,58 @@ http_interactions:
         {"id": null, "code": null, "description": null, "type": null, "date": null},
         "prosecution_cases": [], "defendant_judicial_results": [], "defendant_attendance":
         []}, "shared_time": "2025-03-06T12:10:56.016+00:00"}'
+  recorded_at: Mon, 14 Apr 2025 11:06:05 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/v2/hearings/unresulted-hearing-id?date=2019-10-23
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic <Basic>
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Laa-Transaction-Id:
+      - 186944fc-3c7e-4a57-b0f6-3b791c699a9f
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: OK
+    headers:
+      Date:
+      - Mon, 14 Apr 2025 11:06:05 GMT
+      Server:
+      - uvicorn
+      Content-Length:
+      - '1167'
+      Content-Type:
+      - application/json; charset=utf-8
+      Laa-Transaction-Id:
+      - 186944fc-3c7e-4a57-b0f6-3b791c699a9f
+      Access-Control-Expose-Headers:
+      - Laa-Transaction-Id
+      Cache-Control:
+      - no-store
+      Content-Security-Policy:
+      - default-src 'self'; base-uri 'self'; img-src 'self' fastapi.tiangolo.com data:;
+        style-src 'self' cdn.jsdelivr.net 'unsafe-inline'; script-src 'self' cdn.jsdelivr.net
+        'unsafe-inline'
+      Strict-Transport-Security:
+      - includeSubDomains; preload; max-age=2592000
+      Referrer-Policy:
+      - no-referrer
+      X-Frame-Options:
+      - SAMEORIGIN
+    body:
+      encoding: UTF-8
+      string: ''
   recorded_at: Mon, 14 Apr 2025 11:06:05 GMT
 - request:
     method: get
@@ -1162,6 +1218,63 @@ http_interactions:
 - request:
     method: get
     uri: http://localhost:8000/v2/hearings/0304d126-d773-41fd-af01-83e017cecd80/hearing_events?date=2019-10-23
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic <Basic>
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Laa-Transaction-Id:
+      - b451944d-e2a3-4cd5-bae7-4fbaca496116
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 14 Apr 2025 16:01:47 GMT
+      Server:
+      - uvicorn
+      Content-Length:
+      - '437'
+      Content-Type:
+      - application/json; charset=utf-8
+      Laa-Transaction-Id:
+      - b451944d-e2a3-4cd5-bae7-4fbaca496116
+      Access-Control-Expose-Headers:
+      - Laa-Transaction-Id
+      Cache-Control:
+      - no-store
+      Content-Security-Policy:
+      - default-src 'self'; base-uri 'self'; img-src 'self' fastapi.tiangolo.com data:;
+        style-src 'self' cdn.jsdelivr.net 'unsafe-inline'; script-src 'self' cdn.jsdelivr.net
+        'unsafe-inline'
+      Strict-Transport-Security:
+      - includeSubDomains; preload; max-age=2592000
+      Referrer-Policy:
+      - no-referrer
+      X-Frame-Options:
+      - SAMEORIGIN
+    body:
+      encoding: UTF-8
+      string: '{"hearing_id": "0304d126-d773-41fd-af01-83e017cecd80", "has_active_hearing":
+        true, "events": [{"id": "4c523134-3e18-407a-94e5-6e9ad5cb507c", "definition_id":
+        "641d53b9-8ae9-40ac-be90-c884bcfd47f8", "defence_counsel_id": null, "recorded_label":
+        "Est ut cum placeat.", "event_time": "2019-10-23T11:20:46.344000+00:00", "last_modified_time":
+        "2025-03-21T11:20:46.344000+00:00", "alterable": false, "note": "Praesentium
+        animi hic dolore."}]}'
+  recorded_at: Mon, 14 Apr 2025 16:01:48 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/v2/hearings/unresulted-hearing-id/hearing_events?date=2019-10-23
     body:
       encoding: US-ASCII
       string: ''


### PR DESCRIPTION
#### What
Court applications come with a list of hearing summaries, including unresulted hearings. We link to a hearing details page for each hearing summary. On the hearing details page we try to load hearing details from HMCTS. But we believe (based on how it works for prosecution case hearings) that HMCTS will return a blank response for hearing details which CDA will turn into a 404. For prosecution cases we gracefully handle this.

This PR adds the same graceful handling logic to court application hearings that we already have for prosecution case hearings, so that we don't crash when viewing details of unresulted hearings.