### PR TITLE
Allow explicit use of turbo

### DIFF
--- a/app/assets/javascript/application.js
+++ b/app/assets/javascript/application.js
@@ -10,7 +10,7 @@ import Rails from '@rails/ujs'
 //    individual forms
 // 2) This doesn't disable turbo as a whole, so it will still do link-prefetching,
 //    and the turbo-frame system used for the cookie banner will still work.
-Turbo.config.forms.mode = 'off'
+Turbo.config.forms.mode = 'optin'
 
 Rails.start()
 

--- a/app/assets/javascript/application.js
+++ b/app/assets/javascript/application.js
@@ -5,11 +5,13 @@ import '@hotwired/turbo'
 import Rails from '@rails/ujs'
 
 // Prevent turbo from intercepting form submissions in ways that don't play nicely
-// with things like the Rails flash system. Note:
+// with things like the Rails flash system, unless it's explicitly asked for. Note:
 // 1) This avoids the need for having to a add a `data-turbo=false` annotation to
 //    individual forms
 // 2) This doesn't disable turbo as a whole, so it will still do link-prefetching,
 //    and the turbo-frame system used for the cookie banner will still work.
+// 3) the `data-turbo-method="delete" annotation on anchors is controlled by this setting,
+//    so switching this to "off" would disable those.
 Turbo.config.forms.mode = 'optin'
 
 Rails.start()


### PR DESCRIPTION
#### What
I turned off Turbo Forms to stop form submissions being intercepted (and occasionally broken) by Turbo. BUT in doing so I turned off Turbo's "sneakily turn this link into a button" functionality, which is how sign-out and delete-user links work.

By switching the mode to "opt-in", Turbo won't kick in unless it's explicitly asked via thing like the `turbo_method` annotation. That way it won't interfere with forms, but it will do "sneakily turn this link into a button".