### PR TITLE
ACD-900: Accessibility tests

### DIFF
--- a/app/views/maintenance_mode/show.html.haml
+++ b/app/views/maintenance_mode/show.html.haml
@@ -2,7 +2,7 @@
 %html.govuk-template{ lang: 'en' }
   %head
     %title
-      = content_for?(:page_title) ? yield(:page_title) : service_name
+      = service_name
 
     %meta{ charset: "utf-8" }/
     = stylesheet_link_tag 'application', media: 'all'
@@ -40,5 +40,3 @@
           = t('maintenance_mode.text')
 
     = render 'layouts/footer'
-
-  = content_for?(:custom_packs) ? yield(:custom_packs) : ''

--- a/spec/features/application_hearings_spec.rb
+++ b/spec/features/application_hearings_spec.rb
@@ -31,7 +31,7 @@ RSpec.feature 'Court Application Hearings', :vcr do
     expect(page).to have_content "Sorry, something went wrong"
   end
 
-  scenario 'I view a hearing details page' do
+  scenario 'I view a hearing details page', :js do
     sign_in user
     visit court_application_path(court_application_id)
     click_on "23/10/2019"
@@ -65,6 +65,8 @@ RSpec.feature 'Court Application Hearings', :vcr do
 
     # Result
     expect(page).to have_content "Result\nNot available"
+
+    expect(page).to be_accessible
   end
 
   scenario 'I navigate between hearing pages' do

--- a/spec/features/application_subjects_spec.rb
+++ b/spec/features/application_subjects_spec.rb
@@ -23,11 +23,11 @@ RSpec.feature 'Court Application subjects', :vcr do
     expect(page).to have_content "Sorry, something went wrong"
   end
 
-  scenario 'I view the application details' do
+  scenario 'I view the application details', :js do
     sign_in user
     visit court_application_subject_path(found_court_application_id)
     expect(page).to have_content(
-      ["Home", "Search", "Case EPAYAQECKM", "Appeal", "Mauricio Rath"].join # Breadcrumb
+      ["Home", "Search", "Case EPAYAQECKM", "Appeal", "Mauricio Rath"].join("\n") # Breadcrumb
     ).and have_content(
       "Appeal"
     ).and have_content(
@@ -37,6 +37,7 @@ RSpec.feature 'Court Application subjects', :vcr do
     ).and have_content(
       "KQJXI10ZJXCI"
     )
+    expect(page).to be_accessible
 
     click_on "View appeal application summary"
 

--- a/spec/features/case_summary_spec.rb
+++ b/spec/features/case_summary_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+RSpec.feature 'Case summary', :stub_case_search, type: :feature do
+  let(:user) { create(:user) }
+  let(:case_reference) { 'TEST12345' }
+
+  before do
+    sign_in user
+    visit prosecution_case_path(case_reference)
+  end
+
+  scenario 'I visit the case summary page', :js do
+    expect(page).to have_current_path(prosecution_case_path(case_reference))
+    expect(page).to have_content case_reference
+
+    # Defendants
+    expect(page).to have_content(
+      'Maxie Turcotte Raynor'
+    ).and have_content(
+      '30/06/1973'
+    ).and have_content('Not linked')
+
+    # Hearings
+    expect(page).to have_content(
+      '23/10/2019'
+    ).and have_content('Trial (TRL)')
+
+    expect(page).to be_accessible
+  end
+end

--- a/spec/features/cookies_spec.rb
+++ b/spec/features/cookies_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.feature 'Cookies', type: :feature do
-  scenario 'viewing cookie settings' do
+  scenario 'viewing cookie settings', :js do
     visit cookies_path
     click_link_or_button 'Cookie settings'
 
@@ -9,6 +9,8 @@ RSpec.feature 'Cookies', type: :feature do
     within '.govuk-main-wrapper' do
       expect(page).to have_css('.govuk-heading-xl', text: 'Change your cookie settings')
     end
+
+    expect(page).to be_accessible
   end
 
   context 'when on the cookies page' do

--- a/spec/features/court_applications_spec.rb
+++ b/spec/features/court_applications_spec.rb
@@ -26,7 +26,7 @@ RSpec.feature 'Court Applications', :vcr do
     expect(page).to have_content "Sorry, something went wrong"
   end
 
-  scenario 'I view the application details' do
+  scenario 'I view the application details', :js do
     sign_in user
     visit court_application_path(found_court_application_id)
     expect(page).to have_content "Appeal against a conviction"
@@ -35,6 +35,8 @@ RSpec.feature 'Court Applications', :vcr do
     expect(page).to have_content "Mauricio Rath"
     expect(page).to have_content "06/05/1994"
     expect(page).to have_content "Not linked"
+    expect(page).to be_accessible
+
     click_on "Mauricio Rath"
     expect(page).to have_current_path court_application_subject_path(found_court_application_id)
   end

--- a/spec/features/defendants_view_spec.rb
+++ b/spec/features/defendants_view_spec.rb
@@ -30,8 +30,11 @@ RSpec.feature 'defendants view', type: :feature do
   context 'when visting laa_references page' do
     let(:defendant_by_id_fixture) { load_json_stub('unlinked_defendant.json') }
 
-    scenario 'laa_references page shows data' do
+    before do
       visit "laa_references/new?id=#{defendant_id}&urn=#{case_urn}"
+    end
+
+    scenario 'laa_references page shows data' do
       expect(page).to have_title('Defendant details')
       expect(page).to have_css('th.govuk-table__header', text: 'Date of birth')
       expect(page).to have_css('th.govuk-table__header', text: 'Case URN')
@@ -44,6 +47,10 @@ RSpec.feature 'defendants view', type: :feature do
       expect(page).to have_css('th.govuk-table__header', text: 'Plea')
       expect(page).to have_css('th.govuk-table__header', text: 'Mode of trial')
       expect(page).to have_content('Create link to court data')
+    end
+
+    scenario 'it is accessible', :js do
+      expect(page).to be_accessible
     end
 
     scenario 'show full plea history' do
@@ -82,8 +89,11 @@ RSpec.feature 'defendants view', type: :feature do
     let(:defendant_fixture) { load_json_stub('linked/defendant_by_reference_body.json') }
     let(:defendant_by_id_fixture) { load_json_stub('linked_defendant.json') }
 
-    scenario 'defendants page shows data' do
+    before do
       visit "defendants/#{defendant_id}/edit?urn=#{case_urn}"
+    end
+
+    scenario 'defendants page shows data' do
       expect(page).to have_title('Defendant details')
       expect(page).to have_css('th.govuk-table__header', text: 'Date of birth')
       expect(page).to have_css('th.govuk-table__header', text: 'Case URN')
@@ -97,6 +107,10 @@ RSpec.feature 'defendants view', type: :feature do
       expect(page).to have_css('th.govuk-table__header', text: 'Plea')
       expect(page).to have_css('th.govuk-table__header', text: 'Mode of trial')
       expect(page).to have_content('Remove link to court data')
+    end
+
+    scenario 'it is accessible', :js do
+      expect(page).to be_accessible
     end
 
     scenario 'show full plea history manually' do

--- a/spec/features/hearings_spec.rb
+++ b/spec/features/hearings_spec.rb
@@ -64,6 +64,10 @@ RSpec.feature 'Viewing the hearings page', :stub_case_search, :stub_v2_hearing_s
       it 'displays court applications section' do
         expect(page).to have_css('.govuk-heading-l', text: 'Court Applications')
       end
+
+      it 'is accessible', :js do
+        expect(page).to be_accessible
+      end
     end
 
     context 'with no hearing events', :stub_v2_hearing_events_not_found do

--- a/spec/features/maintenance_mode_spec.rb
+++ b/spec/features/maintenance_mode_spec.rb
@@ -2,11 +2,17 @@ require 'rails_helper'
 
 RSpec.describe 'Maintenance mode', type: :feature do
   context 'when enabled' do
-    before { allow(FeatureFlag).to receive(:enabled?).with(:maintenance_mode).and_return(true) }
+    before do
+      allow(FeatureFlag).to receive(:enabled?).with(:maintenance_mode).and_return(true)
+      visit authenticated_root_path
+    end
 
     it 'shows a generic error' do
-      visit authenticated_root_path
       expect(page).to have_content 'This service is currently unavailable'
+    end
+
+    it 'is accessible', :js do
+      expect(page).to be_accessible
     end
   end
 end

--- a/spec/features/search/cda/case_reference_spec.rb
+++ b/spec/features/search/cda/case_reference_spec.rb
@@ -109,6 +109,7 @@ RSpec.feature 'Case reference search', :vcr, :js, type: :feature do
       fill_in 'search-term-field', with: 'TEST12345'
       click_button 'Search'
       expect(page).to have_text '4 search results'
+      expect(page).to be_accessible
     end
 
     scenario 'there is just one result' do


### PR DESCRIPTION
#### What
Add AXE accessibility tests to all pages that don't currently have them. This is:
- Case summary
- Defendant / LAA reference
- Hearing
- Application summary
- Subject
- Application hearing
- Cookies
- Maintenance mode