### PR TITLE
ACD-1199: Usability improvements for mobile and accessibility

### DIFF
--- a/app/views/hearing_days/show.html.haml
+++ b/app/views/hearing_days/show.html.haml
@@ -16,7 +16,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-one-third
-    .govuk-heading-l
+    %h2.govuk-heading-l
       = t('.details')
     %div{ class: "govuk-!-margin-bottom-9" }
       .govuk-heading-s{ class: "govuk-!-margin-bottom-1" }
@@ -52,7 +52,7 @@
       = @hearing_details.judiciary_list
 
   .govuk-grid-column-two-thirds
-    .govuk-heading-l
+    %h2.govuk-heading-l
       = t('.events')
     - if @hearing_events&.events&.any?
       %table.govuk-table
@@ -79,7 +79,7 @@
     = render partial: 'hearings/court_applications', locals: { hearing: (@hearing_details.hearing if @hearing_details.loaded?) }
 
     - if @application.subject_summary.proceedings_concluded
-      .govuk-heading-l
+      %h2.govuk-heading-l
         = t('.result')
       .govuk-body
         = @application.result_string

--- a/app/views/prosecution_cases/_hearing_summaries.html.haml
+++ b/app/views/prosecution_cases/_hearing_summaries.html.haml
@@ -1,28 +1,29 @@
 %h2.govuk-heading-l{ class: "govuk-!-margin-bottom-4" }
   = t('search.result.hearing.heading')
-%table.govuk-table.app-sortable-table{ class: "govuk-!-margin-bottom-9" }
-  %caption.govuk-table__caption.govuk-visually-hidden
-    = t('search.result.hearing.caption')
-  %thead.govuk-table__head
-    %tr.govuk-table__row
-      %th.govuk-table__header{ scope: 'col' }
-        = hearings_sorter_link(case_summary, 'date')
-      %th.govuk-table__header{ scope: 'col' }
-        = hearings_sorter_link(case_summary, 'type')
-      %th.govuk-table__header{ scope: 'col' }
-        = hearings_sorter_link(case_summary, 'provider')
-  %tbody.govuk-table__body
-    - case_summary.sorted_hearing_summaries_with_day.each do |hearing_summary|
+.moj-scrollable-pane{ role: 'region', aria: { label: t('search.result.hearing.caption') }, tabindex: '0' }
+  %table.govuk-table.app-sortable-table{ class: "govuk-!-margin-bottom-9" }
+    %caption.govuk-table__caption.govuk-visually-hidden
+      = t('search.result.hearing.caption')
+    %thead.govuk-table__head
       %tr.govuk-table__row
-        %td.govuk-table__cell
-          = link_to hearing_summary.day.strftime('%d/%m/%Y'), hearing_path(id: hearing_summary.id,
-                                                                           urn: case_summary.prosecution_case_reference,
-                                                                           day: hearing_summary.day.to_date), class: 'govuk-link'
-        %td.govuk-table__cell
-          = hearing_summary.hearing_type
-          - if hearing_summary.estimated_duration
-            %br
-            %span.app-body-secondary
-              = hearing_summary.formatted_estimated_duration
-        %td.govuk-table__cell
-          = hearing_summary ? hearing_summary.defence_counsel_list : t('generic.not_available')
+        %th.govuk-table__header{ scope: 'col' }
+          = hearings_sorter_link(case_summary, 'date')
+        %th.govuk-table__header{ scope: 'col' }
+          = hearings_sorter_link(case_summary, 'type')
+        %th.govuk-table__header{ scope: 'col' }
+          = hearings_sorter_link(case_summary, 'provider')
+    %tbody.govuk-table__body
+      - case_summary.sorted_hearing_summaries_with_day.each do |hearing_summary|
+        %tr.govuk-table__row
+          %td.govuk-table__cell
+            = link_to hearing_summary.day.strftime('%d/%m/%Y'), hearing_path(id: hearing_summary.id,
+                                                                             urn: case_summary.prosecution_case_reference,
+                                                                             day: hearing_summary.day.to_date), class: 'govuk-link'
+          %td.govuk-table__cell
+            = hearing_summary.hearing_type
+            - if hearing_summary.estimated_duration
+              %br
+              %span.app-body-secondary
+                = hearing_summary.formatted_estimated_duration
+          %td.govuk-table__cell
+            = hearing_summary ? hearing_summary.defence_counsel_list : t('generic.not_available')

--- a/app/views/prosecution_cases/_overall_defendants.html.haml
+++ b/app/views/prosecution_cases/_overall_defendants.html.haml
@@ -1,19 +1,20 @@
 %h2.govuk-heading-l{ class: "govuk-!-margin-bottom-4" }
   = t('search.result.defendant.heading')
-%table.govuk-table{ class: "govuk-!-margin-bottom-9" }
-  %caption.govuk-table__caption.govuk-visually-hidden
-    = t('search.result.defendant.caption')
-  %thead.govuk-table__head
-    %tr.govuk-table__row
-      %th.govuk-table__header{ scope: 'col' }= t('search.result.defendant.name')
-      %th.govuk-table__header{ scope: 'col' }= t('search.result.defendant.date_of_birth')
-      %th.govuk-table__header{ scope: 'col' }= t('search.result.defendant.maat_number')
-  %tbody.govuk-table__body
-    - case_summary.defendants.each do |overall_defendant|
+.moj-scrollable-pane{ role: 'region', aria: { label: t('search.result.defendant.caption') }, tabindex: '0' }
+  %table.govuk-table{ class: "govuk-!-margin-bottom-9" }
+    %caption.govuk-table__caption.govuk-visually-hidden
+      = t('search.result.defendant.caption')
+    %thead.govuk-table__head
       %tr.govuk-table__row
-        %td.govuk-table__cell
-          = link_to overall_defendant.name, defendant_link_path(overall_defendant, case_summary.prosecution_case_reference), class: 'govuk-link'
-        %td.govuk-table__cell
-          = l(overall_defendant.date_of_birth&.to_date)
-        %td.govuk-table__cell
-          = overall_defendant.linked? ? overall_defendant.maat_reference : t('search.result.defendant.unlinked')
+        %th.govuk-table__header{ scope: 'col' }= t('search.result.defendant.name')
+        %th.govuk-table__header{ scope: 'col' }= t('search.result.defendant.date_of_birth')
+        %th.govuk-table__header{ scope: 'col' }= t('search.result.defendant.maat_number')
+    %tbody.govuk-table__body
+      - case_summary.defendants.each do |overall_defendant|
+        %tr.govuk-table__row
+          %td.govuk-table__cell
+            = link_to overall_defendant.name, defendant_link_path(overall_defendant, case_summary.prosecution_case_reference), class: 'govuk-link'
+          %td.govuk-table__cell
+            = l(overall_defendant.date_of_birth&.to_date)
+          %td.govuk-table__cell
+            = overall_defendant.linked? ? overall_defendant.maat_reference : t('search.result.defendant.unlinked')

--- a/app/views/prosecution_cases/related_court_applications.html.haml
+++ b/app/views/prosecution_cases/related_court_applications.html.haml
@@ -19,27 +19,28 @@
       .govuk-body
         = t('prosecution_case.related_court_applications.no_related_applications')
     - else
-      %table.govuk-table
-        %caption.govuk-table__caption.govuk-visually-hidden
-          = t('prosecution_case.related_court_applications.caption')
-        %thead.govuk-table__head
-          %tr.govuk-table__row
-            %th.govuk-table__header{ scope: 'col', class: 'govuk-!-width-one-third' }= t('prosecution_case.related_court_applications.application_type')
-            %th.govuk-table__header{ scope: 'col' }= t('prosecution_case.related_court_applications.respondent')
-            %th.govuk-table__header{ scope: 'col' }= t('prosecution_case.related_court_applications.maat_id')
-            %th.govuk-table__header{ scope: 'col' }= t('prosecution_case.related_court_applications.result')
-            %th.govuk-table__header{ scope: 'col' }= t('prosecution_case.related_court_applications.first_hearing_jurisdiction')
-        %tbody.govuk-table__body
-          - court_applications.each do |court_application|
+      .moj-scrollable-pane{ role: 'region', aria: { label: t('prosecution_case.related_court_applications.caption') }, tabindex: '0' }
+        %table.govuk-table
+          %caption.govuk-table__caption.govuk-visually-hidden
+            = t('prosecution_case.related_court_applications.caption')
+          %thead.govuk-table__head
             %tr.govuk-table__row
-              %td.govuk-table__cell
-                = link_to court_application.application_title, court_application_path(court_application.application_id), class: 'govuk-link'
-              %td.govuk-table__cell
-                = court_application.subject_summary.name
-              %td.govuk-table__cell
-                = court_application.linked_maat_id.presence || t('prosecution_case.related_court_applications.not_linked')
-              %td.govuk-table__cell
-                = court_application.result_string
-              %td.govuk-table__cell
-                = court_application.first_hearing&.jurisdiction || t('generic.not_available')
+              %th.govuk-table__header{ scope: 'col', class: 'govuk-!-width-one-third' }= t('prosecution_case.related_court_applications.application_type')
+              %th.govuk-table__header{ scope: 'col' }= t('prosecution_case.related_court_applications.respondent')
+              %th.govuk-table__header{ scope: 'col' }= t('prosecution_case.related_court_applications.maat_id')
+              %th.govuk-table__header{ scope: 'col' }= t('prosecution_case.related_court_applications.result')
+              %th.govuk-table__header{ scope: 'col' }= t('prosecution_case.related_court_applications.first_hearing_jurisdiction')
+          %tbody.govuk-table__body
+            - court_applications.each do |court_application|
+              %tr.govuk-table__row
+                %td.govuk-table__cell
+                  = link_to court_application.application_title, court_application_path(court_application.application_id), class: 'govuk-link'
+                %td.govuk-table__cell
+                  = court_application.subject_summary.name
+                %td.govuk-table__cell
+                  = court_application.linked_maat_id.presence || t('prosecution_case.related_court_applications.not_linked')
+                %td.govuk-table__cell
+                  = court_application.result_string
+                %td.govuk-table__cell
+                  = court_application.first_hearing&.jurisdiction || t('generic.not_available')
       = render 'shared/pagination', pagy:, item_name: t('prosecution_case.related_court_applications.item')

--- a/app/views/results/_defendant.html.haml
+++ b/app/views/results/_defendant.html.haml
@@ -1,5 +1,5 @@
-%div{ class: "govuk-!-margin-left-3" }
-  %table.govuk-table.govuk-grid-column-one-thirds
+.moj-scrollable-pane{ role: 'region', aria: { label: t('search.result.caption') }, tabindex: '0' }
+  %table.govuk-table
     %caption.govuk-table__caption.govuk-visually-hidden
       = t('search.result.caption')
     %thead.govuk-table__head

--- a/app/views/searches/_results.html.haml
+++ b/app/views/searches/_results.html.haml
@@ -1,5 +1,7 @@
-= render partial: 'results_header', locals: { term: term, dob: dob, results: results }
+.govuk-grid-column-two-thirds
+  = render partial: 'results_header', locals: { term: term, dob: dob, results: results }
 - if results.empty?
   = render 'results/none'
 - else
-  = render partial: 'results/defendant', locals: { results: results }
+  .govuk-grid-column-full
+    = render partial: 'results/defendant', locals: { results: results }

--- a/app/views/searches/_results_header.html.haml
+++ b/app/views/searches/_results_header.html.haml
@@ -1,3 +1,2 @@
-.govuk-grid-column-two-thirds
-  .govuk-heading-l
-    = t('search.result.appeals_heading', term: results.size, result: t('search.result.result').pluralize(results.length))
+.govuk-heading-l
+  = t('search.result.appeals_heading', term: results.size, result: t('search.result.result').pluralize(results.length))

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -62,7 +62,7 @@
                 %td.govuk-table__cell
                   = link_to user.name, user_path(user), class: 'govuk-link'
                 %td.govuk-table__cell
-                  = link_to user.username.to_s, user_path(user), class: 'govuk-link'
+                  = user.username
                 %td.govuk-table__cell
                   = mail_to user.email, class: 'govuk-link', target: '_blank' do
                     = user.email

--- a/spec/features/users/index_users_spec.rb
+++ b/spec/features/users/index_users_spec.rb
@@ -65,7 +65,7 @@ RSpec.feature 'Index users', :js, type: :feature do
       end
       row = page.find(%(tr[data-user-id="#{other_user.id}"]))
       expect(row).to have_link(other_user.name, href: user_path(other_user))
-      expect(row).to have_link(other_user.username, href: user_path(other_user))
+      expect(row).to have_text(other_user.username)
       expect(row).to have_link(other_user.email, href: "mailto:#{other_user.email}")
       expect(row).to have_link('Edit', href: edit_user_path(other_user))
       expect(row).to have_link('Delete', href: users_confirm_delete_path(other_user))


### PR DESCRIPTION
## Summary

- Result tables (search results, prosecution case, related court applications) now scroll horizontally on mobile using `moj-scrollable-pane`, instead of the whole page scrolling.
- Heading elements (`Details`, `Events`, `Result`) in the hearing day view corrected from `<div>` to `<h2>`.
- Username link removed from the users index table.