### PR TITLE
ACD-1371: Update lodash (to fix vulnerability)

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,9 @@
     "stylelint-order": "^7.0.0",
     "wait-on": "^9.0.1"
   },
+  "resolutions": {
+    "lodash": ">=4.18.0"
+  },
   "standard": {
     "globals": [
       "dataLayer",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3260,10 +3260,10 @@ lodash.truncate@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==
 
-lodash@^4.17.21:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+lodash@>=4.18.0, lodash@^4.17.21:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
+  integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
 
 loose-envify@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
## Summary

Force lodash resolution to >=4.18.0 to fix high-severity code injection vulnerability (CVE-2026-4800).