### PR TITLE
ACD-806: Show error codes

### DIFF
--- a/app/controllers/defendants_controller.rb
+++ b/app/controllers/defendants_controller.rb
@@ -98,7 +98,7 @@ class DefendantsController < ApplicationController
   def handle_error(exception, title, details)
     logger.error 'SERVER_ERROR_OCCURRED'
     log_sentry_error(exception, exception.errors)
-    render_edit(title, details)
+    render_edit(title, cda_error_string(exception) || details)
   end
 
   def set_unlink_reasons

--- a/app/controllers/hearings_controller.rb
+++ b/app/controllers/hearings_controller.rb
@@ -47,7 +47,7 @@ class HearingsController < ApplicationController
     @hearing ||= helpers.decorate(Cda::Hearing.new, Cda::HearingDecorator)
   rescue ActiveResource::ServerError, ActiveResource::ClientError => e
     log_and_capture_error(e, 'SERVER_ERROR_OCCURRED')
-    redirect_to_prosecution_case(alert: I18n.t('hearings.show.flash.notice.server_error'))
+    redirect_to_prosecution_case(alert: server_error_message(e))
   end
 
   def set_hearing_day
@@ -93,11 +93,15 @@ class HearingsController < ApplicationController
     @prosecution_case = helpers.decorate(@prosecution_case_search.call, Cda::CaseSummaryDecorator)
   rescue ActiveResource::ServerError, ActiveResource::ClientError => e
     log_and_capture_error(e, 'SERVER_ERROR_OCCURRED')
-    redirect_to_prosecution_case(alert: I18n.t('hearings.show.flash.notice.server_error'))
+    redirect_to_prosecution_case(alert: server_error_message(e))
   end
 
   def show_alert(title, message)
     flash.now[:alert] = { title:, message: }
+  end
+
+  def server_error_message(exception)
+    cda_error_string(exception) || I18n.t('hearings.show.flash.notice.server_error')
   end
 
   def hearing_id

--- a/app/controllers/laa_references_controller.rb
+++ b/app/controllers/laa_references_controller.rb
@@ -32,9 +32,10 @@ class LaaReferencesController < ApplicationController
 
   def defendant
     @defendant ||= @defendant_search.call
-  rescue CourtDataAdaptor::Errors::UnprocessableEntity
+  rescue CourtDataAdaptor::Errors::UnprocessableEntity => e
     logger.info 'CDA_GETDEFENDANT_RETURNED_UNPROCESSABLE'
-    flash[:alert] = I18n.t('error.connection_error_message', it_helpdesk: I18n.t('error.it_helpdesk'))
+    flash[:alert] =
+      I18n.t('error.connection_error_message', details: cda_error_string(e) || I18n.t('error.it_helpdesk'))
     redirect_back(fallback_location: authenticated_root_path)
   end
 
@@ -95,7 +96,7 @@ class LaaReferencesController < ApplicationController
   def handle_error(exception, title, details)
     logger.error 'SERVER_ERROR_OCCURRED'
     log_sentry_error(exception, exception.errors)
-    render_new(title, details)
+    render_new(title, cda_error_string(exception) || details)
   end
 
   def no_maat_id?

--- a/app/controllers/prosecution_cases_controller.rb
+++ b/app/controllers/prosecution_cases_controller.rb
@@ -21,13 +21,13 @@ class ProsecutionCasesController < ApplicationController
 
   def set_prosecution_case
     build_prosecution_case
-  rescue ActiveResource::BadRequest
+  rescue ActiveResource::BadRequest => e
     logger.info 'CLIENT_ERROR_OCCURRED'
-    redirect_to_search_path
+    redirect_to_search_path(e)
   rescue ActiveResource::ServerError, ActiveResource::ClientError => e
     logger.error 'SERVER_ERROR_OCCURRED'
     Sentry.capture_exception(e)
-    redirect_to_search_path
+    redirect_to_search_path(e)
   end
 
   def build_prosecution_case
@@ -48,8 +48,8 @@ class ProsecutionCasesController < ApplicationController
     params[:id]
   end
 
-  def redirect_to_search_path
+  def redirect_to_search_path(exception)
     redirect_to searches_path(search: { filter: 'case_reference', term: urn })
-    flash[:notice] = I18n.t('prosecution_case.show.failure')
+    flash[:notice] = cda_error_string(exception) || I18n.t('prosecution_case.show.failure')
   end
 end

--- a/app/controllers/prosecution_cases_controller.rb
+++ b/app/controllers/prosecution_cases_controller.rb
@@ -31,7 +31,7 @@ class ProsecutionCasesController < ApplicationController
   end
 
   def build_prosecution_case
-    raise(ActiveResource::BadRequest, "URN not found") unless search_results
+    raise(ActiveResource::BadRequest, "URN '#{urn}' not found") unless search_results
     @prosecution_case ||= helpers.decorate(search_results, Cda::CaseSummaryDecorator)
     update_prosecution_case
   end

--- a/app/controllers/prosecution_cases_controller.rb
+++ b/app/controllers/prosecution_cases_controller.rb
@@ -31,6 +31,7 @@ class ProsecutionCasesController < ApplicationController
   end
 
   def build_prosecution_case
+    raise(ActiveResource::BadRequest, "URN not found") unless search_results
     @prosecution_case ||= helpers.decorate(search_results, Cda::CaseSummaryDecorator)
     update_prosecution_case
   end

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -80,7 +80,7 @@ class SearchesController < ApplicationController
     logger.error 'SERVER_ERROR_OCCURRED'
 
     log_sentry_error(exception, exception.response.body)
-    render_error(I18n.t('search.error.failure'), I18n.t('error.it_helpdesk'))
+    render_error(I18n.t('search.error.failure'), cda_error_string(exception) || I18n.t('error.it_helpdesk'))
   end
 
   def render_error(title, message)

--- a/app/controllers/subjects_controller.rb
+++ b/app/controllers/subjects_controller.rb
@@ -21,7 +21,7 @@ class SubjectsController < ApplicationController
   rescue ActiveModel::ValidationError,
          CourtDataAdaptor::Errors::BadRequest,
          CourtDataAdaptor::Errors::UnprocessableEntity => e
-    handle_link_failure(e.message)
+    handle_link_failure(e.message, e)
   ensure
     render :show unless performed?
   end
@@ -38,7 +38,7 @@ class SubjectsController < ApplicationController
   rescue ActiveModel::ValidationError,
          CourtDataAdaptor::Errors::BadRequest,
          CourtDataAdaptor::Errors::UnprocessableEntity => e
-    handle_unlink_failure(e.message)
+    handle_unlink_failure(e.message, e)
   ensure
     render :show unless performed?
   end
@@ -80,13 +80,13 @@ class SubjectsController < ApplicationController
     )
   end
 
-  def handle_link_failure(message)
+  def handle_link_failure(message, exception = nil)
     logger.warn "LINK FAILURE (params: #{@form_model.as_json}): #{message}"
-    @form_model.errors.add(:maat_reference, t('subjects.link.failure'))
+    @form_model.errors.add(:maat_reference, cda_error_string(exception) || t('subjects.link.failure'))
   end
 
-  def handle_unlink_failure(message)
+  def handle_unlink_failure(message, exception = nil)
     logger.warn "UNLINK FAILURE (params: #{@form_model.as_json}): #{message}"
-    @form_model.errors.add(:reason_code, t('subjects.unlink.failure'))
+    @form_model.errors.add(:reason_code, cda_error_string(exception) || t('subjects.unlink.failure'))
   end
 end

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -121,6 +121,7 @@ ignore_unused:
 - activemodel.errors.models.*
 - activerecord.errors.models.*
 - court_applications.results.*
+- cda_errors.*
 
 ## Exclude these keys from the `i18n-tasks eq-base' report:
 # ignore_eq_base:

--- a/config/locales/en/cda_errors.yml
+++ b/config/locales/en/cda_errors.yml
@@ -1,0 +1,7 @@
+---
+en:
+  cda_errors:
+    commmon_platform_connection_failed: HMCTS Common Platform could not be reached. This may be a temporary error. If this problem persists, please contact the IT Helpdesk on 0800 9175148.
+    defendant_id_contract_failure: The defendant you are trying to link is not in a valid state to be linked.
+    maat_reference_contract_failure: The MAAT reference you provided is not available to be associated with this defendant.
+    multiple_maats: The HMCTS Common Platform record for this defendant is corrupted and cannot be displayed. HMCTS is aware of this issue.

--- a/config/locales/en/cda_errors.yml
+++ b/config/locales/en/cda_errors.yml
@@ -5,3 +5,4 @@ en:
     defendant_id_contract_failure: The defendant you are trying to link is not in a valid state to be linked.
     maat_reference_contract_failure: The MAAT reference you provided is not available to be associated with this defendant.
     multiple_maats: The HMCTS Common Platform record for this defendant is corrupted and cannot be displayed. HMCTS is aware of this issue.
+    subject_id_contract_failure: The appellant you are trying to link is not in a valid state to be linked.

--- a/config/locales/en/cda_errors.yml
+++ b/config/locales/en/cda_errors.yml
@@ -4,5 +4,6 @@ en:
     commmon_platform_connection_failed: HMCTS Common Platform could not be reached. This may be a temporary error. If this problem persists, please contact the IT Helpdesk on 0800 9175148.
     defendant_id_contract_failure: The defendant you are trying to link is not in a valid state to be linked.
     maat_reference_contract_failure: The MAAT reference you provided is not available to be associated with this defendant.
-    multiple_maats: The HMCTS Common Platform record for this defendant is corrupted and cannot be displayed. HMCTS is aware of this issue.
+    multiple_maats: The HMCTS record for this defendant cannot be displayed. HMCTS is aware of this issue. The record will be available once this issue has been resolved.
+    spaces_in_urn: The HMCTS record for this defendant cannot be displayed. HMCTS is aware of this issue. The record will be available once this issue has been resolved.
     subject_id_contract_failure: The appellant you are trying to link is not in a valid state to be linked.

--- a/config/locales/en/views/error.yml
+++ b/config/locales/en/views/error.yml
@@ -10,7 +10,7 @@ en:
     422_title: The change you wanted was rejected
     500_message: Try again later.
     500_title: Sorry, something went wrong
-    connection_error_message: There was a problem getting the information you requested. %{it_helpdesk}
+    connection_error_message: There was a problem getting the information you requested. %{details}
     description_html: You can also <a class="govuk-link" href="/">browse from the homepage</a> to find the information you need.
     it_helpdesk: If this problem persists, please contact the IT Helpdesk on 0800 9175148.
     refresh: Please refresh the page.

--- a/lib/court_data_adaptor/errors.rb
+++ b/lib/court_data_adaptor/errors.rb
@@ -43,7 +43,8 @@ module CourtDataAdaptor
         return unless error_response['error_codes']
 
         error_response['error_codes'].filter_map { |code| build_message(code) }.join(" ").presence
-      rescue StandardError
+      rescue StandardError => e
+        Rails.logger.error "CourtDataAdaptor::Errors::ErrorCodeParser error: #{e.message}"
         nil
       end
 

--- a/lib/court_data_adaptor/errors.rb
+++ b/lib/court_data_adaptor/errors.rb
@@ -7,19 +7,22 @@ module CourtDataAdaptor
         @response = response
         @status = response.status
         @errors = response.body
-        @error_string = format_user_facing_string
+        @error_string = build_error_string
         super(msg)
       end
       attr_reader :response, :status, :errors, :error_string
 
       private
 
-      def format_user_facing_string
-        user_facing_string = retrieve_user_facing_string
-        user_facing_string || I18n.t('error.it_helpdesk')
+      def build_error_string
+        build_from_error_code || parse_from_body || I18n.t('error.it_helpdesk')
       end
 
-      def retrieve_user_facing_string
+      def build_from_error_code
+        ErrorCodeParser.call(response)
+      end
+
+      def parse_from_body
         # Believe it or not, if CDA returns an unprocessable entity error, the response JSON will contain
         # a key called "error" whose value will be a string that includes a ruby hash literal, e.g.
         # `{"error"=>"Contract failed with: {:defendant_id=>[\"cannot be linked right now as we do not have all the required information, please try again later\"]}"}`
@@ -28,6 +31,26 @@ module CourtDataAdaptor
         return unless regex_match
 
         "#{regex_match[1].humanize} #{regex_match[2]}"
+      end
+    end
+
+    class ErrorCodeParser
+      def self.call(cda_response)
+        return unless cda_response
+
+        body = cda_response.body
+        error_response = body.is_a?(String) ? JSON.parse(body) : body
+        return unless error_response['error_codes']
+
+        error_response['error_codes'].filter_map { |code| build_message(code) }.join(" ").presence
+      rescue StandardError
+        nil
+      end
+
+      def self.build_message(code)
+        return unless code && I18n.t('cda_errors').key?(code.to_sym)
+
+        I18n.t("cda_errors.#{code}")
       end
     end
 

--- a/spec/features/defendants_view_spec.rb
+++ b/spec/features/defendants_view_spec.rb
@@ -66,7 +66,9 @@ RSpec.feature 'defendants view', type: :feature do
       scenario 'laa_references page returns to previous page' do
         visit "laa_references/new?id=#{defendant_id}&urn=#{case_urn}"
         expect(page).to have_current_path '/'
-        expect(page).to have_content "The HMCTS Common Platform record for this defendant is corrupted"
+        expect(page).to have_content(
+          "The HMCTS record for this defendant cannot be displayed."
+        )
       end
     end
   end

--- a/spec/features/defendants_view_spec.rb
+++ b/spec/features/defendants_view_spec.rb
@@ -22,7 +22,8 @@ RSpec.feature 'defendants view', type: :feature do
 
     stub_request(:get, %r{#{api_url}/defendants/500})
       .to_return(
-        status: 422
+        status: 422,
+        body: '{ "error_codes": ["multiple_maats"] }'
       )
   end
 
@@ -59,9 +60,14 @@ RSpec.feature 'defendants view', type: :feature do
       end
     end
 
-    scenario 'laa_references page returns to previous page' do
-      visit "laa_references/new?id=500&urn=#{case_urn}"
-      expect(page).to have_current_path '/'
+    context "when defendant is unavailable" do
+      let(:defendant_id) { "500" }
+
+      scenario 'laa_references page returns to previous page' do
+        visit "laa_references/new?id=#{defendant_id}&urn=#{case_urn}"
+        expect(page).to have_current_path '/'
+        expect(page).to have_content "The HMCTS Common Platform record for this defendant is corrupted"
+      end
     end
   end
 

--- a/spec/features/search/cda/case_reference_spec.rb
+++ b/spec/features/search/cda/case_reference_spec.rb
@@ -66,6 +66,9 @@ RSpec.feature 'Case reference search', :vcr, :js, type: :feature do
     expect(page).to have_css('.govuk-error-summary')
     within '.govuk-error-summary' do
       expect(page).to have_content('Unable to complete the search. Please try again in a moment.')
+
+      # It shows a situation-specific error message
+      expect(page).to have_content('HMCTS Common Platform could not be reached')
     end
 
     expect(page).to be_accessible.within '#main-content'

--- a/spec/requests/linking/link_defendant_maat_reference_v2_spec.rb
+++ b/spec/requests/linking/link_defendant_maat_reference_v2_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'link defendant maat reference', :vcr, :stub_unlinked, type: :req
     let(:maat_invalid_reference) do
       {
         title: 'Unable to link the defendant using the MAAT ID.',
-        message: 'If this problem persists, please contact the IT Helpdesk on 0800 9175148.'
+        message: 'The MAAT reference you provided is not available to be associated with this defendant.'
       }
     end
     let(:maat_error_message) do

--- a/spec/support/webmock/court_data_adaptor/webmock.rb
+++ b/spec/support/webmock/court_data_adaptor/webmock.rb
@@ -217,7 +217,8 @@ RSpec.configure do |config|
       status: 422,
       headers: { 'Content-Type' => 'application/json' },
       body: { 'errors' => { 'maat_reference' =>
-                             ['1234567 has no common platform data created against Maat application.'] } }
+                             ['1234567 has no common platform data created against Maat application.'] },
+              'error_codes' => ['maat_reference_contract_failure'] }
               .to_json
     )
   end
@@ -312,7 +313,7 @@ RSpec.configure do |config|
     stub_request(:get, %r{http.*/v2/prosecution_cases\?filter.*})
       .to_return(
         status: 500,
-        body: '',
+        body: '{ "error_codes": ["commmon_platform_connection_failed"] }',
         headers: { 'Content-Type' => 'application/json' }
       )
   end


### PR DESCRIPTION
When CDA returns a failure response, try to extract an error code from the body, and if one is found and we know a user-friendly string that is appropriate to it, display that string in the UI.

[Link to story](https://dsdmoj.atlassian.net/browse/ACD-806)