### PR TITLE
ACD-278: Expand accessibility checks to cover whole page

### DIFF
--- a/app/assets/stylesheets/components/_phase_banner.scss
+++ b/app/assets/stylesheets/components/_phase_banner.scss
@@ -40,5 +40,6 @@ $app-local-colour: govuk-colour("bright-purple");
 
   .govuk-tag.govuk-phase-banner__content__tag {
     background-color: $app-local-colour;
+    color: white;
   }
 }

--- a/app/assets/stylesheets/components/_phase_banner.scss
+++ b/app/assets/stylesheets/components/_phase_banner.scss
@@ -2,6 +2,7 @@ $app-uat-colour: govuk-colour("orange");
 $app-test-colour: govuk-colour("turquoise");
 $app-dev-colour: govuk-colour("pink");
 $app-local-colour: govuk-colour("bright-purple");
+$app-local-text-colour: govuk-colour("white");
 
 .app-environment-uat {
   .govuk-header__container {
@@ -39,7 +40,7 @@ $app-local-colour: govuk-colour("bright-purple");
   }
 
   .govuk-tag.govuk-phase-banner__content__tag {
+    color: $app-local-text-colour;
     background-color: $app-local-colour;
-    color: white;
   }
 }

--- a/app/views/search_filters/_form.html.haml
+++ b/app/views/search_filters/_form.html.haml
@@ -6,6 +6,6 @@
                                      Search.filters,
                                      :id,
                                      :name,
-                                     legend: { text: t('search_filter.legend_text'), size: 'xl' }
+                                     legend: { text: t('search_filter.legend_text'), size: 'xl', tag: 'h1' }
 
   = f.govuk_submit(t('generic.continue'))

--- a/spec/features/search/cda/case_reference_spec.rb
+++ b/spec/features/search/cda/case_reference_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature 'Case reference search', :vcr, :js, type: :feature do
       expect(find('a', text: 'Marlin Schaefer Leuschke')['href']).to match(%r{defendants/.*/edit})
     end
 
-    expect(page).to be_accessible.within '#main-content'
+    expect(page).to be_accessible
   end
 
   scenario 'with non existent case URN' do
@@ -36,7 +36,7 @@ RSpec.feature 'Case reference search', :vcr, :js, type: :feature do
     click_button 'Search'
     expect(page).to have_css('.govuk-body', text: 'There are no matching results')
 
-    expect(page).to be_accessible.within '#main-content'
+    expect(page).to be_accessible
   end
 
   scenario 'with no case reference provided' do
@@ -55,7 +55,7 @@ RSpec.feature 'Case reference search', :vcr, :js, type: :feature do
 
     expect(page).to have_css('#search-term-error', text: 'Search term required')
 
-    expect(page).to be_accessible.within '#main-content'
+    expect(page).to be_accessible
   end
 
   scenario 'with error from common_platform', :stub_defendants_cda_failed do
@@ -75,7 +75,7 @@ RSpec.feature 'Case reference search', :vcr, :js, type: :feature do
       expect(page).to have_content('HMCTS Common Platform could not be reached')
     end
 
-    expect(page).to be_accessible.within '#main-content'
+    expect(page).to be_accessible
   end
 
   scenario 'with error from CDA', :stub_defendants_failed_case_search do
@@ -93,7 +93,7 @@ RSpec.feature 'Case reference search', :vcr, :js, type: :feature do
         .to have_content('Unable to complete the search. Please adjust the search terms and try again.')
     end
 
-    expect(page).to be_accessible.within '#main-content'
+    expect(page).to be_accessible
   end
 
   context 'when appeals flag is set' do

--- a/spec/features/search/cda/defendant_by_name_spec.rb
+++ b/spec/features/search/cda/defendant_by_name_spec.rb
@@ -39,7 +39,7 @@ RSpec.feature 'Defendant by name and dob search', :vcr, :js, type: :feature do
     end
 
     scenario 'it is axe-accessible', :js do
-      expect(page).to be_accessible.within '#main-content'
+      expect(page).to be_accessible
     end
   end
 

--- a/spec/features/search/cda/defendant_by_reference_spec.rb
+++ b/spec/features/search/cda/defendant_by_reference_spec.rb
@@ -25,7 +25,7 @@ RSpec.feature 'Defendant by reference search', :vcr, :js, type: :feature do
         expect(page).to have_content('HX685369B').once
       end
 
-      expect(page).to be_accessible.within '#main-content'
+      expect(page).to be_accessible
     end
 
     scenario 'with no results' do
@@ -38,7 +38,7 @@ RSpec.feature 'Defendant by reference search', :vcr, :js, type: :feature do
 
       expect(page).to have_css('.govuk-body', text: 'There are no matching results')
 
-      expect(page).to be_accessible.within '#main-content'
+      expect(page).to be_accessible
     end
 
     scenario 'with no defendant reference specified' do
@@ -57,7 +57,7 @@ RSpec.feature 'Defendant by reference search', :vcr, :js, type: :feature do
 
       expect(page).to have_css('#search-term-error', text: 'Search term required')
 
-      expect(page).to be_accessible.within '#main-content'
+      expect(page).to be_accessible
     end
   end
 end

--- a/spec/features/search/cda/filters_spec.rb
+++ b/spec/features/search/cda/filters_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature 'Search filters', :js, type: :feature do
     expect(page).to have_css('.govuk-radios__item',
                              text: 'A defendant by name and date of birth')
 
-    expect(page).to be_accessible.within '#main-content'
+    expect(page).to be_accessible
   end
 
   scenario 'user chooses defendant ASN or NI filter' do
@@ -28,7 +28,7 @@ RSpec.feature 'Search filters', :js, type: :feature do
     click_link_or_button 'Continue'
     expect(page).to have_text('Defendant ASN or National insurance number')
 
-    expect(page).to be_accessible.within '#main-content'
+    expect(page).to be_accessible
   end
 
   scenario 'user chooses defendant name filter' do
@@ -38,7 +38,7 @@ RSpec.feature 'Search filters', :js, type: :feature do
     click_link_or_button 'Continue'
     expect(page).to have_text('Defendant name')
 
-    expect(page).to be_accessible.within '#main-content'
+    expect(page).to be_accessible
   end
 
   scenario 'user chooses case number filter' do
@@ -48,6 +48,6 @@ RSpec.feature 'Search filters', :js, type: :feature do
     click_link_or_button 'Continue'
     expect(page).to have_text('Unique reference number')
 
-    expect(page).to be_accessible.within '#main-content'
+    expect(page).to be_accessible
   end
 end

--- a/spec/features/search/filters_spec.rb
+++ b/spec/features/search/filters_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature 'Search filters', :js, type: :feature do
     expect(page).to have_css('.govuk-radios__item',
                              text: 'A defendant by name and date of birth')
 
-    expect(page).to be_accessible.within '#main-content'
+    expect(page).to be_accessible
   end
 
   scenario 'user chooses defendant ASN or NI filter' do
@@ -28,7 +28,7 @@ RSpec.feature 'Search filters', :js, type: :feature do
     click_link_or_button 'Continue'
     expect(page).to have_text('Defendant ASN or National insurance number')
 
-    expect(page).to be_accessible.within '#main-content'
+    expect(page).to be_accessible
   end
 
   scenario 'user chooses defendant name filter' do
@@ -38,7 +38,7 @@ RSpec.feature 'Search filters', :js, type: :feature do
     click_link_or_button 'Continue'
     expect(page).to have_text('Defendant name')
 
-    expect(page).to be_accessible.within '#main-content'
+    expect(page).to be_accessible
   end
 
   scenario 'user chooses case number filter' do
@@ -48,6 +48,6 @@ RSpec.feature 'Search filters', :js, type: :feature do
     click_link_or_button 'Continue'
     expect(page).to have_text('Unique reference number')
 
-    expect(page).to be_accessible.within '#main-content'
+    expect(page).to be_accessible
   end
 end

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature 'Sign in', type: :feature do
   end
 
   it 'page should be accessible', :js do
-    expect(page).to be_accessible.within '#main-content'
+    expect(page).to be_accessible
   end
 
   context 'with success' do

--- a/spec/features/users/edit_user_spec.rb
+++ b/spec/features/users/edit_user_spec.rb
@@ -56,7 +56,7 @@ RSpec.feature 'Edit user', :js, type: :feature do
       fill_in 'Email', with: 'changed@example.com'
       fill_in 'Confirm email', with: 'changed@example.com'
 
-      expect(page).to be_accessible.within '#main-content'
+      expect(page).to be_accessible
 
       expect do
         click_link_or_button 'Save'

--- a/spec/features/users/index_users_spec.rb
+++ b/spec/features/users/index_users_spec.rb
@@ -51,7 +51,7 @@ RSpec.feature 'Index users', :js, type: :feature do
       # Verify sorting by name
       expect(page.text.index(user.email)).to be < page.text.index(other_user.email)
 
-      expect(page).to be_accessible.within '#main-content'
+      expect(page).to be_accessible
     end
 
     context 'when searching' do

--- a/spec/features/users/password_change_spec.rb
+++ b/spec/features/users/password_change_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature 'Password change', :js, type: :feature do
     click_link_or_button 'Change password'
 
     expect(page).to have_govuk_page_heading(text: 'Change password')
-    expect(page).to be_accessible.within '#main-content'
+    expect(page).to be_accessible
 
     fill_in 'Current password', with: user.password
     fill_in 'New password', with: 'my-new-password'

--- a/spec/features/users/password_reset_spec.rb
+++ b/spec/features/users/password_reset_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature 'Password reset', :js, type: :feature do
     click_link_or_button 'Forgot your password?'
 
     expect(page).to have_govuk_page_heading(text: 'Forgot your password?')
-    expect(page).to be_accessible.within '#main-content'
+    expect(page).to be_accessible
     fill_in 'Email', with: user.email
     expect do
       click_link_or_button 'Send me reset password instructions'

--- a/spec/features/users/password_unlock_spec.rb
+++ b/spec/features/users/password_unlock_spec.rb
@@ -45,7 +45,7 @@ RSpec.feature 'Password unlock', type: :feature do
       expect(page).to have_link('Didn\'t receive unlock instructions?')
       click_link_or_button 'Didn\'t receive unlock instructions?'
       expect(page).to have_govuk_page_heading(text: 'Resend unlock instructions')
-      expect(page).to be_accessible.within '#main-content'
+      expect(page).to be_accessible
     end
 
     scenario 'caseworker requests unlock email to be resent' do


### PR DESCRIPTION
#### What
Our current accessibility checks just check #main. This PR expands the checks to check the whole page, and fixes the issues raised:
- The root search screen is lacking an h1 - fixed by inserting one into the form legend
- The 'local' tag is not sufficiently high contrast - fixed by changing the text color in the label
