### PR TITLE
Acd 839 consistent error summary for all the forms

### DIFF
--- a/app/controllers/defendants_controller.rb
+++ b/app/controllers/defendants_controller.rb
@@ -93,8 +93,7 @@ class DefendantsController < ApplicationController
          CourtDataAdaptor::Errors::BadRequest => e
     handle_error(e, I18n.t('defendants.unlink.unprocessable'), e.error_string)
   rescue CourtDataAdaptor::Errors::InternalServerError,
-         CourtDataAdaptor::Errors::ClientError,
-         JsonApiClient::Errors::NotFound => e
+         CourtDataAdaptor::Errors::ClientError => e
     handle_error(e, I18n.t('defendants.unlink.failure'), I18n.t('error.it_helpdesk'))
   rescue StandardError => e
     logger.error "Error: DefendantsController#unlink_laa_reference_and_redirect: #{e.message}"

--- a/app/views/defendants/_form.html.haml
+++ b/app/views/defendants/_form.html.haml
@@ -1,8 +1,9 @@
 = form_with(model: unlink_attempt, url: defendant_path(defendant.id), method: 'patch', data: { turbo: false }) do |f|
+  - content_for :error_summary do
+    = f.govuk_error_summary
+
   .govuk-grid-row
     .govuk-grid-column-two-thirds
-      = f.govuk_error_summary
-
       = render partial: 'defendants/defendant',
                locals: { defendant: defendant,
                          prosecution_case_reference: prosecution_case_reference }

--- a/app/views/laa_references/_form.html.haml
+++ b/app/views/laa_references/_form.html.haml
@@ -1,8 +1,9 @@
 = form_with(model: link_attempt, url: '/laa_references', data: { turbo: false }) do |f|
+  - content_for :error_summary do
+    = f.govuk_error_summary
+
   .govuk-grid-row
     .govuk-grid-column-two-thirds
-      = f.govuk_error_summary
-
       = render partial: 'defendants/defendant', locals: { defendant: defendant,
                                                           prosecution_case_reference: prosecution_case_reference }
 

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -43,6 +43,7 @@
       = render_breadcrumbs(builder: govuk_breadcrumb_builder)
       %main.govuk-main-wrapper#main-content{ role: "main" }
         = render partial: 'layouts/flashes' unless flash.empty?
+        = content_for :error_summary
         = content_for :pre_heading
         = content_for :page_heading
         = yield

--- a/app/views/search_filters/_form.html.haml
+++ b/app/views/search_filters/_form.html.haml
@@ -1,5 +1,6 @@
 = form_with model: search_filter do |f|
-  = f.govuk_error_summary
+  - content_for :error_summary do
+    = f.govuk_error_summary
 
   = f.govuk_collection_radio_buttons :id,
                                      Search.filters,

--- a/app/views/searches/_form.html.haml
+++ b/app/views/searches/_form.html.haml
@@ -1,7 +1,9 @@
 = form_with model: search do |f|
+  - content_for :error_summary do
+    = f.govuk_error_summary
+
   .govuk-grid-row
     .govuk-grid-column-two-thirds
-      = f.govuk_error_summary
       = f.hidden_field(:filter, value: filter)
       = f.govuk_text_field(:term, value: term, label: { text: label })
 

--- a/app/views/subjects/show.html.haml
+++ b/app/views/subjects/show.html.haml
@@ -13,7 +13,8 @@
       link_court_application_subject_path(@application.application_id)
     end
   = form_with(model: @form_model, url: link_url, data: { turbo: false }) do |f|
-    = f.govuk_error_summary
+    - content_for :error_summary do
+      = f.govuk_error_summary
 
     .govuk-grid-row
       .govuk-grid-column-two-thirds

--- a/app/views/users/_form.html.haml
+++ b/app/views/users/_form.html.haml
@@ -1,5 +1,6 @@
 = form_with model: user do |f|
-  = f.govuk_error_summary
+  - content_for :error_summary do
+    = f.govuk_error_summary
 
   = f.govuk_text_field(:first_name,
                        label: { text: t('users.form.fields.first_name_label') })


### PR DESCRIPTION
#### What
Makes Error Summary consistent with all the form: according with the GDS guide (https://design-system.service.gov.uk/components/error-summary/) the Error Summary component must stay "at the top of a page" and not under the page header.

#### Ticket
https://dsdmoj.atlassian.net/browse/ACD-839
