### PR TITLE
ACD-831: Prevent double-click

### DIFF
--- a/app/views/defendants/_form.html.haml
+++ b/app/views/defendants/_form.html.haml
@@ -28,7 +28,7 @@
                               rows: 5,
                               max_chars: 500
 
-          = f.govuk_submit(t('defendants.form.submit'))
+          = f.govuk_submit(t('defendants.form.submit'), data: { disable_with: t('defendants.form.unlinking') })
 
         .govuk-warning-text
           %span.govuk-warning-text__icon{ "aria-hidden" => "true" } !

--- a/config/locales/en/views/defendants.yml
+++ b/config/locales/en/views/defendants.yml
@@ -8,6 +8,7 @@ en:
       reason_code:
         label: Reason for unlinking
       submit: Remove link to court data
+      unlinking: Unlinking...
     unlink:
       detail: Remove link to court data
       failure: The link to the court data source could not be removed.


### PR DESCRIPTION
#### What
Bring defendant unlinking inline with defendant linking and appellant linking/unlinking by auto-disabling the submit button on click.

https://dsdmoj.atlassian.net/browse/ACD-831
