### PR TITLE
ACD-280: Disable turbo-forms

### DIFF
--- a/app/assets/javascript/application.js
+++ b/app/assets/javascript/application.js
@@ -1,10 +1,7 @@
-// This file is automatically compiled by Webpack, along with any other files
-// present in this directory. You're encouraged to place your actual application logic in
-// a relevant structure within app/javascript and only use these pack files to reference
-// that code so it'll be compiled.
-
+/* global Turbo */
 import '../stylesheets/application.scss'
 import '@hotwired/turbo'
+
 import Rails from '@rails/ujs'
 
 // Prevent turbo from intercepting form submissions in ways that don't play nicely
@@ -13,7 +10,7 @@ import Rails from '@rails/ujs'
 //    individual forms
 // 2) This doesn't disable turbo as a whole, so it will still do link-prefetching,
 //    and the turbo-frame system used for the cookie banner will still work.
-Turbo.config.forms.mode = "off"
+Turbo.config.forms.mode = 'off'
 
 Rails.start()
 

--- a/app/assets/javascript/application.js
+++ b/app/assets/javascript/application.js
@@ -7,6 +7,14 @@ import '../stylesheets/application.scss'
 import '@hotwired/turbo'
 import Rails from '@rails/ujs'
 
+// Prevent turbo from intercepting form submissions in ways that don't play nicely
+// with things like the Rails flash system. Note:
+// 1) This avoids the need for having to a add a `data-turbo=false` annotation to
+//    individual forms
+// 2) This doesn't disable turbo as a whole, so it will still do link-prefetching,
+//    and the turbo-frame system used for the cookie banner will still work.
+Turbo.config.forms.mode = "off"
+
 Rails.start()
 
 // Uncomment to copy all static images under ../images to the output folder and reference

--- a/app/views/cookies/_form.html.haml
+++ b/app/views/cookies/_form.html.haml
@@ -1,4 +1,4 @@
-= form_for cookie, local: true, url: cookies_settings_path, html: { class: 'app-js-only', "data-turbo": false } do |f|
+= form_for cookie, local: true, url: cookies_settings_path, html: { class: 'app-js-only' } do |f|
   %h2.govuk-heading-l{ "data-cy" => "cookie-settings" }
     = t('cookie_settings.section_settings.heading')
 

--- a/app/views/devise/passwords/new.html.haml
+++ b/app/views/devise/passwords/new.html.haml
@@ -4,6 +4,6 @@
     = form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
       = f.govuk_error_summary
       = f.govuk_email_field(:email, label: { text: 'Email' }, autofocus: true, autocomplete: 'email')
-      = f.govuk_submit(t('devise.passwords.user.form.reset.submit'), "data-turbo": 'false')
+      = f.govuk_submit(t('devise.passwords.user.form.reset.submit'))
 
     = render "devise/shared/links"

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -25,6 +25,6 @@
                                            legend: { text: 'Remember me', size: 's' },
                                            hint: { text: 'Do you want to be remembered on this computer?' }
 
-        = f.govuk_submit(t('devise.sessions.user.form.submit'), "data-cy": 'login-submit', "data-turbo": 'false')
+        = f.govuk_submit(t('devise.sessions.user.form.submit'), "data-cy": 'login-submit')
 
     = render "devise/shared/links"

--- a/app/views/devise/unlocks/new.html.haml
+++ b/app/views/devise/unlocks/new.html.haml
@@ -5,6 +5,6 @@
     = form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f|
       = f.govuk_error_summary
       = f.govuk_email_field(:email, label: { text: 'Email' }, autofocus: true, autocomplete: 'email')
-      = f.govuk_submit(t('devise.unlocks.user.form.submit'), "data-turbo": 'false')
+      = f.govuk_submit(t('devise.unlocks.user.form.submit'))
 
     = render "devise/shared/links"

--- a/app/views/searches/_form.html.haml
+++ b/app/views/searches/_form.html.haml
@@ -1,4 +1,4 @@
-= form_with model: search, html: { "data-turbo": false } do |f|
+= form_with model: search do |f|
   .govuk-grid-row
     .govuk-grid-column-two-thirds
       = f.govuk_error_summary

--- a/app/views/users/_form.html.haml
+++ b/app/views/users/_form.html.haml
@@ -25,4 +25,4 @@
                                    :titlecase,
                                    legend: { text: t('users.form.fields.roles_legend') }
 
-  = f.govuk_submit(t('users.form.fields.save_button'), "data-turbo": 'false')
+  = f.govuk_submit(t('users.form.fields.save_button'))

--- a/app/views/users/change_password.html.haml
+++ b/app/views/users/change_password.html.haml
@@ -13,4 +13,4 @@
   = f.govuk_password_field(:password_confirmation,
                            label: { text: t('users.change_password.confirm_password_label') })
 
-  = f.govuk_submit(t('users.change_password.change_password_button'), "data-turbo": 'false')
+  = f.govuk_submit(t('users.change_password.change_password_button'))

--- a/config/locales/en/views/layouts.yml
+++ b/config/locales/en/views/layouts.yml
@@ -6,7 +6,7 @@ en:
         accept_cookies: Accept analytics cookies
         analytics_cookies: We'd also like to use analytics cookies so we can understand how you use the service and make improvements.
         confirmation_accept: You've accepted additional cookies.
-        confirmation_link_to_settings_html: You can <a class="govuk-link" href="%{href}" data-turbo="false">change your cookie settings</a> at any time.
+        confirmation_link_to_settings_html: You can <a class="govuk-link" href="%{href}">change your cookie settings</a> at any time.
         confirmation_reject: You've rejected additional cookies.
         cookie_settings: Cookie settings
         essential_cookies: We use some essential cookies to make this service work.


### PR DESCRIPTION
#### What
Turbo forms has lots of unhelpful side effects. We currently disable it on a per-form basis, but as there's no form where we _do_ want it, it's easier to disable it globally.