### PR TITLE
ACD-853: Standardise breadcrumbs

### DIFF
--- a/app/controllers/concerns/breadcrumbs.rb
+++ b/app/controllers/concerns/breadcrumbs.rb
@@ -14,11 +14,6 @@ module Breadcrumbs
     end
     helper_method :search_breadcrumb_name
 
-    def application_search_breadcrumb_name
-      I18n.t('search.application_breadcrumb')
-    end
-    helper_method :application_search_breadcrumb_name
-
     def search_breadcrumb_path
       searches_path(search: current_search_params)
     end

--- a/app/controllers/court_applications_controller.rb
+++ b/app/controllers/court_applications_controller.rb
@@ -4,11 +4,17 @@ class CourtApplicationsController < ApplicationController
   before_action :load_and_authorize_application
 
   add_breadcrumb :search_filter_breadcrumb_name, :new_search_filter_path
-  add_breadcrumb :application_search_breadcrumb_name, :search_breadcrumb_path
+  add_breadcrumb :search_breadcrumb_name, :search_breadcrumb_path
+  add_breadcrumb proc { |v| v.prosecution_case_name(v.controller.prosecution_case_reference) },
+                 proc { |v| v.prosecution_case_path(v.controller.prosecution_case_reference) }
 
   def show
-    add_breadcrumb @application.application_title
+    add_breadcrumb t('subjects.appeal')
     @date_sort_direction = params.fetch(:date_sort_direction, DEFAULT_SORT_DIRECTION)
+  end
+
+  def prosecution_case_reference
+    @application.case_summary.prosecution_case_reference
   end
 
   private

--- a/app/controllers/hearing_days_controller.rb
+++ b/app/controllers/hearing_days_controller.rb
@@ -3,14 +3,12 @@ class HearingDaysController < ApplicationController
                 :load_hearing_events
 
   add_breadcrumb :search_filter_breadcrumb_name, :new_search_filter_path
-  add_breadcrumb :application_search_breadcrumb_name, :search_breadcrumb_path
+  add_breadcrumb :search_breadcrumb_name, :search_breadcrumb_path
+  before_action :add_extra_breadcrumbs
 
   HEARING_SORT_DIRECTION = "asc".freeze
 
-  def show
-    add_breadcrumb @application.application_title, court_application_path(@application.application_id)
-    add_breadcrumb t(".breadcrumb", day: @hearing_day.day_string)
-  end
+  def show; end
 
   private
 
@@ -74,5 +72,12 @@ class HearingDaysController < ApplicationController
 
   def flat_hearing_days
     @flat_hearing_days ||= @application.hearing_days_sorted_by(HEARING_SORT_DIRECTION)
+  end
+
+  def add_extra_breadcrumbs
+    reference = @application.case_summary.prosecution_case_reference
+    add_breadcrumb prosecution_case_name(reference), prosecution_case_path(reference)
+    add_breadcrumb t('subjects.appeal'), court_application_path(@application.application_id)
+    add_breadcrumb t('hearing_days.show.breadcrumb', day: @hearing_day.day_string)
   end
 end

--- a/app/views/maintenance_mode/show.html.haml
+++ b/app/views/maintenance_mode/show.html.haml
@@ -8,7 +8,6 @@
     = stylesheet_link_tag 'application', media: 'all'
     = javascript_include_tag 'application', defer: true
     = csrf_meta_tags
-    = javascript_include_tag 'govuk_frontend'
 
     %meta{ content: "width=device-width, initial-scale=1, viewport-fit=cover", name: "viewport" }/
     %meta{ content: "blue", name: "theme-color" }/

--- a/config/locales/en/views/searches.yml
+++ b/config/locales/en/views/searches.yml
@@ -1,7 +1,6 @@
 ---
 en:
   search:
-    application_breadcrumb: Search for a case
     breadcrumb: Search
     dob:
       legend_text: Defendant date of birth

--- a/config/locales/en/views/subjects.yml
+++ b/config/locales/en/views/subjects.yml
@@ -1,6 +1,7 @@
 ---
 en:
   subjects:
+    appeal: Appeal
     link:
       failure: Unable to link the defendant to that MAAT ID
       success: You have successfully linked to the court data source

--- a/spec/features/application_subjects_spec.rb
+++ b/spec/features/application_subjects_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature 'Court Application subjects', :vcr do
     sign_in user
     visit court_application_subject_path(found_court_application_id)
     expect(page).to have_content(
-      ["Home", "Search for a case", "Mauricio Rath"].join # Breadcrumb
+      ["Home", "Search", "Case EPAYAQECKM", "Appeal", "Mauricio Rath"].join # Breadcrumb
     ).and have_content(
       "Appeal"
     ).and have_content(


### PR DESCRIPTION
Breadcrumbs are shorter and mirror logical structure of the site:

```
Home:
  Search:
     Case:
        Defendant
        Hearing
        Appeal:
           Appellant
           Hearing day
```