### PR TITLE
Fix redirection users/sign_in -> root /

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,8 @@ Rails.application.routes.draw do
     unauthenticated :user do
       root to: 'users/sessions#new', as: :unauthenticated_root
     end
+
+    get '/users/sign_in', to: redirect('/')
   end
 
   resources :search_filters, only: %i[new create]

--- a/spec/requests/users/sign_in_redirect_spec.rb
+++ b/spec/requests/users/sign_in_redirect_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+RSpec.describe 'GET /users/sign_in', type: :request do
+  context 'when unauthenticated' do
+    it 'redirects to root' do
+      get '/users/sign_in'
+      expect(response).to redirect_to('/')
+    end
+  end
+
+  context 'when authenticated' do
+    let(:user) { create(:user, :with_caseworker_role) }
+
+    before { sign_in user }
+
+    it 'redirects to root' do
+      get '/users/sign_in'
+      expect(response).to redirect_to('/')
+    end
+  end
+end


### PR DESCRIPTION
#### What
Before: users/sign_in treated the string "sign_in" as a ID.
Now: it redirects to /, where the button "sign in" is present.
