### PR TITLE
Define pod resource requests and limits

### DIFF
--- a/helm_deploy/templates/deployment.yaml
+++ b/helm_deploy/templates/deployment.yaml
@@ -50,6 +50,8 @@ spec:
             initialDelaySeconds: 30
             timeoutSeconds: 10
             periodSeconds: 10
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
           lifecycle:
             preStop:
               exec:

--- a/helm_deploy/values/dev.yaml
+++ b/helm_deploy/values/dev.yaml
@@ -5,6 +5,7 @@ replicas:
 image:
   tag: ""
   repository: "nginx"
+resources: {}
 env: dev
 host: dev.view-court-data.service.justice.gov.uk
 cdaHost: https://laa-court-data-adaptor-dev.apps.live.cloud-platform.service.justice.gov.uk/api/internal/v1

--- a/helm_deploy/values/production.yaml
+++ b/helm_deploy/values/production.yaml
@@ -5,6 +5,13 @@ replicas:
 image:
   tag: ""
   repository: "nginx"
+resources:
+  limits:
+    cpu: 1
+    memory: 1000Mi
+  requests:
+    cpu: 100m
+    memory: 500Mi
 env: production
 host: view-court-data.service.justice.gov.uk
 cdaHost: https://court-data-adaptor.service.justice.gov.uk/api/internal/v1

--- a/helm_deploy/values/test.yaml
+++ b/helm_deploy/values/test.yaml
@@ -5,6 +5,7 @@ replicas:
 image:
   tag: ""
   repository: "nginx"
+resources: {}
 env: test
 host: test.view-court-data.service.justice.gov.uk
 cdaHost: https://laa-court-data-adaptor-test.apps.live.cloud-platform.service.justice.gov.uk/api/internal/v1

--- a/helm_deploy/values/uat.yaml
+++ b/helm_deploy/values/uat.yaml
@@ -5,6 +5,13 @@ replicas:
 image:
   tag: ""
   repository: "nginx"
+resources:
+  limits:
+    cpu: 1
+    memory: 1000Mi
+  requests:
+    cpu: 100m
+    memory: 500Mi
 env: uat
 host: uat.view-court-data.service.justice.gov.uk
 cdaHost: https://laa-court-data-adaptor-uat.apps.live.cloud-platform.service.justice.gov.uk/api/internal/v1


### PR DESCRIPTION
This PR defines the pod resource requests and limits for both CPU and memory. Previously these were not defined and would default to the following values:

CPU: request `10m`, limit `1`
Memory: request `100Mi`, limit `1000Mi`

VCD pods have recently been seeing CPU requests exceeding the request limit of `10m` as well as the memory request exceeding `100Mi`, causing the pods to restart. This is likely due to overall load on CDA and needs further investigation, but in the meantime this commit ups the CPU request limit in an attempt to stabilise pods during increased workload.

[Link to task](https://dsdmoj.atlassian.net/browse/LAACONNECT-1460)