### PR TITLE
ACD-886: Separate heading from title when heading has PII

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -49,6 +49,7 @@ class ApplicationController < ActionController::Base
 
   def unexpected_exception_handler(exception)
     raise if Rails.env.development?
+
     logger.error("Unexpected #{exception.class} error: #{exception}")
     process_error_based_on_type(exception)
   end

--- a/app/helpers/govuk_design_system_helper.rb
+++ b/app/helpers/govuk_design_system_helper.rb
@@ -7,14 +7,14 @@
 require 'gds_design_system_breadcrumb_builder'
 
 module GovukDesignSystemHelper
-  def govuk_page_title(heading = nil, caption = nil, options = {})
-    title = options.delete(:title)
-    content_for :page_title, (title ? page_title(title) : page_title(heading, caption))
+  def govuk_page_heading(heading_text = nil, caption_text: nil, title: nil, tag_options: {})
+    title_content = title ? page_title(title) : page_title(heading_text, caption_text)
+    content_for :page_title, title_content
 
     content_for :page_heading do
-      options = prepend_classes('govuk-heading-xl', options)
-      tag.h1(**options) do
-        page_heading(heading, caption)
+      tag_options = prepend_classes('govuk-heading-xl', tag_options)
+      tag.h1(**tag_options) do
+        page_heading(heading_text, caption_text)
       end
     end
   end

--- a/app/helpers/govuk_design_system_helper.rb
+++ b/app/helpers/govuk_design_system_helper.rb
@@ -7,13 +7,14 @@
 require 'gds_design_system_breadcrumb_builder'
 
 module GovukDesignSystemHelper
-  def govuk_page_title(title = nil, caption = nil, tag_options = {})
-    content_for :page_title, page_title(title, caption)
+  def govuk_page_title(heading = nil, caption = nil, options = {})
+    title = options.delete(:title)
+    content_for :page_title, (title ? page_title(title) : page_title(heading, caption))
 
     content_for :page_heading do
-      tag_options = prepend_classes('govuk-heading-xl', tag_options)
-      tag.h1(**tag_options) do
-        page_heading(title, caption)
+      options = prepend_classes('govuk-heading-xl', options)
+      tag.h1(**options) do
+        page_heading(heading, caption)
       end
     end
   end
@@ -119,9 +120,9 @@ module GovukDesignSystemHelper
     tag.span(caption, class: 'govuk-caption-xl').concat(page_title_var)
   end
 
-  def page_title(title, caption)
+  def page_title(title, caption = nil)
     page_title_var = title || contextual_title
-    caption_var = caption.strip.concat if caption.present?
+    caption_var = caption.strip if caption.present?
     "#{caption_var} #{page_title_var} - #{service_name} - GOV.UK".strip
   end
 end

--- a/app/views/cookies/cookie_details.html.haml
+++ b/app/views/cookies/cookie_details.html.haml
@@ -1,4 +1,4 @@
-= govuk_page_title(t('cookies.page_title', service_name: service_name))
+= govuk_page_heading(t('cookies.page_title', service_name: service_name))
 
 %p.govuk-body= t('cookies.section_one.paragraph_one')
 

--- a/app/views/cookies/new.html.haml
+++ b/app/views/cookies/new.html.haml
@@ -1,4 +1,4 @@
-= govuk_page_title(t('cookie_settings.page_title'))
+= govuk_page_heading(t('cookie_settings.page_title'))
 
 %p.govuk-body= t('cookie_settings.section_intro.paragraph_one')
 

--- a/app/views/court_applications/show.html.haml
+++ b/app/views/court_applications/show.html.haml
@@ -1,4 +1,4 @@
-= govuk_page_title(@application.case_summary.prosecution_case_reference, @application.application_title)
+= govuk_page_heading(@application.case_summary.prosecution_case_reference, caption_text: @application.application_title)
 
 .govuk-body
   %strong

--- a/app/views/defendants/edit.html.haml
+++ b/app/views/defendants/edit.html.haml
@@ -1,4 +1,4 @@
-= govuk_page_title(@defendant.name, t('generic.defendant'))
+= govuk_page_title(@defendant.name, t('generic.defendant'), title: t('defendants.title'))
 
 - content_for :custom_packs do
   = javascript_include_tag 'unlink', defer: true

--- a/app/views/defendants/edit.html.haml
+++ b/app/views/defendants/edit.html.haml
@@ -1,4 +1,4 @@
-= govuk_page_title(@defendant.name, t('generic.defendant'), title: t('defendants.title'))
+= govuk_page_heading(@defendant.name, caption_text: t('generic.defendant'), title: t('defendants.title'))
 
 - content_for :custom_packs do
   = javascript_include_tag 'unlink', defer: true

--- a/app/views/devise/passwords/new.html.haml
+++ b/app/views/devise/passwords/new.html.haml
@@ -1,4 +1,4 @@
-= govuk_page_title(t('devise.passwords.user.form.reset.page_title'))
+= govuk_page_heading(t('devise.passwords.user.form.reset.page_title'))
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     = form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,4 +1,4 @@
-= govuk_page_title(t('devise.sessions.user.form.page_title'))
+= govuk_page_heading(t('devise.sessions.user.form.page_title'))
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds

--- a/app/views/devise/unlocks/new.html.haml
+++ b/app/views/devise/unlocks/new.html.haml
@@ -1,4 +1,4 @@
-= govuk_page_title(t('devise.unlocks.user.form.page_title'))
+= govuk_page_heading(t('devise.unlocks.user.form.page_title'))
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds

--- a/app/views/errors/internal_error.html.haml
+++ b/app/views/errors/internal_error.html.haml
@@ -1,4 +1,4 @@
-= govuk_page_title(t('error.500_title'))
+= govuk_page_heading(t('error.500_title'))
 
 %p.govuk-body= t('error.500_message')
 %p.govuk-body= t('error.description_html')

--- a/app/views/errors/not_found.html.haml
+++ b/app/views/errors/not_found.html.haml
@@ -1,4 +1,4 @@
-= govuk_page_title(t('error.404_title'))
+= govuk_page_heading(t('error.404_title'))
 
 %p.govuk-body= t('error.404_message')
 %p.govuk-body= t('error.404_message_2')

--- a/app/views/errors/unacceptable.html.haml
+++ b/app/views/errors/unacceptable.html.haml
@@ -1,4 +1,4 @@
-= govuk_page_title(t('error.422_title'))
+= govuk_page_heading(t('error.422_title'))
 
 %p.govuk-body= t('error.422_message')
 %p.govuk-body= t('error.description_html')

--- a/app/views/errors/unauthorized.html.haml
+++ b/app/views/errors/unauthorized.html.haml
@@ -1,4 +1,4 @@
-= govuk_page_title(t('error.401_title'))
+= govuk_page_heading(t('error.401_title'))
 
 .govuk-body
   %p= t('error.401_message')

--- a/app/views/hearing_days/show.html.haml
+++ b/app/views/hearing_days/show.html.haml
@@ -1,7 +1,7 @@
 - content_for :pre_heading do
   %strong.govuk-tag{ class: "govuk-!-margin-bottom-5" }
     = t(".appeal")
-= govuk_page_title(@hearing_day.day_string, t('generic.hearing_day'), class: 'govuk-!-margin-bottom-3')
+= govuk_page_heading(@hearing_day.day_string, caption_text: t('generic.hearing_day'), tag_options: { class: 'govuk-!-margin-bottom-3' })
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds

--- a/app/views/hearing_repull_batches/new.html.haml
+++ b/app/views/hearing_repull_batches/new.html.haml
@@ -1,4 +1,4 @@
-= govuk_page_title(t('.title'))
+= govuk_page_heading(t('.title'))
 
 = form_with model: @batch, url: hearing_repull_batches_path do |f|
   .govuk-grid-row

--- a/app/views/hearing_repull_batches/show.html.haml
+++ b/app/views/hearing_repull_batches/show.html.haml
@@ -1,4 +1,4 @@
-= govuk_page_title(t('.title'))
+= govuk_page_heading(t('.title'))
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     %table.govuk-table

--- a/app/views/hearings/show.html.haml
+++ b/app/views/hearings/show.html.haml
@@ -1,4 +1,4 @@
-= govuk_page_title(@hearing_day&.strftime('%d/%m/%Y'), t('generic.hearing_day'), class: 'govuk-!-margin-bottom-2')
+= govuk_page_heading(@hearing_day&.strftime('%d/%m/%Y'), caption_text: t('generic.hearing_day'), tag_options: { class: 'govuk-!-margin-bottom-2' })
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds

--- a/app/views/laa_references/new.html.haml
+++ b/app/views/laa_references/new.html.haml
@@ -1,4 +1,4 @@
-= govuk_page_title(@defendant.name, t('generic.defendant'))
+= govuk_page_title(@defendant.name, t('generic.defendant'), title: t('defendants.title'))
 
 = render partial: 'form', locals: { link_attempt: @link_attempt,
                                     defendant: @defendant,

--- a/app/views/laa_references/new.html.haml
+++ b/app/views/laa_references/new.html.haml
@@ -1,4 +1,4 @@
-= govuk_page_title(@defendant.name, t('generic.defendant'), title: t('defendants.title'))
+= govuk_page_heading(@defendant.name, caption_text: t('generic.defendant'), title: t('defendants.title'))
 
 = render partial: 'form', locals: { link_attempt: @link_attempt,
                                     defendant: @defendant,

--- a/app/views/prosecution_cases/show.html.haml
+++ b/app/views/prosecution_cases/show.html.haml
@@ -1,4 +1,4 @@
-= govuk_page_title(prosecution_case.prosecution_case_reference, t('generic.case'))
+= govuk_page_heading(prosecution_case.prosecution_case_reference, caption_text: t('generic.case'))
 
 .govuk-grid-row
   .govuk-grid-column-full

--- a/app/views/searches/new.html.haml
+++ b/app/views/searches/new.html.haml
@@ -1,4 +1,4 @@
-= govuk_page_title(t('search.page_title'))
+= govuk_page_heading(t('search.page_title'))
 
 .govuk-grid-row
   .govuk-grid-column-full

--- a/app/views/subjects/show.html.haml
+++ b/app/views/subjects/show.html.haml
@@ -3,7 +3,7 @@
     = t(".appeal")
 - content_for :custom_packs do
   = javascript_include_tag 'unlink', defer: true
-= govuk_page_title(@subject.name, t(".defendant"))
+= govuk_page_title(@subject.name, t(".defendant"), title: t(".title"))
 
 .govuk-width-container
   :ruby

--- a/app/views/subjects/show.html.haml
+++ b/app/views/subjects/show.html.haml
@@ -3,7 +3,7 @@
     = t(".appeal")
 - content_for :custom_packs do
   = javascript_include_tag 'unlink', defer: true
-= govuk_page_title(@subject.name, t(".defendant"), title: t(".title"))
+= govuk_page_heading(@subject.name, caption_text: t(".defendant"), title: t(".title"))
 
 .govuk-width-container
   :ruby

--- a/app/views/users/change_password.html.haml
+++ b/app/views/users/change_password.html.haml
@@ -1,4 +1,4 @@
-= govuk_page_title(t('users.change_password.page_title'))
+= govuk_page_heading(t('users.change_password.page_title'))
 
 = form_for(@user, url: update_password_user_path(@user)) do |f|
   = f.govuk_error_summary

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -1,3 +1,3 @@
-= govuk_page_title(t('users.edit.page_title'))
+= govuk_page_heading(t('users.edit.page_title'))
 
 = render partial: 'form', locals: { user: @user }

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -1,4 +1,4 @@
-= govuk_page_title(t('users.index.page_title'))
+= govuk_page_heading(t('users.index.page_title'))
 
 .govuk-grid-row
   .govuk-grid-column-full

--- a/app/views/users/new.html.haml
+++ b/app/views/users/new.html.haml
@@ -1,2 +1,2 @@
-= govuk_page_title(t('users.new.page_title'))
+= govuk_page_heading(t('users.new.page_title'))
 = render partial: 'form', locals: { user: @user }

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,4 +1,4 @@
-= govuk_page_title(t('users.show.page_heading', name: @user.name), nil, title: t('users.show.page_title'))
+= govuk_page_heading(t('users.show.page_heading', name: @user.name), title: t('users.show.page_title'))
 
 %table.govuk-table
   %caption.govuk-table__caption

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,4 +1,4 @@
-= govuk_page_title(t('users.show.page_title', name: @user.name))
+= govuk_page_title(t('users.show.page_heading', name: @user.name), nil, title: t('users.show.page_title'))
 
 %table.govuk-table
   %caption.govuk-table__caption

--- a/config/locales/en/views/defendants.yml
+++ b/config/locales/en/views/defendants.yml
@@ -10,6 +10,7 @@ en:
       submit: Remove link to court data
       unlinking: Unlinking...
     reload: Reload page with full offence history
+    title: Defendant details
     unlink:
       detail: Remove link to court data
       failure: The link to the court data source could not be removed.

--- a/config/locales/en/views/subjects.yml
+++ b/config/locales/en/views/subjects.yml
@@ -17,6 +17,7 @@ en:
         plea: Plea
       offences: Offences
       plea_summary: "%{value} on %{date}"
+      title: Appellant details
       view_summary: View appeal application summary
     unlink:
       failure: Unable to unlink the defendant

--- a/config/locales/en/views/users.yml
+++ b/config/locales/en/views/users.yml
@@ -73,7 +73,8 @@ en:
       edit_link_aria: Edit %{name}'s account
       email_label: Email
       name_label: Name
-      page_title: "%{name}'s account"
+      page_heading: "%{name}'s account"
+      page_title: User account
       roles_label: Roles
       username_label: Username
     update:

--- a/spec/features/defendants_view_spec.rb
+++ b/spec/features/defendants_view_spec.rb
@@ -32,7 +32,7 @@ RSpec.feature 'defendants view', type: :feature do
 
     scenario 'laa_references page shows data' do
       visit "laa_references/new?id=#{defendant_id}&urn=#{case_urn}"
-      expect(page).to have_title('Jammy Dodger')
+      expect(page).to have_title('Defendant details')
       expect(page).to have_css('th.govuk-table__header', text: 'Date of birth')
       expect(page).to have_css('th.govuk-table__header', text: 'Case URN')
       expect(page).to have_css('th.govuk-table__header', text: 'NI number')
@@ -60,7 +60,7 @@ RSpec.feature 'defendants view', type: :feature do
 
       scenario 'page shows without linking options' do
         visit "laa_references/new?id=#{defendant_id}&urn=#{case_urn}"
-        expect(page).to have_title('Jammy Dodger')
+        expect(page).to have_title('Defendant details')
         expect(page).to have_no_content('Create link to court data')
       end
     end
@@ -84,7 +84,7 @@ RSpec.feature 'defendants view', type: :feature do
 
     scenario 'defendants page shows data' do
       visit "defendants/#{defendant_id}/edit?urn=#{case_urn}"
-      expect(page).to have_title('Jammy Dodger')
+      expect(page).to have_title('Defendant details')
       expect(page).to have_css('th.govuk-table__header', text: 'Date of birth')
       expect(page).to have_css('th.govuk-table__header', text: 'Case URN')
       expect(page).to have_css('th.govuk-table__header', text: 'NI number')
@@ -113,7 +113,7 @@ RSpec.feature 'defendants view', type: :feature do
 
       scenario 'page shows without linking options' do
         visit "defendants/#{defendant_id}/edit?urn=#{case_urn}"
-        expect(page).to have_title('Jammy Dodger')
+        expect(page).to have_title('Defendant details')
         expect(page).to have_no_content('Remove link to court data')
       end
     end

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature 'Sign in', type: :feature do
   before { visit 'users/sign_in' }
 
   it 'page header is displayed' do
-    expect(page).to have_govuk_page_title(text: 'Sign in')
+    expect(page).to have_govuk_page_heading(text: 'Sign in')
   end
 
   it 'page should be accessible', :js do
@@ -73,7 +73,7 @@ RSpec.feature 'Sign in', type: :feature do
       fill_in 'Username or email', with: 'billy bob'
       fill_in 'Password', with: user.password
       click_button 'Sign in'
-      expect(page).to have_govuk_page_title(text: 'Sign in')
+      expect(page).to have_govuk_page_heading(text: 'Sign in')
       expect(page).to have_govuk_flash(:alert, text: 'Invalid username or password')
     end
   end

--- a/spec/features/sign_out_spec.rb
+++ b/spec/features/sign_out_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature 'Sign out', type: :feature do
   end
 
   it 'displays sign in page' do
-    expect(page).to have_govuk_page_title(text: 'Sign in')
+    expect(page).to have_govuk_page_heading(text: 'Sign in')
   end
 
   it 'displays sign in link' do

--- a/spec/features/users/edit_user_spec.rb
+++ b/spec/features/users/edit_user_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature 'Edit user', :js, type: :feature do
     scenario 'cannot navigate to edit themselves' do
       visit user_path(user)
 
-      expect(page).to have_govuk_page_title(text: "#{user.name}'s account")
+      expect(page).to have_govuk_page_heading(text: "#{user.name}'s account")
       expect(page).to have_no_link('Edit', href: 'edit')
     end
 
@@ -36,7 +36,7 @@ RSpec.feature 'Edit user', :js, type: :feature do
         click_link_or_button 'Edit'
       end
 
-      expect(page).to have_govuk_page_title(text: 'Edit user')
+      expect(page).to have_govuk_page_heading(text: 'Edit user')
       expect(page).to have_field('First name', type: 'text')
       expect(page).to have_field('Last name', type: 'text')
       expect(page).to have_field('Username', type: 'text')

--- a/spec/features/users/index_users_spec.rb
+++ b/spec/features/users/index_users_spec.rb
@@ -30,7 +30,7 @@ RSpec.feature 'Index users', :js, type: :feature do
 
       click_link_or_button 'Manage users'
 
-      expect(page).to have_govuk_page_title(text: 'List of users')
+      expect(page).to have_govuk_page_heading(text: 'List of users')
 
       within '.govuk-table__head' do
         expect(page).to have_css('.govuk-table__header', text: 'Name')

--- a/spec/features/users/new_user_spec.rb
+++ b/spec/features/users/new_user_spec.rb
@@ -28,13 +28,13 @@ RSpec.feature 'New user', type: :feature do
 
     scenario 'can new and create users' do
       visit users_path
-      expect(page).to have_govuk_page_title(text: 'List of users')
+      expect(page).to have_govuk_page_heading(text: 'List of users')
 
       expect(page).to have_link(text: 'Create a new user')
       click_link_or_button 'Create a new user'
       expect(page).to have_current_path(new_user_path)
 
-      expect(page).to have_govuk_page_title(text: 'New user')
+      expect(page).to have_govuk_page_heading(text: 'New user')
       expect(page).to have_field('First name', type: 'text')
       expect(page).to have_field('Last name', type: 'text')
       expect(page).to have_field('Username', type: 'text')
@@ -67,7 +67,7 @@ RSpec.feature 'New user', type: :feature do
       expect(page).to have_current_path(user_path(new_user))
       expect(page).to have_govuk_flash(:notice, text: 'User successfully added')
 
-      expect(page).to have_govuk_page_title(text: 'Jim Bob\'s account')
+      expect(page).to have_govuk_page_heading(text: 'Jim Bob\'s account')
       expect(page).to have_css('.govuk-table__cell', text: 'Jim Bob')
       expect(page).to have_css('.govuk-table__cell', text: 'jim.bob@example.com')
       expect(page).to have_css('.govuk-table__cell', text: 'bob-j')

--- a/spec/features/users/password_change_spec.rb
+++ b/spec/features/users/password_change_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature 'Password change', :js, type: :feature do
   scenario 'caseworker amends their own password' do
     visit user_path(user)
 
-    expect(page).to have_govuk_page_title(text: "#{user.name}'s account")
+    expect(page).to have_govuk_page_heading(text: "#{user.name}'s account")
     expect(page).to have_text(user.name)
     expect(page).to have_text(user.email)
     expect(page).to have_no_link('Edit')
@@ -18,7 +18,7 @@ RSpec.feature 'Password change', :js, type: :feature do
 
     click_link_or_button 'Change password'
 
-    expect(page).to have_govuk_page_title(text: 'Change password')
+    expect(page).to have_govuk_page_heading(text: 'Change password')
     expect(page).to be_accessible.within '#main-content'
 
     fill_in 'Current password', with: user.password

--- a/spec/features/users/password_reset_spec.rb
+++ b/spec/features/users/password_reset_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature 'Password reset', :js, type: :feature do
     expect(page).to have_link('Forgot your password?')
     click_link_or_button 'Forgot your password?'
 
-    expect(page).to have_govuk_page_title(text: 'Forgot your password?')
+    expect(page).to have_govuk_page_heading(text: 'Forgot your password?')
     expect(page).to be_accessible.within '#main-content'
     fill_in 'Email', with: user.email
     expect do

--- a/spec/features/users/password_unlock_spec.rb
+++ b/spec/features/users/password_unlock_spec.rb
@@ -44,7 +44,7 @@ RSpec.feature 'Password unlock', type: :feature do
     scenario 'unlock request page is accessible', :js do
       expect(page).to have_link('Didn\'t receive unlock instructions?')
       click_link_or_button 'Didn\'t receive unlock instructions?'
-      expect(page).to have_govuk_page_title(text: 'Resend unlock instructions')
+      expect(page).to have_govuk_page_heading(text: 'Resend unlock instructions')
       expect(page).to be_accessible.within '#main-content'
     end
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe ApplicationHelper, type: :helper do
   subject { helper }
 
-  it { is_expected.to respond_to :govuk_page_title }
+  it { is_expected.to respond_to :govuk_page_heading }
   it { is_expected.to respond_to :govuk_breadcrumb_builder }
   it { is_expected.to respond_to :service_name }
   it { is_expected.to respond_to :l }

--- a/spec/helpers/govuk_design_system_helper_spec.rb
+++ b/spec/helpers/govuk_design_system_helper_spec.rb
@@ -3,10 +3,10 @@
 RSpec.describe GovukDesignSystemHelper, type: :helper do
   include RSpecHtmlMatchers
 
-  describe '#govuk_page_title' do
-    context 'when page title provided' do
+  describe '#govuk_page_heading' do
+    context 'when heading text provided' do
       before do
-        helper.govuk_page_title('My page title')
+        helper.govuk_page_heading('My page title')
       end
 
       it 'stores :page_title' do
@@ -29,9 +29,34 @@ RSpec.describe GovukDesignSystemHelper, type: :helper do
       end
     end
 
+    context 'when title provided' do
+      before do
+        helper.govuk_page_heading('My page heading', title: 'Other title')
+      end
+
+      it 'stores :page_title' do
+        expect(helper.content_for(:page_title)).to include 'Other title'
+      end
+
+      it 'stores :page_heading' do
+        expect(helper.content_for(:page_heading)).to include 'My page heading'
+      end
+
+      it ':page_title contains plain text' do
+        expect(helper.content_for(:page_title)).to eql 'Other title - View court data - GOV.UK'
+      end
+
+      it ':page_heading contains GDS styled heading' do
+        markup = helper.content_for(:page_heading)
+        expect(markup).to have_tag(:h1, with: { class: 'govuk-heading-xl' }) do
+          with_text 'My page heading'
+        end
+      end
+    end
+
     context 'when caption provided' do
       before do
-        helper.govuk_page_title('My page title', 'My page caption')
+        helper.govuk_page_heading('My page title', caption_text: 'My page caption')
       end
 
       it 'stores :page_title' do
@@ -59,7 +84,7 @@ RSpec.describe GovukDesignSystemHelper, type: :helper do
     context 'when no page title provided' do
       before do
         allow(controller).to receive_messages(controller_name: 'Widgets', action_name: 'show')
-        helper.govuk_page_title
+        helper.govuk_page_heading
       end
 
       it ':page_title contains title based on controller action' do
@@ -76,7 +101,8 @@ RSpec.describe GovukDesignSystemHelper, type: :helper do
 
     context 'with custom classes' do
       before do
-        helper.govuk_page_title('A page title', 'A page caption', class: 'my-custom-class1 my-custom-class2')
+        helper.govuk_page_heading('A page title', caption_text: 'A page caption',
+                                                  tag_options: { class: 'my-custom-class1 my-custom-class2' })
       end
 
       it ':page_heading contains custom classes, prepended by govuk class' do

--- a/spec/support/capybara_extensions.rb
+++ b/spec/support/capybara_extensions.rb
@@ -9,11 +9,11 @@
 #
 module CapybaraExtensions
   module Matchers
-    def has_govuk_page_title?(options = {})
+    def has_govuk_page_heading?(options = {})
       has_selector?('h1.govuk-heading-xl', **options)
     end
 
-    def has_no_govuk_page_title?(options = {})
+    def has_no_govuk_page_heading?(options = {})
       has_no_selector?('h1.govuk-heading-xl', **options)
     end
 

--- a/spec/views/hearings/show.html.haml_spec.rb
+++ b/spec/views/hearings/show.html.haml_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'hearings/show', :stub_v2_hearing_data, :stub_v2_hearing_summary,
   end
 
   before do
-    allow(view).to receive(:govuk_page_title).and_return 'Hearings Page'
+    allow(view).to receive(:govuk_page_heading).and_return 'Hearings Page'
 
     assign(:hearing, hearing)
     assign(:hearing_day, hearing_day)

--- a/spec/views/prosecution_cases/show.html.haml_spec.rb
+++ b/spec/views/prosecution_cases/show.html.haml_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'prosecution_cases/show.html.haml', type: :view do
   end
 
   before do
-    allow(view).to receive(:govuk_page_title).and_return 'A Gov uk page title'
+    allow(view).to receive(:govuk_page_heading).and_return 'A Gov uk page title'
     allow(decorated_case_summary).to receive_messages(case_summary_details)
   end
 


### PR DESCRIPTION
#### What
When the page heading has PII, provide a separate page title so that the PII doesn't get sent to Google Analytics.