### PR TITLE
ACD-869: Add a prometheus exporter container to worker pods

### DIFF
--- a/helm_deploy/templates/deployment-worker.yaml
+++ b/helm_deploy/templates/deployment-worker.yaml
@@ -91,4 +91,22 @@ spec:
                 secretKeyRef:
                   name: aws-secrets
                   key: SENTRY_DSN
+        - name: laa-court-data-ui-worker-metrics
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: Always
+          command: ['sh', '-c', "bundle exec prometheus_exporter --bind 0.0.0.0"]
+          ports:
+          - containerPort: 9394
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: 9394
+            initialDelaySeconds: 10
+            periodSeconds: 60
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: 9394
+            initialDelaySeconds: 10
+            periodSeconds: 60
 {{ end }}


### PR DESCRIPTION
#### What
Worker pods try to export their metrics to prometheus on localhost:9394 just like web pods, but unlike web pods, there's nothing listening on localhost:9394. This PR adds the thing that listens on that port and exports the data to Prometheus. Not only does this get rid of the error message clogging up the logs, it means we get pod health metrics from worker pods added to the data that makes it into Prometheus.
