### PR TITLE
ACD-1418: Extend link without MAAT ID to Appeal and Breach court applications

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -18,7 +18,7 @@ class ErrorsController < ApplicationController
   end
 
   def unacceptable
-    render status: :unprocessable_entity
+    render status: :unprocessable_content
   end
 
   def internal_error

--- a/app/views/laa_references/_form.html.haml
+++ b/app/views/laa_references/_form.html.haml
@@ -25,6 +25,7 @@
 
         = f.govuk_submit t('laa_reference.link.form.submit'), data: { disable_with: 'Linking...' }, name: 'maat_ref_required', value: 'true'
 
+-# Dummy MAAT linking: create link for the Substantive cases without MAAT ID
 = govuk_detail(t('laa_reference.missing_maat_id.label')) do
   = form_with(model: link_attempt, url: '/laa_references', data: { turbo: false }) do |f|
     %p.govuk-details__details-text= t('laa_reference.missing_maat_id.description')

--- a/app/views/subjects/show.html.haml
+++ b/app/views/subjects/show.html.haml
@@ -126,8 +126,8 @@
 
           = f.govuk_submit t('laa_reference.link.form.submit'), data: { disable_with: 'Linking...' }, name: 'maat_ref_required', value: 'true'
 
-          -# For POCA it is possible linking without a MAAT ID (Dummy MAAT ID)
-          - if @application.poca?
+          -# For POCA, Appeal and Breach it is possible to link without a MAAT ID (Dummy MAAT ID)
+          - if @application.poca? || @application.appeal? || @application.breach?
             = govuk_detail(t('laa_reference.missing_maat_id.label')) do
               %p.govuk-details__details-text= t('laa_reference.missing_maat_id.description')
               = f.govuk_submit(t('laa_reference.missing_maat_id.submit'), secondary: true, name: 'maat_ref_required', value: 'false')

--- a/spec/features/application_subjects_spec.rb
+++ b/spec/features/application_subjects_spec.rb
@@ -58,6 +58,8 @@ RSpec.feature 'Court Application subjects', :vcr do
       "Plea for the breach Not available"
     ).and have_content(
       "View breach"
+    ).and have_content(
+      "The MAAT id is missing"
     )
   end
 

--- a/spec/features/link_court_applications_spec.rb
+++ b/spec/features/link_court_applications_spec.rb
@@ -37,6 +37,11 @@ RSpec.feature 'Link court applications' do
       expect(page).to have_content "Enter a MAAT ID in the correct format"
     end
 
+    scenario 'I can see the option to create a link without MAAT ID for an appeal application' do
+      visit court_application_subject_path(unlinked_court_application_id)
+      expect(page).to have_content "The MAAT id is missing"
+    end
+
     context 'when linking is disabled' do
       before do
         allow(FeatureFlag).to receive(:enabled?).and_call_original

--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe 'error routes', type: :request do
     before { get '/422' }
 
     it 'has a status of 422' do
-      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to have_http_status(:unprocessable_content)
     end
 
     it 'renders the 422/unacceptable template' do


### PR DESCRIPTION
## Summary

Caseworkers can now link Appeal and Breach court applications to the MAAT system without entering a valid MAAT ID (dummy MAAT linking), in addition to the existing POCA support.