### PR TITLE
Fix Breadcrumb builder specs

### DIFF
--- a/spec/lib/gds_design_system_breadcrumb_builder_spec.rb
+++ b/spec/lib/gds_design_system_breadcrumb_builder_spec.rb
@@ -2,18 +2,18 @@
 
 require 'gds_design_system_breadcrumb_builder'
 
-RSpec.describe GdsDesignSystemBreadcrumbBuilder do
-  subject(:builder) { described_class.new(template, []) }
-
-  let(:template) { Class.new(ActionView::TestCase) }
+RSpec.describe GdsDesignSystemBreadcrumbBuilder, type: :helper do
+  subject(:builder) { described_class.new(helper, []) }
 
   it { is_expected.to respond_to :render, :render_element }
 
-  describe '#render', skip: 'FIX: test template not responding to :tag' do
+  describe '#render' do
     subject(:content) { builder.render }
 
     it 'renders outer <div>' do
-      expect(content).to include('<div class="govuk-breadcrumbs">')
+      expect(content).to include(
+        '<div class="govuk-breadcrumbs" role="navigation" aria-label="Navigate Case">'
+      )
     end
 
     it 'renders order list <ol>' do


### PR DESCRIPTION
By making the test a `helper` spec, we can pass the `helper` variable into the builder, and the tests run correctly. As we’re doing string matching, we need to include the `role` and `aria-label` in the expectations for the outer `div` test too.