### PR TITLE
ACD-873: Format all user-facing dates appropriately

### DIFF
--- a/app/controllers/hearings_controller.rb
+++ b/app/controllers/hearings_controller.rb
@@ -15,7 +15,7 @@ class HearingsController < ApplicationController
                  proc { |v| v.prosecution_case_path(v.controller.prosecution_case_reference) }
 
   def show
-    add_breadcrumb "#{t('generic.hearing_day')} #{hearing_day&.strftime('%d/%m/%Y')}", ''
+    add_breadcrumb "#{t('generic.hearing_day')} #{hearing_day&.to_fs(:date_only)}", ''
   end
 
   def redirect_to_prosecution_case(**flash)

--- a/app/controllers/hearings_controller.rb
+++ b/app/controllers/hearings_controller.rb
@@ -15,7 +15,7 @@ class HearingsController < ApplicationController
                  proc { |v| v.prosecution_case_path(v.controller.prosecution_case_reference) }
 
   def show
-    add_breadcrumb "#{t('generic.hearing_day')} #{hearing_day&.to_fs(:date_only)}", ''
+    add_breadcrumb "#{t('generic.hearing_day')} #{hearing_day&.to_fs(:day_month_year)}", ''
   end
 
   def redirect_to_prosecution_case(**flash)

--- a/app/decorators/cda/cracked_ineffective_trial_decorator.rb
+++ b/app/decorators/cda/cracked_ineffective_trial_decorator.rb
@@ -15,7 +15,7 @@ module Cda
     private
 
     def cracked_at(hearing)
-      hearing.hearing_days.first.sitting_day.to_date.strftime('%d/%m/%Y')
+      hearing.hearing_days.first.sitting_day.to_fs(:date_only)
     end
   end
 end

--- a/app/decorators/cda/cracked_ineffective_trial_decorator.rb
+++ b/app/decorators/cda/cracked_ineffective_trial_decorator.rb
@@ -15,7 +15,7 @@ module Cda
     private
 
     def cracked_at(hearing)
-      hearing.hearing_days.first.sitting_day.to_fs(:date_only)
+      hearing.hearing_days.first.sitting_day.to_fs(:day_month_year)
     end
   end
 end

--- a/app/decorators/cracked_ineffective_trial_decorator.rb
+++ b/app/decorators/cracked_ineffective_trial_decorator.rb
@@ -25,6 +25,6 @@ class CrackedIneffectiveTrialDecorator < BaseDecorator
   private
 
   def cracked_at(hearing)
-    hearing.hearing_days.first.to_date.to_fs(:date_only)
+    hearing.hearing_days.first.to_date.to_fs(:day_month_year)
   end
 end

--- a/app/decorators/cracked_ineffective_trial_decorator.rb
+++ b/app/decorators/cracked_ineffective_trial_decorator.rb
@@ -25,6 +25,6 @@ class CrackedIneffectiveTrialDecorator < BaseDecorator
   private
 
   def cracked_at(hearing)
-    hearing.hearing_days.first.to_date.strftime('%d/%m/%Y')
+    hearing.hearing_days.first.to_date.to_fs(:date_only)
   end
 end

--- a/app/decorators/offence_decorator.rb
+++ b/app/decorators/offence_decorator.rb
@@ -17,7 +17,7 @@ class OffenceDecorator < BaseDecorator
   def start_date
     return unless super
 
-    Date.parse(super).to_fs(:date_only)
+    Date.parse(super).to_fs(:day_month_year)
   end
 
   private
@@ -35,7 +35,7 @@ class OffenceDecorator < BaseDecorator
 
     t('offence.plea.sentence',
       plea: plea&.code&.humanize || t('generic.not_available'),
-      pleaded_at: plea_date&.to_fs(:date_only) || t('generic.not_available'))
+      pleaded_at: plea_date&.to_fs(:day_month_year) || t('generic.not_available'))
   end
 
   def mode_of_trial_reason_descriptions

--- a/app/decorators/offence_decorator.rb
+++ b/app/decorators/offence_decorator.rb
@@ -17,7 +17,7 @@ class OffenceDecorator < BaseDecorator
   def start_date
     return unless super
 
-    Date.parse(super).strftime("%d/%m/%Y")
+    Date.parse(super).to_fs(:date_only)
   end
 
   private
@@ -35,7 +35,7 @@ class OffenceDecorator < BaseDecorator
 
     t('offence.plea.sentence',
       plea: plea&.code&.humanize || t('generic.not_available'),
-      pleaded_at: plea_date&.strftime('%d/%m/%Y') || t('generic.not_available'))
+      pleaded_at: plea_date&.to_fs(:date_only) || t('generic.not_available'))
   end
 
   def mode_of_trial_reason_descriptions

--- a/app/views/hearings/show.html.haml
+++ b/app/views/hearings/show.html.haml
@@ -1,4 +1,4 @@
-= govuk_page_title(@hearing_day&.strftime('%d/%m/%Y'), t('generic.hearing_day'), class: 'govuk-!-margin-bottom-2')
+= govuk_page_title(@hearing_day&.to_fs(:date_only), t('generic.hearing_day'), class: 'govuk-!-margin-bottom-2')
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds

--- a/app/views/hearings/show.html.haml
+++ b/app/views/hearings/show.html.haml
@@ -1,4 +1,4 @@
-= govuk_page_title(@hearing_day&.to_fs(:date_only), t('generic.hearing_day'), class: 'govuk-!-margin-bottom-2')
+= govuk_page_title(@hearing_day&.to_fs(:day_month_year), t('generic.hearing_day'), class: 'govuk-!-margin-bottom-2')
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds

--- a/app/views/prosecution_cases/_hearing_summaries.html.haml
+++ b/app/views/prosecution_cases/_hearing_summaries.html.haml
@@ -15,9 +15,9 @@
     - case_summary.sorted_hearing_summaries_with_day.each_with_index do |hearing_summary, idx|
       %tr.govuk-table__row
         %td.govuk-table__cell
-          = link_to hearing_summary.day.to_fs(:date_only), hearing_path(id: hearing_summary.id,
-                                                                        urn: case_summary.prosecution_case_reference, column: case_summary.hearings_sort_column,
-                                                                        direction: case_summary.hearings_sort_direction, page: idx), class: 'govuk-link'
+          = link_to hearing_summary.day.to_fs(:day_month_year), hearing_path(id: hearing_summary.id,
+                                                                             urn: case_summary.prosecution_case_reference, column: case_summary.hearings_sort_column,
+                                                                             direction: case_summary.hearings_sort_direction, page: idx), class: 'govuk-link'
         %td.govuk-table__cell
           = hearing_summary.hearing_type
           - if hearing_summary.estimated_duration

--- a/app/views/prosecution_cases/_hearing_summaries.html.haml
+++ b/app/views/prosecution_cases/_hearing_summaries.html.haml
@@ -15,9 +15,9 @@
     - case_summary.sorted_hearing_summaries_with_day.each_with_index do |hearing_summary, idx|
       %tr.govuk-table__row
         %td.govuk-table__cell
-          = link_to hearing_summary.day.strftime('%d/%m/%Y'), hearing_path(id: hearing_summary.id,
-                                                                           urn: case_summary.prosecution_case_reference, column: case_summary.hearings_sort_column,
-                                                                           direction: case_summary.hearings_sort_direction, page: idx), class: 'govuk-link'
+          = link_to hearing_summary.day.to_fs(:date_only), hearing_path(id: hearing_summary.id,
+                                                                        urn: case_summary.prosecution_case_reference, column: case_summary.hearings_sort_column,
+                                                                        direction: case_summary.hearings_sort_direction, page: idx), class: 'govuk-link'
         %td.govuk-table__cell
           = hearing_summary.hearing_type
           - if hearing_summary.estimated_duration

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -46,7 +46,7 @@
               - if user.last_sign_in_at
                 - if user.last_sign_in_at < 3.months.ago
                   %span.warning-text &#x25CF;
-                = user.last_sign_in_at.to_formatted_s(:date_only)
+                = user.last_sign_in_at.to_formatted_s(:day_month_year)
               - else
                 %span
                   = t('users.generic.never_signed_in')

--- a/config/application.rb
+++ b/config/application.rb
@@ -47,6 +47,7 @@ module LaaCourtDataUi
 
     config.active_support.to_time_preserves_timezone = :zone
 
-    Time::DATE_FORMATS[:date_only] = "%b %d, %Y"
+    Time::DATE_FORMATS[:date_only] = "%-d %B %Y"
+    Date::DATE_FORMATS[:date_only] = "%-d %B %Y"
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -47,7 +47,7 @@ module LaaCourtDataUi
 
     config.active_support.to_time_preserves_timezone = :zone
 
-    Time::DATE_FORMATS[:date_only] = "%-d %B %Y"
-    Date::DATE_FORMATS[:date_only] = "%-d %B %Y"
+    Time::DATE_FORMATS[:day_month_year] = "%-d %B %Y"
+    Date::DATE_FORMATS[:day_month_year] = "%-d %B %Y"
   end
 end

--- a/lib/court_data_adaptor/resource/hearing_day.rb
+++ b/lib/court_data_adaptor/resource/hearing_day.rb
@@ -4,7 +4,7 @@ module CourtDataAdaptor
       attr_accessor :hearing
 
       def day_string
-        sitting_day.to_date.to_fs(:date_only)
+        sitting_day.to_date.to_fs(:day_month_year)
       end
 
       def time_string

--- a/lib/court_data_adaptor/resource/hearing_day.rb
+++ b/lib/court_data_adaptor/resource/hearing_day.rb
@@ -4,7 +4,7 @@ module CourtDataAdaptor
       attr_accessor :hearing
 
       def day_string
-        sitting_day.to_date.strftime('%d/%m/%Y')
+        sitting_day.to_date.to_fs(:date_only)
       end
 
       def time_string

--- a/spec/decorators/cda/cracked_ineffective_trial_decorator_spec.rb
+++ b/spec/decorators/cda/cracked_ineffective_trial_decorator_spec.rb
@@ -36,13 +36,13 @@ RSpec.describe Cda::CrackedIneffectiveTrialDecorator, type: :decorator do
     context 'when type is cracked' do
       let(:type) { 'CrACKed' }
 
-      it { is_expected.to include('Cracked on 19/01/2021') }
+      it { is_expected.to include('Cracked on 19 January 2021') }
     end
 
     context 'when type is vacated' do
       let(:type) { 'Vacated' }
 
-      it { is_expected.to include('Vacated on 19/01/2021') }
+      it { is_expected.to include('Vacated on 19 January 2021') }
     end
   end
 

--- a/spec/decorators/cracked_ineffective_trial_decorator_spec.rb
+++ b/spec/decorators/cracked_ineffective_trial_decorator_spec.rb
@@ -86,13 +86,13 @@ RSpec.describe CrackedIneffectiveTrialDecorator, type: :decorator do
     context 'when type is cracked' do
       let(:type) { 'CrACKed' }
 
-      it { is_expected.to include('Cracked on 19/01/2021') }
+      it { is_expected.to include('Cracked on 19 January 2021') }
     end
 
     context 'when type is vacated' do
       let(:type) { 'Vacated' }
 
-      it { is_expected.to include('Vacated on 19/01/2021') }
+      it { is_expected.to include('Vacated on 19 January 2021') }
     end
   end
 

--- a/spec/decorators/offence_decorator_spec.rb
+++ b/spec/decorators/offence_decorator_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe OffenceDecorator, type: :decorator do
         allow(offence).to receive(:pleas).and_return(plea_collection)
       end
 
-      it { is_expected.to eql('Not guilty on 01/01/2020<br>Guilty on 20/01/2020') }
+      it { is_expected.to eql('Not guilty on 1 January 2020<br>Guilty on 20 January 2020') }
     end
 
     context 'when pleas are not in pleaded_at order' do
@@ -66,7 +66,7 @@ RSpec.describe OffenceDecorator, type: :decorator do
         allow(offence).to receive(:pleas).and_return(plea_collection)
       end
 
-      it { is_expected.to eql 'Not guilty on 01/01/2020<br>Guilty on 01/02/2020' }
+      it { is_expected.to eql 'Not guilty on 1 January 2020<br>Guilty on 1 February 2020' }
     end
 
     context 'when plea does not contain an expected key' do
@@ -78,8 +78,8 @@ RSpec.describe OffenceDecorator, type: :decorator do
 
       let(:html_content) do
         ['Not guilty on Not available',
-         'Not available on 20/01/2020',
-         'Not available on 21/01/2020'].join('<br>')
+         'Not available on 20 January 2020',
+         'Not available on 21 January 2020'].join('<br>')
       end
 
       before do
@@ -120,7 +120,7 @@ RSpec.describe OffenceDecorator, type: :decorator do
       before { allow(offence).to receive(:start_date).and_return("2023-01-05") }
 
       it "formats it" do
-        expect(decorator.start_date).to eq "05/01/2023"
+        expect(decorator.start_date).to eq "5 January 2023"
       end
     end
 

--- a/spec/features/application_hearings_spec.rb
+++ b/spec/features/application_hearings_spec.rb
@@ -34,7 +34,7 @@ RSpec.feature 'Court Application Hearings', :vcr do
   scenario 'I view a hearing details page' do
     sign_in user
     visit court_application_path(court_application_id)
-    click_on "23/10/2019"
+    click_on "23 October 2019"
     expect(page).to have_current_path court_application_hearing_hearing_day_path(court_application_id,
                                                                                  first_hearing_id,
                                                                                  first_hearing_day)
@@ -71,17 +71,17 @@ RSpec.feature 'Court Application Hearings', :vcr do
     sign_in user
     visit court_application_hearing_hearing_day_path(court_application_id, first_hearing_id,
                                                      first_hearing_day)
-    expect(page).to have_content "23/10/2019"
+    expect(page).to have_content "23 October 2019"
     expect(page).to have_content "Next"
     expect(page).to have_no_content "Previous"
 
     click_on "Next"
-    expect(page).to have_content "10/04/2025"
+    expect(page).to have_content "10 April 2025"
     expect(page).to have_no_content "Next"
     expect(page).to have_content "Previous"
 
     click_on "Previous"
-    expect(page).to have_content "23/10/2019"
+    expect(page).to have_content "23 October 2019"
   end
 
   scenario 'Hearing details are not available' do
@@ -115,7 +115,7 @@ RSpec.feature 'Court Application Hearings', :vcr do
     visit court_application_hearing_hearing_day_path(problematic_application_id,
                                                      problematic_hearing_id,
                                                      missing_hearing_day)
-    expect(page).to have_content "11/04/2025"
+    expect(page).to have_content "11 April 2025"
     expect(page).to have_content "No events are associated with this hearing"
     expect(page).to have_no_content "Something went wrong"
   end

--- a/spec/features/breadcrumbs_spec.rb
+++ b/spec/features/breadcrumbs_spec.rb
@@ -83,13 +83,13 @@ RSpec.feature 'Breadcrumb', :stub_unlinked, type: :feature do
         when_i_search_for case_urn
 
         click_link_or_button(case_urn, match: :first)
-        click_link_or_button('23/10/2019', match: :first)
+        click_link_or_button('23 October 2019', match: :first)
         expect(page).to have_current_path(hearing_path(hearing_id_from_fixture,
                                                        column: 'date',
                                                        direction: 'asc',
                                                        urn: case_urn,
                                                        page: '0'))
-        then_has_hearing_details_breadcrumbs(case_urn, '23/10/2019')
+        then_has_hearing_details_breadcrumbs(case_urn, '23 October 2019')
       end
     end
 
@@ -111,13 +111,13 @@ RSpec.feature 'Breadcrumb', :stub_unlinked, type: :feature do
       expect(page).to have_current_path(prosecution_case_path(case_urn))
       then_has_case_details_breadcrumbs(case_urn)
 
-      click_link_or_button('23/10/2019', match: :first)
+      click_link_or_button('23 October 2019', match: :first)
       expect(page).to have_current_path(hearing_path(hearing_id_from_fixture,
                                                      column: 'date',
                                                      direction: 'asc',
                                                      urn: case_urn,
                                                      page: '0'))
-      then_has_hearing_details_breadcrumbs(case_urn, '23/10/2019')
+      then_has_hearing_details_breadcrumbs(case_urn, '23 October 2019')
 
       click_breadcrumb 'Search'
       expect(page).to have_current_path(

--- a/spec/features/court_applications_spec.rb
+++ b/spec/features/court_applications_spec.rb
@@ -48,17 +48,17 @@ RSpec.feature 'Court Applications', :vcr do
   scenario 'I view and sort an application with hearings' do
     sign_in user
     visit court_application_path(id_with_hearings)
-    expect(page).to have_content "23/10/2019 Mention - Defendant to Attend (MDA) Not available"
-    expect(page).to have_content "10/04/2025 Pre-Trial Review (PTR) Mr Leone Spinka (Direct counsel)"
+    expect(page).to have_content "23 October 2019 Mention - Defendant to Attend (MDA) Not available"
+    expect(page).to have_content "10 April 2025 Pre-Trial Review (PTR) Mr Leone Spinka (Direct counsel)"
 
-    node = find("a", text: "23/10/2019")
+    node = find("a", text: "23 October 2019")
     expect(node["href"]).to eq court_application_hearing_hearing_day_path(id_with_hearings,
                                                                           hearing_id_from_vcr, "2019-10-23")
 
-    expect(page.body.index("23/10/2019")).to be < page.body.index("10/04/2025")
+    expect(page.body.index("23 October 2019")).to be < page.body.index("10 April 2025")
     click_on "Date"
-    expect(page.body.index("23/10/2019")).to be > page.body.index("10/04/2025")
+    expect(page.body.index("23 October 2019")).to be > page.body.index("10 April 2025")
     click_on "Date"
-    expect(page.body.index("23/10/2019")).to be < page.body.index("10/04/2025")
+    expect(page.body.index("23 October 2019")).to be < page.body.index("10 April 2025")
   end
 end

--- a/spec/features/hearing_pagination_spec.rb
+++ b/spec/features/hearing_pagination_spec.rb
@@ -18,21 +18,21 @@ RSpec.feature 'Hearing pagination', :vcr, type: :feature do
   context 'when viewing case details' do
     scenario 'user can see links to hearing pages' do
       within :table, 'Hearings' do
-        expect(page).to have_link('23/10/2019', href: hearing_page_url(0), class: 'govuk-link')
-        expect(page).to have_link('26/10/2019', href: hearing_page_url(1), class: 'govuk-link')
-        expect(page).to have_link('31/10/2019', href: hearing_page_url(4), class: 'govuk-link')
+        expect(page).to have_link('23 October 2019', href: hearing_page_url(0), class: 'govuk-link')
+        expect(page).to have_link('26 October 2019', href: hearing_page_url(1), class: 'govuk-link')
+        expect(page).to have_link('31 October 2019', href: hearing_page_url(4), class: 'govuk-link')
       end
     end
 
     scenario 'user can navigate to a paginated hearing page' do
-      click_link_or_button('23/10/2019')
+      click_link_or_button('23 October 2019')
       expect(page).to have_current_path(hearing_page_url(0), url: true)
     end
   end
 
   context 'when on hearing page' do
     context 'with first hearing\'s day displayed' do
-      before { click_link_or_button('23/10/2019') }
+      before { click_link_or_button('23 October 2019') }
 
       scenario 'user can see Next page navigation only' do
         expect(page).to have_no_link('Previous')
@@ -41,7 +41,7 @@ RSpec.feature 'Hearing pagination', :vcr, type: :feature do
     end
 
     context 'with a "middle" hearing\'s day displayed' do
-      before { click_link_or_button('26/10/2019') }
+      before { click_link_or_button('26 October 2019') }
 
       scenario 'user can see Next page and Previous navigation' do
         expect(page).to have_link('Previous')
@@ -51,7 +51,7 @@ RSpec.feature 'Hearing pagination', :vcr, type: :feature do
 
     context 'with a last hearing\'s day displayed' do
       before do
-        click_link_or_button('31/10/2019')
+        click_link_or_button('31 October 2019')
         # There are 3 sitting days for this hearing
         click_link_or_button('Next')
         click_link_or_button('Next')
@@ -66,34 +66,34 @@ RSpec.feature 'Hearing pagination', :vcr, type: :feature do
 
   context 'when navigating between hearing days' do
     context 'when on first page' do
-      before { click_link_or_button('23/10/2019') }
+      before { click_link_or_button('23 October 2019') }
 
       scenario 'user can navigate to next hearing day' do
         click_link_or_button 'Next'
         expect(page)
           .to have_css('h1', text: 'Hearing day')
-          .and have_css('h1', text: '26/10/2019')
+          .and have_css('h1', text: '26 October 2019')
 
         click_link_or_button 'Next'
         expect(page)
           .to have_css('h1', text: 'Hearing day')
-          .and have_css('h1', text: '27/10/2019')
+          .and have_css('h1', text: '27 October 2019')
       end
     end
 
     context 'when on last page' do
-      before { click_link_or_button('31/10/2019') }
+      before { click_link_or_button('31 October 2019') }
 
       scenario 'user can navigate to previous hearing days' do
         click_link_or_button 'Previous'
         expect(page)
           .to have_css('h1', text: 'Hearing day')
-          .and have_css('h1', text: '28/10/2019')
+          .and have_css('h1', text: '28 October 2019')
 
         click_link_or_button 'Previous'
         expect(page)
           .to have_css('h1', text: 'Hearing day')
-          .and have_css('h1', text: '27/10/2019')
+          .and have_css('h1', text: '27 October 2019')
       end
     end
   end

--- a/spec/features/hearing_sorting_spec.rb
+++ b/spec/features/hearing_sorting_spec.rb
@@ -29,12 +29,12 @@ RSpec.feature 'Hearing sorting', :vcr, type: :feature do
         expect(page).to have_link('Providers attending',
                                   href: prosecution_cases_page_url('provider', 'desc'), class: 'govuk-link')
         rows = find_all('tbody/tr')
-        expect(rows[0]).to have_link('23/10/2019', href: hearing_page_url(0, 'date', 'asc'),
-                                                   class: 'govuk-link')
-        expect(rows[1]).to have_link('26/10/2019', href: hearing_page_url(1, 'date', 'asc'),
-                                                   class: 'govuk-link')
-        expect(rows[2]).to have_link('27/10/2019', href: hearing_page_url(2, 'date', 'asc'),
-                                                   class: 'govuk-link')
+        expect(rows[0]).to have_link('23 October 2019', href: hearing_page_url(0, 'date', 'asc'),
+                                                        class: 'govuk-link')
+        expect(rows[1]).to have_link('26 October 2019', href: hearing_page_url(1, 'date', 'asc'),
+                                                        class: 'govuk-link')
+        expect(rows[2]).to have_link('27 October 2019', href: hearing_page_url(2, 'date', 'asc'),
+                                                        class: 'govuk-link')
       end
     end
 
@@ -48,12 +48,12 @@ RSpec.feature 'Hearing sorting', :vcr, type: :feature do
         expect(page).to have_link('Providers attending',
                                   href: prosecution_cases_page_url('provider', 'asc'), class: 'govuk-link')
         rows = find_all('tbody/tr')
-        expect(rows[0]).to have_link('02/11/2019', href: hearing_page_url(0, 'date', 'desc'),
-                                                   class: 'govuk-link')
-        expect(rows[5]).to have_link('26/10/2019', href: hearing_page_url(5, 'date', 'desc'),
-                                                   class: 'govuk-link')
-        expect(rows[6]).to have_link('23/10/2019', href: hearing_page_url(6, 'date', 'desc'),
-                                                   class: 'govuk-link')
+        expect(rows[0]).to have_link('2 November 2019', href: hearing_page_url(0, 'date', 'desc'),
+                                                        class: 'govuk-link')
+        expect(rows[5]).to have_link('26 October 2019', href: hearing_page_url(5, 'date', 'desc'),
+                                                        class: 'govuk-link')
+        expect(rows[6]).to have_link('23 October 2019', href: hearing_page_url(6, 'date', 'desc'),
+                                                        class: 'govuk-link')
       end
     end
 
@@ -67,14 +67,14 @@ RSpec.feature 'Hearing sorting', :vcr, type: :feature do
         expect(page).to have_link('Providers attending',
                                   href: prosecution_cases_page_url('provider', 'asc'), class: 'govuk-link')
         rows = find_all('tbody/tr')
-        expect(rows[0]).to have_link('26/10/2019', href: hearing_page_url(0, 'type', 'desc'),
-                                                   class: 'govuk-link')
+        expect(rows[0]).to have_link('26 October 2019', href: hearing_page_url(0, 'type', 'desc'),
+                                                        class: 'govuk-link')
         expect(rows[0]).to have_text('Pre-Trial Review (PTR)')
-        expect(rows[5]).to have_link('01/11/2019', href: hearing_page_url(5, 'type', 'desc'),
-                                                   class: 'govuk-link')
+        expect(rows[5]).to have_link('1 November 2019', href: hearing_page_url(5, 'type', 'desc'),
+                                                        class: 'govuk-link')
         expect(rows[5]).to have_text('Application to Break Fixture (BFA)')
-        expect(rows[6]).to have_link('02/11/2019', href: hearing_page_url(6, 'type', 'desc'),
-                                                   class: 'govuk-link')
+        expect(rows[6]).to have_link('2 November 2019', href: hearing_page_url(6, 'type', 'desc'),
+                                                        class: 'govuk-link')
         expect(rows[6]).to have_text('Application to Break Fixture (BFA)')
       end
     end
@@ -91,14 +91,14 @@ RSpec.feature 'Hearing sorting', :vcr, type: :feature do
         expect(page).to have_link('Providers attending',
                                   href: prosecution_cases_page_url('provider', 'desc'), class: 'govuk-link')
         rows = find_all('tbody/tr')
-        expect(rows[0]).to have_link('31/10/2019', href: hearing_page_url(0, 'type', 'asc'),
-                                                   class: 'govuk-link')
+        expect(rows[0]).to have_link('31 October 2019', href: hearing_page_url(0, 'type', 'asc'),
+                                                        class: 'govuk-link')
         expect(rows[0]).to have_text('Application to Break Fixture (BFA)')
-        expect(rows[5]).to have_link('27/10/2019', href: hearing_page_url(5, 'type', 'asc'),
-                                                   class: 'govuk-link')
+        expect(rows[5]).to have_link('27 October 2019', href: hearing_page_url(5, 'type', 'asc'),
+                                                        class: 'govuk-link')
         expect(rows[5]).to have_text('Pre-Trial Review (PTR)')
-        expect(rows[6]).to have_link('28/10/2019', href: hearing_page_url(6, 'type', 'asc'),
-                                                   class: 'govuk-link')
+        expect(rows[6]).to have_link('28 October 2019', href: hearing_page_url(6, 'type', 'asc'),
+                                                        class: 'govuk-link')
         expect(rows[6]).to have_text('Pre-Trial Review (PTR)')
       end
     end
@@ -113,14 +113,14 @@ RSpec.feature 'Hearing sorting', :vcr, type: :feature do
         expect(page).to have_link("Providers attending \u25BC",
                                   href: prosecution_cases_page_url('provider', 'asc'), class: 'govuk-link')
         rows = find_all('tbody/tr')
-        expect(rows[2]).to have_link('28/10/2019', href: hearing_page_url(2, 'provider', 'desc'),
-                                                   class: 'govuk-link')
+        expect(rows[2]).to have_link('28 October 2019', href: hearing_page_url(2, 'provider', 'desc'),
+                                                        class: 'govuk-link')
         expect(rows[2]).to have_text('Pre-Trial Review (PTR)')
-        expect(rows[3]).to have_link('31/10/2019', href: hearing_page_url(3, 'provider', 'desc'),
-                                                   class: 'govuk-link')
+        expect(rows[3]).to have_link('31 October 2019', href: hearing_page_url(3, 'provider', 'desc'),
+                                                        class: 'govuk-link')
         expect(rows[3]).to have_text('Application to Break Fixture (BFA)')
-        expect(rows[6]).to have_link('23/10/2019', href: hearing_page_url(6, 'provider', 'desc'),
-                                                   class: 'govuk-link')
+        expect(rows[6]).to have_link('23 October 2019', href: hearing_page_url(6, 'provider', 'desc'),
+                                                        class: 'govuk-link')
         expect(rows[6]).to have_text('Mention - Defendant to Attend (MDA)')
       end
     end
@@ -136,14 +136,14 @@ RSpec.feature 'Hearing sorting', :vcr, type: :feature do
         expect(page).to have_link("Providers attending \u25B2",
                                   href: prosecution_cases_page_url('provider', 'desc'), class: 'govuk-link')
         rows = find_all('tbody/tr')
-        expect(rows[0]).to have_link('23/10/2019', href: hearing_page_url(0, 'provider', 'asc'),
-                                                   class: 'govuk-link')
+        expect(rows[0]).to have_link('23 October 2019', href: hearing_page_url(0, 'provider', 'asc'),
+                                                        class: 'govuk-link')
         expect(rows[0]).to have_text('Mention - Defendant to Attend (MDA)')
-        expect(rows[3]).to have_link('02/11/2019', href: hearing_page_url(3, 'provider', 'asc'),
-                                                   class: 'govuk-link')
+        expect(rows[3]).to have_link('2 November 2019', href: hearing_page_url(3, 'provider', 'asc'),
+                                                        class: 'govuk-link')
         expect(rows[3]).to have_text('Application to Break Fixture (BFA)')
-        expect(rows[6]).to have_link('28/10/2019', href: hearing_page_url(6, 'provider', 'asc'),
-                                                   class: 'govuk-link')
+        expect(rows[6]).to have_link('28 October 2019', href: hearing_page_url(6, 'provider', 'asc'),
+                                                        class: 'govuk-link')
         expect(rows[6]).to have_text('Pre-Trial Review (PTR)')
       end
     end

--- a/spec/views/defendants/_offences.html.haml_spec.rb
+++ b/spec/views/defendants/_offences.html.haml_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'defendants/_offences.html.haml', type: :view do
 
       it 'displays offence start date' do
         is_expected.to have_css('.govuk-table__cell',
-                                text: %r{01/01/2023})
+                                text: /1 January 2023/)
       end
     end
 
@@ -113,7 +113,7 @@ RSpec.describe 'defendants/_offences.html.haml', type: :view do
       it 'displays list of pleas with plea dates' do
         is_expected
           .to have_css('.govuk-table__cell',
-                       text: %r{No plea on 12/03/2020.*Not guilty on 12/04/2020.*Guilty on 12/05/2020})
+                       text: /No plea on 12 March 2020.*Not guilty on 12 April 2020.*Guilty on 12 May 2020/)
       end
     end
 

--- a/spec/views/prosecution_cases/_hearing_summaries.html.haml_spec.rb
+++ b/spec/views/prosecution_cases/_hearing_summaries.html.haml_spec.rb
@@ -71,19 +71,19 @@ RSpec.describe 'prosecution_cases/_hearing_summaries.html.haml', type: :view do
       end
 
       it 'renders link to hearing with urn' do
-        expect(rendered).to have_link('17/01/2021', href: %r{hearings/.*\?.*urn=THECASEURN})
+        expect(rendered).to have_link('17 January 2021', href: %r{hearings/.*\?.*urn=THECASEURN})
       end
 
       it 'renders link to hearing with page' do
-        expect(rendered).to have_link('17/01/2021',
+        expect(rendered).to have_link('17 January 2021',
                                       href: %r{hearings/.*\?.*page=\d})
       end
 
       it 'sorts hearings by hearing day' do
         expect(rendered)
-          .to have_css('tbody.govuk-table__body tr:nth-child(1)', text: '17/01/2021')
-          .and have_css('tbody.govuk-table__body tr:nth-child(2)', text: '18/01/2021')
-          .and have_css('tbody.govuk-table__body tr:nth-child(3)', text: '19/01/2021')
+          .to have_css('tbody.govuk-table__body tr:nth-child(1)', text: '17 January 2021')
+          .and have_css('tbody.govuk-table__body tr:nth-child(2)', text: '18 January 2021')
+          .and have_css('tbody.govuk-table__body tr:nth-child(3)', text: '19 January 2021')
       end
 
       it 'renders provider list per row' do
@@ -107,10 +107,10 @@ RSpec.describe 'prosecution_cases/_hearing_summaries.html.haml', type: :view do
 
       it 'sorts hearings by hearing_days collection then by hearing day datetime' do
         expect(rendered)
-          .to have_css('tbody.govuk-table__body tr:nth-child(1)', text: %r{17/01/2021.*First hearing}m)
-          .and have_css('tbody.govuk-table__body tr:nth-child(2)', text: %r{19/01/2021.*Trial}m)
-          .and have_css('tbody.govuk-table__body tr:nth-child(3)', text: %r{20/01/2021.*Trial}m)
-          .and have_css('tbody.govuk-table__body tr:nth-child(4)', text: %r{20/01/2021.*Sentence}m)
+          .to have_css('tbody.govuk-table__body tr:nth-child(1)', text: /17 January 2021.*First hearing/m)
+          .and have_css('tbody.govuk-table__body tr:nth-child(2)', text: /19 January 2021.*Trial/m)
+          .and have_css('tbody.govuk-table__body tr:nth-child(3)', text: /20 January 2021.*Trial/m)
+          .and have_css('tbody.govuk-table__body tr:nth-child(4)', text: /20 January 2021.*Sentence/m)
       end
     end
 
@@ -126,8 +126,8 @@ RSpec.describe 'prosecution_cases/_hearing_summaries.html.haml', type: :view do
       it 'renders formated estimated duration on the first hearing day' do
         expect(rendered)
           .to have_css('tbody.govuk-table__body tr:nth-child(1)',
-                       text: %r{19/01/2021.*Trial\n\n\nEstimated duration 20 days}m)
-          .and have_css('tbody.govuk-table__body tr:nth-child(2)', text: %r{20/01/2021.*Trial}m)
+                       text: /19 January 2021.*Trial\n\n\nEstimated duration 20 days/m)
+          .and have_css('tbody.govuk-table__body tr:nth-child(2)', text: /20 January 2021.*Trial/m)
       end
 
       it 'does not render duplicated estmated duration' do


### PR DESCRIPTION
#### What
https://dsdmoj.atlassian.net/browse/ACD-873
Use format "1 January 1900" instead of "01/01/1900"
