### PR TITLE
ACD-855: search users

### DIFF
--- a/app/assets/javascript/application.js
+++ b/app/assets/javascript/application.js
@@ -26,33 +26,20 @@ Rails.start()
 
 initAll()
 
-document.addEventListener('DOMContentLoaded', function () {
-  setUpEventListeners()
-})
-
-document.addEventListener('turbo:render', function () {
-  setUpEventListeners()
-})
-
 const setUpEventListeners = () => {
-  document.querySelectorAll('.search-form-toggle').forEach((toggle) => {
-    toggle.addEventListener('click', () => {
-      document.querySelectorAll('.search-form').forEach((element) => {
-        element.classList.remove('moj-js-hidden')
-      })
-      document.querySelectorAll('.search-form-toggle').forEach((element) => {
-        element.classList.add('moj-js-hidden')
-      })
+  document.querySelector('.search-form-toggle').addEventListener('click', () => {
+    document.querySelectorAll('.search-form-element').forEach((element) => {
+      element.classList.remove('moj-js-hidden')
     })
+    document.querySelector('.search-form-toggle').classList.add('moj-js-hidden')
   })
-  document.querySelectorAll('.hide-search-form-toggle').forEach((toggle) => {
-    toggle.addEventListener('click', () => {
-      document.querySelectorAll('.search-form').forEach((element) => {
-        element.classList.add('moj-js-hidden')
-      })
-      document.querySelectorAll('.search-form-toggle').forEach((element) => {
-        element.classList.remove('moj-js-hidden')
-      })
+  document.querySelector('.hide-search-form-toggle').addEventListener('click', () => {
+    document.querySelectorAll('.search-form-element').forEach((element) => {
+      element.classList.add('moj-js-hidden')
     })
+    document.querySelector('.search-form-toggle').classList.remove('moj-js-hidden')
   })
 }
+
+document.addEventListener('DOMContentLoaded', setUpEventListeners)
+document.addEventListener('turbo:render', setUpEventListeners)

--- a/app/assets/javascript/application.js
+++ b/app/assets/javascript/application.js
@@ -25,3 +25,24 @@ Rails.start()
 // const imagePath = (name) => images(name, true)
 
 initAll()
+
+document.querySelectorAll('.search-form-toggle').forEach((toggle) => {
+  toggle.addEventListener('click', () => {
+    document.querySelectorAll('.search-form').forEach((element) => {
+      element.classList.remove('moj-js-hidden');
+    });
+    document.querySelectorAll('.search-form-toggle').forEach((element) => {
+      element.classList.add('moj-js-hidden');
+    });
+  })
+})
+document.querySelectorAll('.hide-search-form-toggle').forEach((toggle) => {
+  toggle.addEventListener('click', () => {
+    document.querySelectorAll('.search-form').forEach((element) => {
+      element.classList.add('moj-js-hidden');
+    });
+    document.querySelectorAll('.search-form-toggle').forEach((element) => {
+      element.classList.remove('moj-js-hidden');
+    });
+  })
+})

--- a/app/assets/javascript/application.js
+++ b/app/assets/javascript/application.js
@@ -26,23 +26,33 @@ Rails.start()
 
 initAll()
 
-document.querySelectorAll('.search-form-toggle').forEach((toggle) => {
-  toggle.addEventListener('click', () => {
-    document.querySelectorAll('.search-form').forEach((element) => {
-      element.classList.remove('moj-js-hidden');
-    });
-    document.querySelectorAll('.search-form-toggle').forEach((element) => {
-      element.classList.add('moj-js-hidden');
-    });
-  })
+document.addEventListener('DOMContentLoaded', function () {
+  setUpEventListeners()
 })
-document.querySelectorAll('.hide-search-form-toggle').forEach((toggle) => {
-  toggle.addEventListener('click', () => {
-    document.querySelectorAll('.search-form').forEach((element) => {
-      element.classList.add('moj-js-hidden');
-    });
-    document.querySelectorAll('.search-form-toggle').forEach((element) => {
-      element.classList.remove('moj-js-hidden');
-    });
-  })
+
+document.addEventListener('turbo:render', function () {
+  setUpEventListeners()
 })
+
+const setUpEventListeners = () => {
+  document.querySelectorAll('.search-form-toggle').forEach((toggle) => {
+    toggle.addEventListener('click', () => {
+      document.querySelectorAll('.search-form').forEach((element) => {
+        element.classList.remove('moj-js-hidden')
+      })
+      document.querySelectorAll('.search-form-toggle').forEach((element) => {
+        element.classList.add('moj-js-hidden')
+      })
+    })
+  })
+  document.querySelectorAll('.hide-search-form-toggle').forEach((toggle) => {
+    toggle.addEventListener('click', () => {
+      document.querySelectorAll('.search-form').forEach((element) => {
+        element.classList.add('moj-js-hidden')
+      })
+      document.querySelectorAll('.search-form-toggle').forEach((element) => {
+        element.classList.remove('moj-js-hidden')
+      })
+    })
+  })
+}

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,6 +5,7 @@ class UsersController < ApplicationController
   load_and_authorize_resource except: :create
 
   def index
+    session.delete(:user_search)
     @user_search = UserSearch.new
     @pagy, @users = pagy(@users)
   end
@@ -97,8 +98,8 @@ class UsersController < ApplicationController
     if params[:user_search]
       params.require(:user_search).permit(
         :search_string,
-        recent_sign_ins: [],
-        old_sign_ins: []
+        :recent_sign_ins,
+        :old_sign_ins
       ).tap { session[:user_search] = it }
     else
       session[:user_search]

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,12 +5,13 @@ class UsersController < ApplicationController
   load_and_authorize_resource except: :create
 
   def index
+    @user_search = UserSearch.new
     @pagy, @users = pagy(@users)
   end
 
   def search
-    redirect to user_path if params[:query].blank?
-    @pagy, @users = pagy(UserSearchService.call(params[:query]))
+    @user_search = UserSearch.new(search_params)
+    @pagy, @users = pagy(UserSearchService.call(@user_search, @users))
     render :index
   end
 
@@ -90,5 +91,17 @@ class UsersController < ApplicationController
         password_confirmation: tmp_password
       )
     )
+  end
+
+  def search_params
+    if params[:user_search]
+      params.require(:user_search).permit(
+        :search_string,
+        recent_sign_ins: [],
+        old_sign_ins: [],
+      ).tap { session[:user_search] = it }
+    else
+      session[:user_search]
+    end
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -98,7 +98,7 @@ class UsersController < ApplicationController
       params.require(:user_search).permit(
         :search_string,
         recent_sign_ins: [],
-        old_sign_ins: [],
+        old_sign_ins: []
       ).tap { session[:user_search] = it }
     else
       session[:user_search]

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,6 +8,12 @@ class UsersController < ApplicationController
     @pagy, @users = pagy(@users)
   end
 
+  def search
+    redirect to user_path if params[:query].blank?
+    @pagy, @users = pagy(UserSearchService.call(params[:query]))
+    render :index
+  end
+
   def show; end
 
   def new; end

--- a/app/models/user_search.rb
+++ b/app/models/user_search.rb
@@ -1,0 +1,28 @@
+class UserSearch
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :search_string, :string
+  attribute :recent_sign_ins, :boolean
+  attribute :old_sign_ins, :boolean
+
+  def filters_applied?
+    search_string.present? || recent_sign_ins || old_sign_ins
+  end
+
+  def toggle_class
+    filters_applied? ? 'moj-js-hidden' : ''
+  end
+
+  def form_class
+    filters_applied? ? '' : 'moj-js-hidden'
+  end
+
+  def recent_count
+    User.where('last_sign_in_at >= ?', 3.months.ago).count
+  end
+
+  def old_count
+    User.where('last_sign_in_at IS NULL OR last_sign_in_at < ?', 3.months.ago).count
+  end
+end

--- a/app/models/user_search.rb
+++ b/app/models/user_search.rb
@@ -19,7 +19,7 @@ class UserSearch
   end
 
   def recent_count
-    User.where('last_sign_in_at >= ?', 3.months.ago).count
+    User.where(last_sign_in_at: 3.months.ago..).count
   end
 
   def old_count

--- a/app/services/user_search_service.rb
+++ b/app/services/user_search_service.rb
@@ -1,18 +1,35 @@
 class UserSearchService
   # Note that this search mechanism is inefficient for large data sets. If the number of users grows
   # beyond 1,000 it may be worth revisiting this in order to use a more advanced text search.
-  def self.call(search_string)
-    new(search_string).call
+  def self.call(search_model, default_scope)
+    new(search_model, default_scope).call
   end
 
-  def initialize(search_string)
-    @search_string = search_string
+  def initialize(search_model, default_scope)
+    @search_model = search_model
+    @default_scope = default_scope
   end
 
   def call
-    search_string.split.reduce(User) do |scope, token|
-      add_filter(token, scope)
+    scope = default_scope
+
+    if search_model.search_string.present?
+      scope = search_model.search_string.split.reduce(scope) do |scope, token|
+        add_filter(token, scope)
+      end
     end
+
+    filter_by_sign_in(scope)
+  end
+
+  def filter_by_sign_in(scope)
+    if search_model.recent_sign_ins && !search_model.old_sign_ins
+      scope = scope.where('last_sign_in_at >= ?', 3.months.ago)
+    elsif search_model.old_sign_ins && !search_model.recent_sign_ins
+      scope = scope.where('last_sign_in_at IS NULL OR last_sign_in_at < ?', 3.months.ago)
+    end
+
+    scope
   end
 
   private
@@ -24,5 +41,5 @@ class UserSearchService
     )
   end
 
-  attr_reader :search_string
+  attr_reader :search_model, :default_scope
 end

--- a/app/services/user_search_service.rb
+++ b/app/services/user_search_service.rb
@@ -14,8 +14,8 @@ class UserSearchService
     scope = default_scope
 
     if search_model.search_string.present?
-      scope = search_model.search_string.split.reduce(scope) do |scope, token|
-        add_filter(token, scope)
+      scope = search_model.search_string.split.reduce(scope) do |sub_scope, token|
+        add_filter(token, sub_scope)
       end
     end
 
@@ -24,12 +24,12 @@ class UserSearchService
 
   def filter_by_sign_in(scope)
     if search_model.recent_sign_ins && !search_model.old_sign_ins
-      scope = scope.where(last_sign_in_at: 3.months.ago..)
+      scope.where(last_sign_in_at: 3.months.ago..)
     elsif search_model.old_sign_ins && !search_model.recent_sign_ins
-      scope = scope.where('last_sign_in_at IS NULL OR last_sign_in_at < ?', 3.months.ago)
+      scope.where('last_sign_in_at IS NULL OR last_sign_in_at < ?', 3.months.ago)
+    else
+      scope
     end
-
-    scope
   end
 
   private

--- a/app/services/user_search_service.rb
+++ b/app/services/user_search_service.rb
@@ -24,7 +24,7 @@ class UserSearchService
 
   def filter_by_sign_in(scope)
     if search_model.recent_sign_ins && !search_model.old_sign_ins
-      scope = scope.where('last_sign_in_at >= ?', 3.months.ago)
+      scope = scope.where(last_sign_in_at: 3.months.ago..)
     elsif search_model.old_sign_ins && !search_model.recent_sign_ins
       scope = scope.where('last_sign_in_at IS NULL OR last_sign_in_at < ?', 3.months.ago)
     end

--- a/app/services/user_search_service.rb
+++ b/app/services/user_search_service.rb
@@ -1,0 +1,28 @@
+class UserSearchService
+  # Note that this search mechanism is inefficient for large data sets. If the number of users grows
+  # beyond 1,000 it may be worth revisiting this in order to use a more advanced text search.
+  def self.call(search_string)
+    new(search_string).call
+  end
+
+  def initialize(search_string)
+    @search_string = search_string
+  end
+
+  def call
+    search_string.split.reduce(User) do |scope, token|
+      add_filter(token, scope)
+    end
+  end
+
+  private
+
+  def add_filter(token, scope)
+    scope.where(
+      "first_name ILIKE :token OR last_name ILIKE :token OR email ILIKE :token OR username ILIKE :token",
+      token:
+    )
+  end
+
+  attr_reader :search_string
+end

--- a/app/views/users/_search_form.html.haml
+++ b/app/views/users/_search_form.html.haml
@@ -1,0 +1,56 @@
+
+= form_with(model: user_search, url: search_users_path) do |f|
+  .moj-filter{ "data-module" => "moj-filter" }
+    .moj-filter__header
+      .moj-filter__header-title
+        %h2.govuk-heading-m
+          = t('users.search.filter')
+      .moj-filter__header-action
+    .moj-filter__content
+      - if user_search.filters_applied?
+        .moj-filter__selected
+          .moj-filter__selected-heading
+            .moj-filter__heading-title
+              %h2.govuk-heading-m
+                = t('users.search.selected_filters')
+            .moj-filter__heading-action
+              %p
+                %a.govuk-link.govuk-link--no-visited-state{ href: search_users_path(user_search: { reset: true }) }
+                  = t('users.search.clear')
+          - if user_search.search_string.present?
+            %h3.govuk-heading-s{ class: "govuk-!-margin-bottom-0" }
+              = t('users.search.keywords')
+              %ul.moj-filter-tags
+                %li
+                  %a.moj-filter__tag{ href: search_users_path(user_search: user_search.attributes.merge('search_string' => '')) }
+                    %span.govuk-visually-hidden
+                      = t('users.search.remove')
+                    = user_search.search_string
+          - if user_search.recent_sign_ins || user_search.old_sign_ins
+            %h3.govuk-heading-s{ class: "govuk-!-margin-bottom-0" }
+              = t('users.search.last_sign_in')
+              %ul.moj-filter-tags
+                %li
+                  - if user_search.recent_sign_ins
+                    %a.moj-filter__tag{ href: search_users_path(user_search: user_search.attributes.merge(recent_sign_ins: false)) }
+                      %span.govuk-visually-hidden
+                        = t('users.search.remove')
+                      = t('users.search.recent')
+                  - if user_search.old_sign_ins
+                    %a.moj-filter__tag{ href: search_users_path(user_search: user_search.attributes.merge(old_sign_ins: false)) }
+                      %span.govuk-visually-hidden
+                        = t('users.search.remove')
+                      = t('users.search.old')
+      .moj-filter__options
+        = f.govuk_submit t('users.search.apply_filters')
+        .govuk-form-group
+          = f.govuk_text_field(:search_string, label: { text: t('users.search.keywords') })
+        .govuk-form-group
+          %fieldset.govuk-fieldset
+            %legend.govuk-fieldset__legend.govuk-fieldset__legend--m
+              = t('users.search.last_sign_in')
+            .govuk-checkboxes.govuk-checkboxes--small.app-no-wrap{ "data-module" => "govuk-checkboxes" }
+              .govuk-checkboxes__item
+                = f.govuk_check_box :recent_sign_ins, 1, nil, label: { text: t('users.search.recent_label', count: user_search.recent_count) }
+              .govuk-checkboxes__item
+                = f.govuk_check_box :old_sign_ins, 1, nil, label: { text: t('users.search.old_label', count: user_search.old_count) }

--- a/app/views/users/_search_form.html.haml
+++ b/app/views/users/_search_form.html.haml
@@ -32,12 +32,12 @@
               %ul.moj-filter-tags
                 %li
                   - if user_search.recent_sign_ins
-                    %a.moj-filter__tag{ href: search_users_path(user_search: user_search.attributes.merge(recent_sign_ins: false)) }
+                    %a.moj-filter__tag{ href: search_users_path(user_search: user_search.attributes.merge('recent_sign_ins' => nil)) }
                       %span.govuk-visually-hidden
                         = t('users.search.remove')
                       = t('users.search.recent')
                   - if user_search.old_sign_ins
-                    %a.moj-filter__tag{ href: search_users_path(user_search: user_search.attributes.merge(old_sign_ins: false)) }
+                    %a.moj-filter__tag{ href: search_users_path(user_search: user_search.attributes.merge('old_sign_ins' => nil)) }
                       %span.govuk-visually-hidden
                         = t('users.search.remove')
                       = t('users.search.old')
@@ -51,6 +51,6 @@
               = t('users.search.last_sign_in')
             .govuk-checkboxes.govuk-checkboxes--small.app-no-wrap{ "data-module" => "govuk-checkboxes" }
               .govuk-checkboxes__item
-                = f.govuk_check_box :recent_sign_ins, 1, nil, label: { text: t('users.search.recent_label', count: user_search.recent_count) }
+                = f.govuk_check_box :recent_sign_ins, 1, nil, multiple: false, label: { text: t('users.search.recent_label', count: user_search.recent_count) }
               .govuk-checkboxes__item
-                = f.govuk_check_box :old_sign_ins, 1, nil, label: { text: t('users.search.old_label', count: user_search.old_count) }
+                = f.govuk_check_box :old_sign_ins, 1, nil, multiple: false, label: { text: t('users.search.old_label', count: user_search.old_count) }

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -73,5 +73,11 @@
       = render 'shared/pagination', pagy: @pagy, item_name: t('users.generic.user')
       = link_to 'Export Users', users_export_all_path, class: 'govuk-button govuk-button--secondary govuk-!-margin-top-5'
     - else
-      .govuk-text
-        = t('users.index.none')
+      %p.govuk-body
+        %strong
+          = t('users.index.none')
+      %p.govuk-body
+        = t('users.index.improve_search')
+      %ul.govuk-list.govuk-list--bullet
+        - t('users.index.search_suggestions').each do |suggestion|
+          %li= suggestion

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -12,11 +12,11 @@
   .govuk-grid-column-one-half
     %button.search-form-toggle.govuk-button.govuk-button--secondary{ type: "button", class: @user_search.toggle_class }
       = t('users.index.show_filter')
-    %button.search-form.hide-search-form-toggle.govuk-button.govuk-button--secondary{ type: "button", class: @user_search.form_class }
+    %button.search-form-element.hide-search-form-toggle.govuk-button.govuk-button--secondary{ type: "button", class: @user_search.form_class }
       = t('users.index.hide_filter')
-  .govuk-grid-column-full.search-form{ class: @user_search.form_class }
+  .govuk-grid-column-full.search-form-element{ class: @user_search.form_class }
     = render 'users/search_form', user_search: @user_search
-  .govuk-grid-column-one-half.search-form{ class: @user_search.form_class }
+  .govuk-grid-column-one-half.search-form-element{ class: @user_search.form_class }
     &nbsp;
   .govuk-grid-column-one-half
     %p{ class: "govuk-body warning-text govuk-!-text-align-right" }

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -8,56 +8,74 @@
               "data-module": 'govuk-button',
               draggable: 'false',
               role: 'button'
-
+.govuk-grid-row
+  - toggle_class = params[:query].present? ? 'moj-js-hidden' : ''
+  - form_class = params[:query].present? ? '' : 'moj-js-hidden'
+  .govuk-grid-column-one-half
+    %button.search-form-toggle.govuk-button.govuk-button--secondary{ type: "button", class: toggle_class }
+      Show filter
+    %button.search-form.hide-search-form-toggle.govuk-button.govuk-button--secondary{ type: "button", class: form_class }
+      Hide filter
+  .govuk-grid-column-full.search-form{ class: form_class }
+    = form_with(url: search_users_path) do |f|
+      = f.govuk_text_field(:query, value: params[:query], label: { text: t('users.index.find') }, hint: { text: t('users.index.find_hint') })
+      = f.govuk_submit t('users.index.search')
+  .govuk-grid-column-one-half.search-form{ class: form_class }
+    &nbsp;
+  .govuk-grid-column-one-half
     %p{ class: "govuk-body warning-text govuk-!-text-align-right" }
       &#x25CF;
       %span.govuk-body
         = t('users.index.inactive_user')
+.govuk-grid-row
+  .govuk-grid-column-full
+    - if @users.any?
+      %table.govuk-table
+        %caption.govuk-table__caption.govuk-visually-hidden
+          = t('users.show.caption')
 
-    %table.govuk-table
-      %caption.govuk-table__caption.govuk-visually-hidden
-        = t('users.show.caption')
+        %thead.govuk-table__head
+          %tr.govuk-table__row
+            %th.govuk-table__header{ scope: 'col' }
+              = t('users.generic.name')
+            %th.govuk-table__header{ scope: 'col' }
+              = t('users.generic.username')
+            %th.govuk-table__header{ scope: 'col' }
+              = t('users.generic.email')
+            %th.govuk-table__header{ scope: 'col' }
+              = t('users.generic.last_sign_in')
+            %th.govuk-table__header{ scope: 'col' }
+              = t('users.generic.action')
 
-      %thead.govuk-table__head
-        %tr.govuk-table__row
-          %th.govuk-table__header{ scope: 'col' }
-            = t('users.generic.name')
-          %th.govuk-table__header{ scope: 'col' }
-            = t('users.generic.username')
-          %th.govuk-table__header{ scope: 'col' }
-            = t('users.generic.email')
-          %th.govuk-table__header{ scope: 'col' }
-            = t('users.generic.last_sign_in')
-          %th.govuk-table__header{ scope: 'col' }
-            = t('users.generic.action')
-
-      %tbody.govuk-table__body
-        - @users.each do |user|
-          %tr.govuk-table__row{ "data-user-id": user.id.to_s }
-            %td.govuk-table__cell
-              = link_to user.name, user_path(user), class: 'govuk-link'
-            %td.govuk-table__cell
-              = link_to user.username.to_s, user_path(user), class: 'govuk-link'
-            %td.govuk-table__cell
-              = mail_to user.email, class: 'govuk-link', target: '_blank' do
-                = user.email
-                %span.govuk-visually-hidden= t('generic.new_window')
-            %td.govuk-table__cell
-              - if user.last_sign_in_at
-                - if user.last_sign_in_at < 3.months.ago
-                  %span.warning-text &#x25CF;
-                = user.last_sign_in_at.to_formatted_s(:date_only)
-              - else
-                %span
-                  = t('users.generic.never_signed_in')
-            %td.govuk-table__cell
-              = link_to edit_user_path(user), class: 'govuk-link' do
-                = t('users.index.edit')
-                %span.govuk-visually-hidden= t('users.index.action_aria', name: user.name)
-              %br
-              = link_to user_path(user), data: { turbo_method: :delete, turbo_confirm: t('users.index.delete_confirmation', name: user.name) }, class: 'govuk-link' do
-                = t('users.index.delete')
-                %span.govuk-visually-hidden= t('users.index.action_aria', name: user.name)
-    = render 'shared/pagination', pagy: @pagy, item_name: t('users.generic.user')
-
-    = link_to 'Export Users', users_export_all_path, class: 'govuk-button govuk-button--secondary govuk-!-margin-top-5'
+        %tbody.govuk-table__body
+          - @users.each do |user|
+            %tr.govuk-table__row{ "data-user-id": user.id.to_s }
+              %td.govuk-table__cell
+                = link_to user.name, user_path(user), class: 'govuk-link'
+              %td.govuk-table__cell
+                = link_to user.username.to_s, user_path(user), class: 'govuk-link'
+              %td.govuk-table__cell
+                = mail_to user.email, class: 'govuk-link', target: '_blank' do
+                  = user.email
+                  %span.govuk-visually-hidden= t('generic.new_window')
+              %td.govuk-table__cell
+                - if user.last_sign_in_at
+                  - if user.last_sign_in_at < 3.months.ago
+                    %span.warning-text &#x25CF;
+                  = user.last_sign_in_at.to_formatted_s(:date_only)
+                - else
+                  %span
+                    = t('users.generic.never_signed_in')
+              %td.govuk-table__cell
+                = link_to edit_user_path(user), class: 'govuk-link' do
+                  = t('users.index.edit')
+                  %span.govuk-visually-hidden= t('users.index.action_aria', name: user.name)
+                %br
+                = link_to user_path(user), data: { turbo_method: :delete, turbo_confirm: t('users.index.delete_confirmation', name: user.name) }, class: 'govuk-link' do
+                  = t('users.index.delete')
+                  %span.govuk-visually-hidden= t('users.index.action_aria', name: user.name)
+      = render 'shared/pagination', pagy: @pagy, item_name: t('users.generic.user')
+      = link_to 'Export Users', users_export_all_path, class: 'govuk-button govuk-button--secondary govuk-!-margin-top-5'
+    - else
+      .govuk-text
+        = t('users.index.none')

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -9,18 +9,14 @@
               draggable: 'false',
               role: 'button'
 .govuk-grid-row
-  - toggle_class = params[:query].present? ? 'moj-js-hidden' : ''
-  - form_class = params[:query].present? ? '' : 'moj-js-hidden'
   .govuk-grid-column-one-half
-    %button.search-form-toggle.govuk-button.govuk-button--secondary{ type: "button", class: toggle_class }
-      Show filter
-    %button.search-form.hide-search-form-toggle.govuk-button.govuk-button--secondary{ type: "button", class: form_class }
-      Hide filter
-  .govuk-grid-column-full.search-form{ class: form_class }
-    = form_with(url: search_users_path) do |f|
-      = f.govuk_text_field(:query, value: params[:query], label: { text: t('users.index.find') }, hint: { text: t('users.index.find_hint') })
-      = f.govuk_submit t('users.index.search')
-  .govuk-grid-column-one-half.search-form{ class: form_class }
+    %button.search-form-toggle.govuk-button.govuk-button--secondary{ type: "button", class: @user_search.toggle_class }
+      = t('users.index.show_filter')
+    %button.search-form.hide-search-form-toggle.govuk-button.govuk-button--secondary{ type: "button", class: @user_search.form_class }
+      = t('users.index.hide_filter')
+  .govuk-grid-column-full.search-form{ class: @user_search.form_class }
+    = render 'users/search_form', user_search: @user_search
+  .govuk-grid-column-one-half.search-form{ class: @user_search.form_class }
     &nbsp;
   .govuk-grid-column-one-half
     %p{ class: "govuk-body warning-text govuk-!-text-align-right" }

--- a/config/locales/en/views/users.yml
+++ b/config/locales/en/views/users.yml
@@ -39,9 +39,13 @@ en:
       delete: Delete
       delete_confirmation: Are you sure you want to delete %{name}'s account?
       edit: Edit
+      find: Find a user
+      find_hint: Enter a name, email address or username
       inactive_user: indicates that the user has not signed in for more than 3 months.
       new_link: Create a new user
+      none: No users matched your search
       page_title: List of users
+      search: Search
     new:
       page_title: New user
     show:

--- a/config/locales/en/views/users.yml
+++ b/config/locales/en/views/users.yml
@@ -40,10 +40,16 @@ en:
       delete_confirmation: Are you sure you want to delete %{name}'s account?
       edit: Edit
       hide_filter: Hide filters
+      improve_search: 'Improve your search results by:'
       inactive_user: indicates that the user has not signed in for more than 3 months.
       new_link: Create a new user
-      none: No users matched your search
+      none: There are no matching results.
       page_title: List of users
+      search_suggestions:
+      - removing filters
+      - double-checking your spelling
+      - using fewer keywords
+      - searching for something less specific.
       show_filter: Show filters
     new:
       page_title: New user

--- a/config/locales/en/views/users.yml
+++ b/config/locales/en/views/users.yml
@@ -39,12 +39,12 @@ en:
       delete: Delete
       delete_confirmation: Are you sure you want to delete %{name}'s account?
       edit: Edit
-      hide_filter: Hide filter
+      hide_filter: Hide filters
       inactive_user: indicates that the user has not signed in for more than 3 months.
       new_link: Create a new user
       none: No users matched your search
       page_title: List of users
-      show_filter: Show filter
+      show_filter: Show filters
     new:
       page_title: New user
     search:

--- a/config/locales/en/views/users.yml
+++ b/config/locales/en/views/users.yml
@@ -41,13 +41,26 @@ en:
       edit: Edit
       find: Find a user
       find_hint: Enter a name, email address or username
+      hide_filter: Hide filter
       inactive_user: indicates that the user has not signed in for more than 3 months.
       new_link: Create a new user
       none: No users matched your search
       page_title: List of users
-      search: Search
+      show_filter: Show filter
     new:
       page_title: New user
+    search:
+      apply_filters: Apply filters
+      clear: Clear filters
+      filter: Filter
+      last_sign_in: Last sign-in
+      keywords: Name, username or email
+      old: Over three months ago
+      old_label: Over three months ago (%{count})
+      recent: Within last three months
+      recent_label: Within last three months (%{count})
+      remove: Remove this filter
+      selected_filters: Selected filters
     show:
       caption: User details
       change_password_link: Change password

--- a/config/locales/en/views/users.yml
+++ b/config/locales/en/views/users.yml
@@ -39,8 +39,6 @@ en:
       delete: Delete
       delete_confirmation: Are you sure you want to delete %{name}'s account?
       edit: Edit
-      find: Find a user
-      find_hint: Enter a name, email address or username
       hide_filter: Hide filter
       inactive_user: indicates that the user has not signed in for more than 3 months.
       new_link: Create a new user
@@ -53,8 +51,8 @@ en:
       apply_filters: Apply filters
       clear: Clear filters
       filter: Filter
-      last_sign_in: Last sign-in
       keywords: Name, username or email
+      last_sign_in: Last sign-in
       old: Over three months ago
       old_label: Over three months ago (%{count})
       recent: Within last three months

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,6 +49,7 @@ Rails.application.routes.draw do
     get 'change_password', on: :member
     patch 'update_password', on: :member
     post 'search', on: :collection
+    get 'search', on: :collection
   end
 
   post '/cookies/settings', to: 'cookies#create'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,6 +48,7 @@ Rails.application.routes.draw do
   resources :users, only: %i[index show new create edit update destroy] do
     get 'change_password', on: :member
     patch 'update_password', on: :member
+    post 'search', on: :collection
   end
 
   post '/cookies/settings', to: 'cookies#create'

--- a/spec/features/users/index_users_spec.rb
+++ b/spec/features/users/index_users_spec.rb
@@ -51,6 +51,23 @@ RSpec.feature 'Index users', :js, type: :feature do
       expect(page).to be_accessible.within '#main-content'
     end
 
+    context 'when searching' do
+      let(:user) { create(:user, :with_manager_role, first_name: 'John') }
+      let!(:other_user) { create(:user, :with_caseworker_role, first_name: 'Jane') }
+
+      scenario 'I search' do
+        click_link_or_button 'Manage users'
+        click_button 'Show filters'
+        fill_in 'Name, username or email', with: user.first_name
+        click_on 'Apply filters'
+        expect(page).to have_content(user.email)
+        expect(page).to have_no_content(other_user.email)
+        click_on 'Clear filters'
+        expect(page).to have_content(user.email)
+        expect(page).to have_content(other_user.email)
+      end
+    end
+
     context 'when lots of users' do
       # In general, `create_list` should be used sparingly, but in this case
       # we really do want to bulk create a large amount of users

--- a/spec/features/users/index_users_spec.rb
+++ b/spec/features/users/index_users_spec.rb
@@ -60,9 +60,12 @@ RSpec.feature 'Index users', :js, type: :feature do
         click_button 'Show filters'
         fill_in 'Name, username or email', with: user.first_name
         click_on 'Apply filters'
+
         expect(page).to have_content(user.email)
         expect(page).to have_no_content(other_user.email)
+
         click_on 'Clear filters'
+
         expect(page).to have_content(user.email)
         expect(page).to have_content(other_user.email)
       end

--- a/spec/services/user_search_service_spec.rb
+++ b/spec/services/user_search_service_spec.rb
@@ -3,13 +3,18 @@ require "rails_helper"
 RSpec.describe UserSearchService do
   subject(:search_results) { described_class.call(user_search, User).to_a }
 
-  let(:user_search) { UserSearch.new(search_string:) }
+  let(:user_search) { UserSearch.new(search_string:, recent_sign_ins:, old_sign_ins:) }
   let(:searched_user) do
-    create(:user, first_name: 'Jane', last_name: 'Doe', username: 'j-doe', email: 'jane@example.com')
+    create(:user, first_name: 'Jane', last_name: 'Doe', username: 'j-doe', email: 'jane@example.com',
+                  last_sign_in_at: 1.day.ago)
   end
   let(:unsearched_user) do
-    create(:user, first_name: 'John', last_name: 'Smith', username: 'j-smith', email: 'john@example.com')
+    create(:user, first_name: 'John', last_name: 'Smith', username: 'j-smith', email: 'john@example.com',
+                  last_sign_in_at: nil)
   end
+  let(:recent_sign_ins) { false }
+  let(:old_sign_ins) { false }
+  let(:search_string) { nil }
 
   before do
     searched_user
@@ -55,5 +60,24 @@ RSpec.describe UserSearchService do
     let(:search_string) { 'Jane Smith' }
 
     it { is_expected.to be_empty }
+  end
+
+  context 'when filtering by recent sign ins' do
+    let(:recent_sign_ins) { true }
+
+    it { is_expected.to include(searched_user) }
+    it { is_expected.not_to include(unsearched_user) }
+  end
+
+  context 'when filtering by old sign ins' do
+    let(:old_sign_ins) { true }
+
+    before do
+      searched_user.update(last_sign_in_at: 4.months.ago)
+      unsearched_user.update(last_sign_in_at: 1.day.ago)
+    end
+
+    it { is_expected.to include(searched_user) }
+    it { is_expected.not_to include(unsearched_user) }
   end
 end

--- a/spec/services/user_search_service_spec.rb
+++ b/spec/services/user_search_service_spec.rb
@@ -1,8 +1,9 @@
 require "rails_helper"
 
 RSpec.describe UserSearchService do
-  subject(:search_results) { described_class.call(query_string).to_a }
+  subject(:search_results) { described_class.call(user_search, User).to_a }
 
+  let(:user_search) { UserSearch.new(search_string:) }
   let(:searched_user) do
     create(:user, first_name: 'Jane', last_name: 'Doe', username: 'j-doe', email: 'jane@example.com')
   end
@@ -16,42 +17,42 @@ RSpec.describe UserSearchService do
   end
 
   context 'when searching by username' do
-    let(:query_string) { 'j-doe' }
+    let(:search_string) { 'j-doe' }
 
     it { is_expected.to include(searched_user) }
     it { is_expected.not_to include(unsearched_user) }
   end
 
   context 'when searching by email' do
-    let(:query_string) { 'jane@example.com' }
+    let(:search_string) { 'jane@example.com' }
 
     it { is_expected.to include(searched_user) }
     it { is_expected.not_to include(unsearched_user) }
   end
 
   context 'when searching by first name' do
-    let(:query_string) { 'Jane' }
+    let(:search_string) { 'Jane' }
 
     it { is_expected.to include(searched_user) }
     it { is_expected.not_to include(unsearched_user) }
   end
 
   context 'when searching by last name' do
-    let(:query_string) { 'Doe' }
+    let(:search_string) { 'Doe' }
 
     it { is_expected.to include(searched_user) }
     it { is_expected.not_to include(unsearched_user) }
   end
 
   context 'when searching by full name' do
-    let(:query_string) { 'Jane Doe' }
+    let(:search_string) { 'Jane Doe' }
 
     it { is_expected.to include(searched_user) }
     it { is_expected.not_to include(unsearched_user) }
   end
 
   context 'when searching by impossible combo' do
-    let(:query_string) { 'Jane Smith' }
+    let(:search_string) { 'Jane Smith' }
 
     it { is_expected.to be_empty }
   end

--- a/spec/services/user_search_service_spec.rb
+++ b/spec/services/user_search_service_spec.rb
@@ -1,0 +1,58 @@
+require "rails_helper"
+
+RSpec.describe UserSearchService do
+  subject(:search_results) { described_class.call(query_string).to_a }
+
+  let(:searched_user) do
+    create(:user, first_name: 'Jane', last_name: 'Doe', username: 'j-doe', email: 'jane@example.com')
+  end
+  let(:unsearched_user) do
+    create(:user, first_name: 'John', last_name: 'Smith', username: 'j-smith', email: 'john@example.com')
+  end
+
+  before do
+    searched_user
+    unsearched_user
+  end
+
+  context 'when searching by username' do
+    let(:query_string) { 'j-doe' }
+
+    it { is_expected.to include(searched_user) }
+    it { is_expected.not_to include(unsearched_user) }
+  end
+
+  context 'when searching by email' do
+    let(:query_string) { 'jane@example.com' }
+
+    it { is_expected.to include(searched_user) }
+    it { is_expected.not_to include(unsearched_user) }
+  end
+
+  context 'when searching by first name' do
+    let(:query_string) { 'Jane' }
+
+    it { is_expected.to include(searched_user) }
+    it { is_expected.not_to include(unsearched_user) }
+  end
+
+  context 'when searching by last name' do
+    let(:query_string) { 'Doe' }
+
+    it { is_expected.to include(searched_user) }
+    it { is_expected.not_to include(unsearched_user) }
+  end
+
+  context 'when searching by full name' do
+    let(:query_string) { 'Jane Doe' }
+
+    it { is_expected.to include(searched_user) }
+    it { is_expected.not_to include(unsearched_user) }
+  end
+
+  context 'when searching by impossible combo' do
+    let(:query_string) { 'Jane Smith' }
+
+    it { is_expected.to be_empty }
+  end
+end


### PR DESCRIPTION
#### What
https://dsdmoj.atlassian.net/browse/ACD-855

Use the MoJ filter component to do a basic search by name, username, email and last sign in date in a way that's compatible with pagination but doesn't put caseworker PII in the query string.

<img width="1101" alt="Screenshot 2025-07-09 at 14 41 56" src="https://github.com/user-attachments/assets/6837e5d8-323a-4782-936e-16865e5f3ee9" />


