### PR TITLE
ACD-890: Sanitise URL params we pass on to CDA

### DIFF
--- a/app/models/cda/base_model.rb
+++ b/app/models/cda/base_model.rb
@@ -11,7 +11,7 @@ module Cda
       }
     end
 
-    def self.make_safe_for_path(variable)
+    def self.safe_path(variable)
       CGI.escapeURIComponent(variable.to_s)
     end
   end

--- a/app/models/cda/base_model.rb
+++ b/app/models/cda/base_model.rb
@@ -10,5 +10,9 @@ module Cda
         'X-Request-ID' => Current.request_id
       }
     end
+
+    def self.make_safe_for_path(variable)
+      CGI.escapeURIComponent(variable.to_s)
+    end
   end
 end

--- a/app/models/cda/defendant.rb
+++ b/app/models/cda/defendant.rb
@@ -4,8 +4,8 @@ module Cda
   class Defendant < BaseModel
     def self.find_from_id_and_urn(defendant_id, urn)
       find(:one,
-           from: "/api/internal/v2/prosecution_cases/#{make_safe_for_path(urn)}/" \
-                 "defendants/#{make_safe_for_path(defendant_id)}")
+           from: "/api/internal/v2/prosecution_cases/#{safe_path(urn)}/" \
+                 "defendants/#{safe_path(defendant_id)}")
     end
 
     def name

--- a/app/models/cda/defendant.rb
+++ b/app/models/cda/defendant.rb
@@ -3,7 +3,9 @@
 module Cda
   class Defendant < BaseModel
     def self.find_from_id_and_urn(defendant_id, urn)
-      find(:one, from: "/api/internal/v2/prosecution_cases/#{urn}/defendants/#{defendant_id}")
+      find(:one,
+           from: "/api/internal/v2/prosecution_cases/#{make_safe_for_path(urn)}/" \
+                 "defendants/#{make_safe_for_path(defendant_id)}")
     end
 
     def name

--- a/app/models/cda/hearing_event_log.rb
+++ b/app/models/cda/hearing_event_log.rb
@@ -3,7 +3,9 @@
 module Cda
   class HearingEventLog < BaseModel
     def self.find_from_hearing_and_date(hearing_id, date)
-      find(:one, from: "/api/internal/v2/hearings/#{hearing_id}/event_log/#{date}")
+      find(:one,
+           from: "/api/internal/v2/hearings/#{make_safe_for_path(hearing_id)}/" \
+                 "event_log/#{make_safe_for_path(date)}")
     end
   end
 end

--- a/app/models/cda/hearing_event_log.rb
+++ b/app/models/cda/hearing_event_log.rb
@@ -4,8 +4,8 @@ module Cda
   class HearingEventLog < BaseModel
     def self.find_from_hearing_and_date(hearing_id, date)
       find(:one,
-           from: "/api/internal/v2/hearings/#{make_safe_for_path(hearing_id)}/" \
-                 "event_log/#{make_safe_for_path(date)}")
+           from: "/api/internal/v2/hearings/#{safe_path(hearing_id)}/" \
+                 "event_log/#{safe_path(date)}")
     end
   end
 end

--- a/app/models/cda/offence_history_collection.rb
+++ b/app/models/cda/offence_history_collection.rb
@@ -3,7 +3,9 @@ module Cda
     has_many :offence_histories, class_name: 'Cda::OffenceHistory'
 
     def self.find_from_id_and_urn(defendant_id, urn)
-      find(:one, from: "/api/internal/v2/prosecution_cases/#{urn}/defendants/#{defendant_id}/offence_history")
+      find(:one,
+           from: "/api/internal/v2/prosecution_cases/#{make_safe_for_path(urn)}/" \
+                 "defendants/#{make_safe_for_path(defendant_id)}/offence_history")
     end
   end
 end

--- a/app/models/cda/offence_history_collection.rb
+++ b/app/models/cda/offence_history_collection.rb
@@ -4,8 +4,8 @@ module Cda
 
     def self.find_from_id_and_urn(defendant_id, urn)
       find(:one,
-           from: "/api/internal/v2/prosecution_cases/#{make_safe_for_path(urn)}/" \
-                 "defendants/#{make_safe_for_path(defendant_id)}/offence_history")
+           from: "/api/internal/v2/prosecution_cases/#{safe_path(urn)}/" \
+                 "defendants/#{safe_path(defendant_id)}/offence_history")
     end
   end
 end

--- a/spec/models/cda/defendant_spec.rb
+++ b/spec/models/cda/defendant_spec.rb
@@ -1,0 +1,31 @@
+RSpec.describe Cda::Defendant, type: :model do
+  describe '.find_from_id_and_urn' do
+    subject(:find_entity) { described_class.find_from_id_and_urn(id, urn) }
+
+    let(:id) { SecureRandom.uuid }
+    let(:urn) { 'ABC123456' }
+
+    it "constructs a request" do
+      stub = stub_request(:get, %r{/v2/prosecution_cases/#{urn}/defendants/#{id}}).to_return(body: '{}')
+
+      find_entity
+
+      expect(stub).to have_been_requested
+    end
+
+    context 'when params contain unsafe characters' do
+      let(:id) { "123/456?789=0" }
+      let(:urn) { 'ABC123456 ' }
+
+      it "sanitises them" do
+        stub = stub_request(:get,
+                            %r{/v2/prosecution_cases/ABC123456%20/defendants/123%2F456%3F789=0})
+               .to_return(body: '{}')
+
+        find_entity
+
+        expect(stub).to have_been_requested
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What
VCD is breaking when the URN has a space in it, but escaping is also important to prevent malicious requests being passed on to CDA