### PR TITLE
Fix SimpleCov deprecation messages

### DIFF
--- a/spec/simplecov_helper.rb
+++ b/spec/simplecov_helper.rb
@@ -9,20 +9,20 @@ SimpleCov.configure do
                                                                     SimpleCov::Formatter::JSONFormatter
                                                                   ])
 
-  add_filter '_spec.rb'
-  add_filter 'spec/'
-  add_filter 'config/'
-  add_filter 'db/seeds'
-  add_filter %r{^/factories/}
-  add_filter 'bin/'
-  add_filter 'lib/tasks'
-  add_filter 'rakefile'
+  skip '_spec.rb'
+  skip 'spec/'
+  skip 'config/'
+  skip 'db/seeds'
+  skip %r{^/factories/}
+  skip 'bin/'
+  skip 'lib/tasks'
+  skip 'rakefile'
 
   # exclude individual files/dirs from test coverage stats
-  add_filter 'app/controllers/users/confirmations_controller'
+  skip 'app/controllers/users/confirmations_controller'
 
   # group functionality for test coverage report
-  add_group 'Models', 'app/models'
-  add_group 'Mailers', '/app/mailers'
-  add_group 'Helpers', 'app/helpers'
+  group 'Models', 'app/models'
+  group 'Mailers', '/app/mailers'
+  group 'Helpers', 'app/helpers'
 end


### PR DESCRIPTION
#### What

- Fix SimpleCov deprecation messages

#### Ticket

- N/A

#### Why

- When running specs we can see lots of deprecation messages from SimpleCov.
  One example of deprecation message we can see:
```
[DEPRECATION] `SimpleCov.add_filter` is deprecated. Replace with `SimpleCov.skip` (same arguments, same behavior). Example: `SimpleCov.skip "lib/tasks"`.
```