### PR TITLE
Increase timeout period for liveness and readiness checks

### DIFF
--- a/helm_deploy/templates/deployment.yaml
+++ b/helm_deploy/templates/deployment.yaml
@@ -36,6 +36,7 @@ spec:
                 - name: X-Forwarded-Ssl
                   value: "on"
             initialDelaySeconds: 15
+            timeoutSeconds: 10
             periodSeconds: 10
           livenessProbe:
             httpGet:
@@ -47,6 +48,7 @@ spec:
                 - name: X-Forwarded-Ssl
                   value: "on"
             initialDelaySeconds: 30
+            timeoutSeconds: 10
             periodSeconds: 10
           lifecycle:
             preStop:


### PR DESCRIPTION
This PR increases the timeout period for liveness and readiness checks for VCD pods. Currently the timeout is not set in code and so defaults to a period of `1s`. During a recent incident, it was observed that VCD pods all restarted simultaneously and the theory for this is that they are tied up on slow request paths to CDA, resulting in requests to the VCD status endpoint taking far longer than `1s`. This commit therefore increases the timeout to a more sensible `10s` limit.