### PR TITLE
ACD-701: Show offence dates

### DIFF
--- a/app/decorators/offence_decorator.rb
+++ b/app/decorators/offence_decorator.rb
@@ -14,6 +14,12 @@ class OffenceDecorator < BaseDecorator
     safe_join(mode_of_trial_reason_descriptions.compact, tag.br)
   end
 
+  def start_date
+    return unless super
+
+    Date.parse(super).strftime("%d/%m/%Y")
+  end
+
   private
 
   def plea_sentences

--- a/app/views/defendants/_offences.html.haml
+++ b/app/views/defendants/_offences.html.haml
@@ -6,12 +6,15 @@
     = t('search.result.offence.caption')
   %thead.govuk-table__head
     %tr.govuk-table__row
+      %th.govuk-table__header{ scope: 'col' }= t('search.result.offence.date')
       %th.govuk-table__header{ scope: 'col' }= t('search.result.offence.title')
       %th.govuk-table__header{ scope: 'col' }= t('search.result.offence.plea')
       %th.govuk-table__header{ scope: 'col' }= t('search.result.offence.mode_of_trial')
   %tbody.govuk-table__body
     - decorate_each(defendant.offences) do |offence|
       %tr.govuk-table__row
+        %td.govuk-table__cell
+          = offence.start_date || t('generic.not_available')
         %td.govuk-table__cell
           = offence.title || t('generic.not_available')
           %span.app-body-secondary

--- a/config/locales/en/views/searches.yml
+++ b/config/locales/en/views/searches.yml
@@ -41,6 +41,7 @@ en:
         providers: Providers attending
       offence:
         caption: Offence list
+        date: Date
         heading: Offences
         mode_of_trial: Mode of trial
         plea: Plea

--- a/lib/court_data_adaptor/resource/offence.rb
+++ b/lib/court_data_adaptor/resource/offence.rb
@@ -12,6 +12,7 @@ module CourtDataAdaptor
       property :pleas, type: :plea_collection, default: []
       property :mode_of_trial, type: :string
       property :mode_of_trial_reasons, type: :mode_of_trial_reason_collection, default: []
+      property :start_date, type: :string
     end
   end
 end

--- a/spec/decorators/offence_decorator_spec.rb
+++ b/spec/decorators/offence_decorator_spec.rb
@@ -115,6 +115,24 @@ RSpec.describe OffenceDecorator, type: :decorator do
     end
   end
 
+  describe '#start_date' do
+    context 'when there is a start date' do
+      before { allow(offence).to receive(:start_date).and_return("2023-01-05") }
+
+      it "formats it" do
+        expect(decorator.start_date).to eq "05/01/2023"
+      end
+    end
+
+    context 'when there is no start date' do
+      before { allow(offence).to receive(:start_date).and_return(nil) }
+
+      it "returns nil" do
+        expect(decorator.start_date).to be_nil
+      end
+    end
+  end
+
   describe '#mode_of_trial_reason_list' do
     subject(:call) { decorator.mode_of_trial_reason_list }
 

--- a/spec/views/defendants/_offences.html.haml_spec.rb
+++ b/spec/views/defendants/_offences.html.haml_spec.rb
@@ -11,6 +11,24 @@ RSpec.describe 'defendants/_offences.html.haml', type: :view do
       assign(:defendant, defendant)
     end
 
+    context 'when offence has a start date' do
+      before { allow(offence).to receive(:start_date).and_return('2023-01-01') }
+
+      it 'displays offence start date' do
+        is_expected.to have_css('.govuk-table__cell',
+                                text: %r{01/01/2023})
+      end
+    end
+
+    context 'when offence has no start date' do
+      before { allow(offence).to receive(:start_date).and_return(nil) }
+
+      it 'displays no offence start date' do
+        is_expected.to have_css('.govuk-table__cell',
+                                text: /Not available/)
+      end
+    end
+
     context 'when the offence has a mode of trial' do
       before { allow(offence).to receive(:mode_of_trial).and_return('Indictable only') }
 


### PR DESCRIPTION
#### What
Implement the offence date UI that we designed for the v2 view, now that it's available in the v1 endpoint

#### Ticket

[Surface offence summary `startDate` in VCD](https://dsdmoj.atlassian.net/browse/ACD-701)

#### Why

#### How

--------

#### TODO (wip)

 - [ ] item 1
 - [X] item 2
 - [X] Has the Acceptance Criteria been met
