### PR TITLE
Fix undefined method 'errors'.

### DIFF
--- a/app/controllers/defendants_controller.rb
+++ b/app/controllers/defendants_controller.rb
@@ -93,8 +93,7 @@ class DefendantsController < ApplicationController
          CourtDataAdaptor::Errors::BadRequest => e
     handle_error(e, I18n.t('defendants.unlink.unprocessable'), e.error_string)
   rescue CourtDataAdaptor::Errors::InternalServerError,
-         CourtDataAdaptor::Errors::ClientError,
-         JsonApiClient::Errors::NotFound => e
+         CourtDataAdaptor::Errors::ClientError => e
     handle_error(e, I18n.t('defendants.unlink.failure'), I18n.t('error.it_helpdesk'))
   rescue StandardError => e
     logger.error "Error: DefendantsController#unlink_laa_reference_and_redirect: #{e.message}"


### PR DESCRIPTION
#### What

Fix undefined method 'errors'.

#### Why
The JsonApiClient::Errors::NotFound will be rescued by `StandardError`. It does not contain the method errors, hence it cannot be handled by `handle_error`.
