### PR TITLE
ACD-827: Handle CourtDataAdaptor::Errors consistently

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -46,7 +46,7 @@ class ApplicationController < ActionController::Base
   ].freeze
 
   def unexpected_exception_handler(exception)
-    raise unless Rails.env.production?
+    raise if Rails.env.development?
 
     case exception
     when ActiveRecord::RecordNotFound, ActionController::RoutingError

--- a/app/controllers/laa_references_controller.rb
+++ b/app/controllers/laa_references_controller.rb
@@ -32,11 +32,6 @@ class LaaReferencesController < ApplicationController
 
   def defendant
     @defendant ||= @defendant_search.call
-  rescue CourtDataAdaptor::Errors::UnprocessableEntity => e
-    logger.info 'CDA_GETDEFENDANT_RETURNED_UNPROCESSABLE'
-    flash[:alert] =
-      I18n.t('error.connection_error_message', details: cda_error_string(e) || I18n.t('error.it_helpdesk'))
-    redirect_back(fallback_location: authenticated_root_path)
   end
 
   def prosecution_case_reference


### PR DESCRIPTION
#### What
For some error types, we have nice error handling logic - we extract the error code if there is one and try to generate an error-specific error message, then show it in a nice box in the UI. For all other errors we just redirect to the /500 page, show a generic error, and return a 500 status code that causes a blip in our error alerting on Slack.

When accessing defendant details via the v1 CDA endpoint from the DefendantsController, the type of errors that are thrown, i.e. CourtDataAdaptor::Errors::Error subclasses, _could_ be handled the "nice" way, as they often do have error codes, and they're "expected" errors. But they're not on the list of handled error types, meaning a worse UX for users and more error alerts on Slack for us for things we don't really care about. Meanwhile they are explicitly handled in LaaReferencesController, which duplicates the "nice" logic that's in the application controller, but specifically to handle CourtDataAdaptor errors only.

This PR adds this family of errors to the nice error handling logic (with a tiny refactor to avoid a massive `when` block in a `case` statement.) It makes it so that we always use our "nice" error handling logic for both DefendantsController and LaaReferencesController, and makes the nice logic available in the test environment.
