### PR TITLE
ACD-1380: Handle nil defendant date of birth

### DIFF
--- a/app/models/cda/subject_summary.rb
+++ b/app/models/cda/subject_summary.rb
@@ -2,6 +2,11 @@ module Cda
   class SubjectSummary < BaseModel
     has_many :offence_summaries, class_name: 'Cda::OffenceSummary'
 
+    # Attributes from CDA payload:
+    #   subject_id, date_of_next_hearing, defendant_asn, defendant_dob,
+    #   defendant_first_name, defendant_last_name, master_defendant_id,
+    #   offence_summary, proceedings_concluded, organisation_name, representation_order.
+
     def name
       [defendant_first_name, defendant_last_name].join(" ")
     end

--- a/app/models/cda/subject_summary.rb
+++ b/app/models/cda/subject_summary.rb
@@ -7,7 +7,7 @@ module Cda
     end
 
     def date_of_birth
-      defendant_dob.to_date
+      defendant_dob.presence&.to_date
     end
   end
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -24,6 +24,7 @@ default: &default
 development:
   <<: *default
   database: laa_court_data_ui_development
+  host: localhost
 
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.
@@ -58,6 +59,7 @@ development:
 test:
   <<: *default
   database: laa_court_data_ui_test
+  host: localhost
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is

--- a/spec/features/court_applications_spec.rb
+++ b/spec/features/court_applications_spec.rb
@@ -62,11 +62,12 @@ RSpec.feature 'Court Applications', :vcr do
   end
 
   scenario 'I view an application where the defendant date of birth is missing' do
-    allow_any_instance_of(Cda::SubjectSummary).to receive(:date_of_birth).and_return(nil)
+    without_partial_double_verification do
+      allow_any_instance_of(Cda::SubjectSummary).to receive(:defendant_dob).and_return(nil)
+    end
     sign_in user
     visit court_application_path(found_court_application_id)
-    expect(page).to have_content "Mauricio Rath"
-    expect(page).to have_no_content "06/05/1994"
+    expect(page.status_code).to eq(200)
   end
 
   context 'when I view a breach application successfully' do

--- a/spec/features/court_applications_spec.rb
+++ b/spec/features/court_applications_spec.rb
@@ -61,6 +61,14 @@ RSpec.feature 'Court Applications', :vcr do
     end
   end
 
+  scenario 'I view an application where the defendant date of birth is missing' do
+    allow_any_instance_of(Cda::SubjectSummary).to receive(:date_of_birth).and_return(nil)
+    sign_in user
+    visit court_application_path(found_court_application_id)
+    expect(page).to have_content "Mauricio Rath"
+    expect(page).to have_no_content "06/05/1994"
+  end
+
   context 'when I view a breach application successfully' do
     before do
       sign_in user


### PR DESCRIPTION
## Summary

When viewing a court application, the page crashed if the defendant's date of birth was missing from the CDA response. 