### PR TITLE
Disable link pre-fetching on defendant links from case details page

### DIFF
--- a/app/views/prosecution_cases/_overall_defendants.html.haml
+++ b/app/views/prosecution_cases/_overall_defendants.html.haml
@@ -12,7 +12,10 @@
     - case_summary.defendants.each do |overall_defendant|
       %tr.govuk-table__row
         %td.govuk-table__cell
-          = link_to overall_defendant.name, defendant_link_path(overall_defendant, case_summary.prosecution_case_reference), class: 'govuk-link'
+          = link_to overall_defendant.name,
+                    defendant_link_path(overall_defendant, case_summary.prosecution_case_reference),
+                    class: 'govuk-link',
+                    data: { turbo: false }
         %td.govuk-table__cell
           = l(overall_defendant.date_of_birth&.to_date)
         %td.govuk-table__cell


### PR DESCRIPTION
- The defendant page is pretty fast anyway now that that we're async-loading the offences data, so the performance implications are minimal
- Turbo's inherent fragility manifests in, e.g., these links breaking in E2E tests in headless Safari. I can't guarantee that they're not causing problems sometimes in normal Safari too.