### PR TITLE
ACD-863: Cope with maat references that start with A

### DIFF
--- a/app/controllers/defendants_controller.rb
+++ b/app/controllers/defendants_controller.rb
@@ -76,7 +76,7 @@ class DefendantsController < ApplicationController
     # reason code must be an integer from 1..7
     unlink_attempt_params.merge(username: current_user.username).tap do |attrs|
       attrs[:defendant_id] = defendant.id
-      attrs[:maat_reference] = defendant.maat_reference.to_i
+      attrs[:maat_reference] = defendant.maat_reference
       attrs[:reason_code] = attrs[:reason_code].to_i
       attrs[:reason_code] = nil if attrs[:reason_code].zero?
     end

--- a/spec/features/unlinking_a_defendant_from_maat_spec.rb
+++ b/spec/features/unlinking_a_defendant_from_maat_spec.rb
@@ -45,7 +45,7 @@ RSpec.feature 'Unlinking a defendant from MAAT', :stub_unlink, type: :feature do
   context 'when user views linked defendant' do
     let(:defendant_id) { '41fcb1cd-516e-438e-887a-5987d92ef90f' }
     let(:url) { "defendants/#{defendant_id}/edit?urn=#{case_urn}" }
-    let(:maat_reference) { 2_123_456 }
+    let(:maat_reference) { 2_123_456.to_s }
 
     it 'does not display the MAAT ID field' do
       expect(page).to have_no_field('MAAT ID')

--- a/spec/requests/unlinking/unlink_defendant_maat_reference_v2_spec.rb
+++ b/spec/requests/unlinking/unlink_defendant_maat_reference_v2_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe 'unlink defendant maat reference', :stub_unlink, type: :request d
   let(:defendant_id) { '41fcb1cd-516e-438e-887a-5987d92ef90f' }
   let(:prosecution_case_reference_from_fixture) { 'TEST12345' }
   let(:api_url_v2) { CourtDataAdaptor::Resource::V2.api_url }
-  let(:maat_reference) { 2_123_456 }
+  let(:maat_reference) { 2_123_456.to_s }
 
   let(:params) do
     {


### PR DESCRIPTION
#### What
When users click 'Create link without a MAAT ID', a dummy MAAT ID gets generated that starts with an `A`. When we try to unlink, we need to pass the current MAAT ID to CDA, but `to_i` turns the dummy MAAT ID to a 0. MAAT IDs are strings, not numbers (because they can contain A or Z) so should be treated as such.