### PR TITLE
ACD-1361: Add link migrated cases page with feature flag

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -5,6 +5,7 @@ COURT_DATA_ADAPTOR_API_TEST_MODE: true
 PER_USER_FEATURE_FLAGS: 'true'
 
 GA_TRACKING_ID: UA-XXXXXXXXX-XX
+SHOW_LINK_MIGRATED_CASES: 'true'
 FAKE_AUTH: true
 
 # Enable by default the following features on test environment

--- a/app/controllers/link_migrated_cases_controller.rb
+++ b/app/controllers/link_migrated_cases_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class LinkMigratedCasesController < ApplicationController
+  authorize_resource class: false
+
+  def show; end
+end

--- a/app/controllers/link_migrated_cases_controller.rb
+++ b/app/controllers/link_migrated_cases_controller.rb
@@ -2,6 +2,17 @@
 
 class LinkMigratedCasesController < ApplicationController
   authorize_resource class: false
+  before_action :check_feature_flag
 
-  def show; end
+  def show
+    render :show
+  end
+
+  private
+
+  def check_feature_flag
+    unless FeatureFlag.enabled?(:show_link_migrated_cases)
+      redirect_to authenticated_user_root_path(current_user)
+    end
+  end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -67,6 +67,7 @@ class Ability
 
   def can_manage_links
     can :create, :link_maat_reference
+    can :show, :link_migrated_case
   end
 
   def can_query_cda

--- a/app/views/layouts/_lower_navigation.html.haml
+++ b/app/views/layouts/_lower_navigation.html.haml
@@ -19,7 +19,7 @@
               = navigation_item(new_search_filter_path, t('layouts.application.header.navigation.search'), active: controller_name.in?(%w[search_filters searches]))
             - if can?(:read, Cda::LinkingStatCollection)
               = navigation_item(new_stats_path, t('layouts.application.header.navigation.view_stats'))
-            - if can?(:show, :link_migrated_case)
+            - if FeatureFlag.enabled?(:show_link_migrated_cases) && can?(:show, :link_migrated_case)
               = navigation_item(link_migrated_cases_path, t('layouts.application.header.navigation.link_migrated_cases'), active: controller_name == 'link_migrated_cases')
             - if can?(:index, User)
               = navigation_item(users_path, t('layouts.application.header.navigation.manage_users'), active: controller_name == 'users')

--- a/app/views/layouts/_lower_navigation.html.haml
+++ b/app/views/layouts/_lower_navigation.html.haml
@@ -19,5 +19,7 @@
               = navigation_item(new_search_filter_path, t('layouts.application.header.navigation.search'), active: controller_name.in?(%w[search_filters searches]))
             - if can?(:read, Cda::LinkingStatCollection)
               = navigation_item(new_stats_path, t('layouts.application.header.navigation.view_stats'))
+            - if can?(:show, :link_migrated_case)
+              = navigation_item(link_migrated_cases_path, t('layouts.application.header.navigation.link_migrated_cases'), active: controller_name == 'link_migrated_cases')
             - if can?(:index, User)
               = navigation_item(users_path, t('layouts.application.header.navigation.manage_users'), active: controller_name == 'users')

--- a/app/views/link_migrated_cases/show.html.haml
+++ b/app/views/link_migrated_cases/show.html.haml
@@ -1,0 +1,3 @@
+.govuk-grid-row
+  .govuk-grid-column-full
+    %h1.govuk-heading-xl Link migrated cases

--- a/config/locales/en/views/layouts.yml
+++ b/config/locales/en/views/layouts.yml
@@ -25,6 +25,7 @@ en:
       header:
         legal_aid_agency: Legal Aid Agency
         navigation:
+          link_migrated_cases: Link migrated cases
           manage_users: Manage users
           menu: Menu
           search: Search

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,6 +73,7 @@ Rails.application.routes.draw do
   get '/cookies/settings', to: 'cookies#new'
   get '/cookies', to: 'cookies#cookie_details'
   get '/accessibility', to: 'pages#accessibility_statement'
+  get '/link_migrated_cases', to: 'link_migrated_cases#show', as: :link_migrated_cases
 
   get 'ping', to: 'status#ping', format: :json
 

--- a/helm_deploy/templates/deployment.yaml
+++ b/helm_deploy/templates/deployment.yaml
@@ -83,6 +83,8 @@ spec:
               value: "{{ .Values.featureFlags.timeBasedAccessRestriction }}"
             - name: SHOW_STATS
               value: "{{ .Values.featureFlags.showStats }}"
+            - name: SHOW_LINK_MIGRATED_CASES
+              value: "{{ .Values.featureFlags.showLinkMigratedCases }}"
             - name: FAKE_AUTH
               value: "{{ .Values.featureFlags.fakeAuth }}"
             - name: COURT_DATA_ADAPTOR_API_UID

--- a/helm_deploy/values/dev.yaml
+++ b/helm_deploy/values/dev.yaml
@@ -19,4 +19,5 @@ featureFlags:
   noLinking: false
   timeBasedAccessRestriction: true
   showStats: true
+  showLinkMigratedCases: true
   fakeAuth: true

--- a/helm_deploy/values/production.yaml
+++ b/helm_deploy/values/production.yaml
@@ -19,4 +19,5 @@ featureFlags:
   noLinking: false
   timeBasedAccessRestriction: true
   showStats: false
+  showLinkMigratedCases: false
   fakeAuth: false

--- a/helm_deploy/values/test.yaml
+++ b/helm_deploy/values/test.yaml
@@ -19,4 +19,5 @@ featureFlags:
   noLinking: false
   timeBasedAccessRestriction: true
   showStats: true
+  showLinkMigratedCases: true
   fakeAuth: false

--- a/helm_deploy/values/uat.yaml
+++ b/helm_deploy/values/uat.yaml
@@ -19,4 +19,5 @@ featureFlags:
   noLinking: false
   timeBasedAccessRestriction: true
   showStats: true
+  showLinkMigratedCases: true
   fakeAuth: false

--- a/spec/features/navigation_spec.rb
+++ b/spec/features/navigation_spec.rb
@@ -16,6 +16,7 @@ RSpec.feature 'Navigation', type: :feature do
 
       within '.govuk-service-navigation' do
         expect(page).to have_link('View court data')
+        expect(page).to have_link('Link migrated cases')
         expect(page).to have_no_link('Manage users')
       end
     end
@@ -37,6 +38,7 @@ RSpec.feature 'Navigation', type: :feature do
       within '.govuk-service-navigation' do
         expect(page).to have_link('View court data')
         expect(page).to have_link('Manage users')
+        expect(page).to have_no_link('Link migrated cases')
       end
     end
   end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -34,7 +34,6 @@ RSpec.shared_examples 'not manage others' do
   }
 end
 
-# rubocop:disable RSpec/EmptyExampleGroup
 RSpec.describe Ability, type: :model do
   subject(:ability) { described_class.new(themself) }
 
@@ -48,6 +47,7 @@ RSpec.describe Ability, type: :model do
     it { is_expected.not_to be_able_to(%i[new create], Search) }
     it { is_expected.not_to be_able_to(%i[read], Cda::ProsecutionCase) }
     it { is_expected.not_to be_able_to(:create, :link_maat_reference) }
+    it { is_expected.not_to be_able_to(:show, :link_migrated_case) }
   end
 
   context 'when a caseworker' do
@@ -58,6 +58,8 @@ RSpec.describe Ability, type: :model do
     is_able_to 'perform search'
     is_able_to 'link maat reference'
     is_able_to 'query v2 CDA'
+
+    it { is_expected.to be_able_to(:show, :link_migrated_case) }
   end
 
   context 'when an admin' do
@@ -65,6 +67,6 @@ RSpec.describe Ability, type: :model do
 
     it { is_expected.to be_able_to(:manage, themself) }
     it { is_expected.to be_able_to(:manage, other_user) }
+    it { is_expected.not_to be_able_to(:show, :link_migrated_case) }
   end
 end
-# rubocop:enable RSpec/EmptyExampleGroup

--- a/spec/requests/authorisation_spec.rb
+++ b/spec/requests/authorisation_spec.rb
@@ -52,6 +52,32 @@ RSpec.describe 'authorization', type: :request do
     end
   end
 
+  context 'when caseworker accesses link migrated cases' do
+    let(:user) { create(:user, roles: ['caseworker']) }
+
+    before do
+      sign_in user
+      get link_migrated_cases_path
+    end
+
+    it 'renders successfully' do
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  context 'when admin tries to access link migrated cases' do
+    let(:user) { create(:user, roles: ['admin']) }
+
+    before do
+      sign_in user
+      get link_migrated_cases_path
+    end
+
+    it 'redirects to root' do
+      expect(response).to redirect_to authenticated_admin_root_path
+    end
+  end
+
   context 'when admin tries to access the search page' do
     let(:user) { create(:user, roles: ['admin']) }
 


### PR DESCRIPTION
## Summary

Adds a new "Link migrated cases" page accessible only to caseworkers, gated behind a feature flag so it can be enabled per environment without a code deployment.

- New `LinkMigratedCasesController` with caseworker-only access enforced via CanCanCan
- Navigation link added to the lower nav (conditionally rendered when feature flag is active)
- Feature flag `link_migrated_cases` configured in Helm values for dev, test, UAT, and production environments
- Request, ability, and navigation specs added