### PR TITLE
ACD-368: Add MAAT reference when unlinking court applications

### DIFF
--- a/app/controllers/subjects_controller.rb
+++ b/app/controllers/subjects_controller.rb
@@ -49,20 +49,25 @@ class SubjectsController < ApplicationController
   end
 
   def load_link
-    @form_model = if @link_status.maat_linked?
-                    UnlinkAttempt.new(
-                      defendant_id: @subject.subject_id,
-                      username: current_user.username,
-                      reason_code: params.dig(:unlink_attempt, :reason_code).to_i,
-                      other_reason_text: params.dig(:unlink_attempt, :other_reason_text)
-                    )
-                  else
-                    LinkAttempt.new(
-                      defendant_id: @subject.subject_id,
-                      username: current_user.username,
-                      maat_reference: params.dig(:link_attempt, :maat_reference)
-                    )
-                  end
+    @form_model = @link_status.maat_linked? ? load_unlink_attempt : load_link_attempt
+  end
+
+  def load_unlink_attempt
+    UnlinkAttempt.new(
+      defendant_id: @subject.subject_id,
+      username: current_user.username,
+      reason_code: params.dig(:unlink_attempt, :reason_code).to_i,
+      other_reason_text: params.dig(:unlink_attempt, :other_reason_text),
+      maat_reference: @subject.maat_reference
+    )
+  end
+
+  def load_link_attempt
+    LinkAttempt.new(
+      defendant_id: @subject.subject_id,
+      username: current_user.username,
+      maat_reference: params.dig(:link_attempt, :maat_reference)
+    )
   end
 
   def handle_link_failure(message)

--- a/lib/court_data_adaptor/query/unlink_court_application.rb
+++ b/lib/court_data_adaptor/query/unlink_court_application.rb
@@ -24,7 +24,8 @@ module CourtDataAdaptor
             subject_id: unlink_object.defendant_id,
             user_name: unlink_object.username,
             unlink_reason_code: unlink_object.reason_code,
-            unlink_other_reason_text: (unlink_object.other_reason_text if unlink_object.text_required?)
+            unlink_other_reason_text: (unlink_object.other_reason_text if unlink_object.text_required?),
+            maat_reference: unlink_object.maat_reference
           }
         }
       end

--- a/spec/features/unlink_court_applications_spec.rb
+++ b/spec/features/unlink_court_applications_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature 'Unlink court applications' do
   context "when there are no problems upstream" do
     around do |example|
       VCR.use_cassette('spec/features/unlink_court_applications_successfully_spec',
-                       match_requests_on: %i[method path query]) do
+                       match_requests_on: %i[method path query body]) do
         example.run
       end
     end
@@ -34,26 +34,6 @@ RSpec.feature 'Unlink court applications' do
       expect(page).to have_content "You have successfully unlinked from the court data source"
       expect(page).to have_no_content "MAAT number 1234568"
       expect(page).to have_content "Enter the MAAT ID"
-    end
-
-    scenario 'I send correct params to CDA' do
-      unlink_stub = stub_request(:patch, /.*court_application_laa_references.*/).with(
-        body: {
-          laa_reference: {
-            subject_id: "6c3eded6-a6d6-4156-940d-e3b5f02deb96",
-            user_name: "kova-a81",
-            unlink_reason_code: 4,
-            unlink_other_reason_text: nil,
-            maat_reference: "1234568"
-          }
-        }.to_json
-      ).to_return(status: 202)
-      visit court_application_subject_path(linked_court_application_id)
-      find("summary", text: "Remove link to court data").click
-      select "Initially processed on Libra", from: "Reason for unlinking"
-      click_on "Remove link to court data"
-      expect(page).to have_content "You have successfully unlinked from the court data source"
-      expect(unlink_stub).to have_been_requested
     end
 
     scenario 'I try to unlink without selecting a reason' do

--- a/spec/fixtures/vcr_cassettes/spec/features/unlink_court_applications_successfully_spec.yml
+++ b/spec/fixtures/vcr_cassettes/spec/features/unlink_court_applications_successfully_spec.yml
@@ -195,7 +195,7 @@ http_interactions:
     uri: http://localhost:9292/api/internal/v2/court_application_laa_references/6c3eded6-a6d6-4156-940d-e3b5f02deb96
     body:
       encoding: UTF-8
-      string: '{"laa_reference":{"subject_id":"6c3eded6-a6d6-4156-940d-e3b5f02deb96","user_name":"roha-t4","unlink_reason_code":4,"unlink_other_reason_text":""}}'
+      string: '{"laa_reference":{"subject_id":"6c3eded6-a6d6-4156-940d-e3b5f02deb96","user_name":"kova-a81","unlink_reason_code":4,"unlink_other_reason_text":null,"maat_reference":"1234568"}}'
     headers:
       User-Agent:
       - Faraday v1.10.4


### PR DESCRIPTION
#### What
As a defence against weird situations where the CDA database ends up with multiple LaaReference records for the same subject ID with different MAAT references, when unlinking court applications, pass in the MAAT reference we want to unlink _from_. (We already do this for prosecution cases).
